### PR TITLE
Add version info to deploy tool

### DIFF
--- a/cmd/deploy/cmd/version.go
+++ b/cmd/deploy/cmd/version.go
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2020 Wind River Systems, Inc. */
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+var GitLastTag string
+var GitHead string
+var GitBranch string
+
+func VersionCmdRun(cmd *cobra.Command, args []string) {
+	fmt.Printf("Version: %s (%s: %s)\n", GitLastTag, GitBranch, GitHead)
+	os.Exit(0)
+}
+
+// versionCmd represents the build command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Display version information",
+	Run:   VersionCmdRun,
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
This update builds in version information to the deploy tool,
collecting data from git in the Makefile and passing into the go build
as ldflags.

Signed-off-by: Don Penney <don.penney@windriver.com>