### PR TITLE
Fix bm.Credentials dereference error in deploy tool

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -599,7 +599,7 @@ func (db *DeploymentBuilder) buildHostsAndProfiles(d *Deployment) error {
 		// BMC password (if applicable)
 		if profile.Spec.BoardManagement != nil && !bmSecretGenerated {
 			bm := profile.Spec.BoardManagement
-			if bm.Credentials.Password != nil && h.BMUsername != nil {
+			if bm.Credentials != nil && bm.Credentials.Password != nil && h.BMUsername != nil {
 				secret, err := starlingxv1.NewBMSecret(bm.Credentials.Password.Secret, db.namespace, *h.BMUsername)
 				if err != nil {
 					return err


### PR DESCRIPTION
Recent updates made the credentials and address fields of
BoardManagement optional, if bmType is "none". The deploy tool had an
assumption that if BoardManagement is set, then Credentials was as
well. In the case of bmType=none, this led to dereferencing a null
pointer.

This commit adds a nil check to test the Credentials field before the
dereference.

Signed-off-by: Don Penney <don.penney@windriver.com>