### PR TITLE
Fix node deletion issue when node is already deleted from system

### DIFF
--- a/pkg/controller/host/host_controller.go
+++ b/pkg/controller/host/host_controller.go
@@ -1317,6 +1317,9 @@ func (r *ReconcileHost) ReconcileResource(client *gophercloud.ServiceClient, ins
 			// The resource may have been deleted by the system or operator
 			// therefore continue and attempt to recreate it.
 			log.Info("resource no longer exists", "id", *id)
+
+			// Set host to nil, in case hosts.Get() returned a partially populated structure
+			host = nil
 		}
 	}
 


### PR DESCRIPTION
When a node has been deleted from the system prior to deleting the
resource, the deployment-manager gets stuck due to a bug in the
reconciler. This update resolves the bug by clearing retrieved data in
order to follow the correct code path.

Signed-off-by: Don Penney <don.penney@windriver.com>