### PR TITLE
Include tool version info in deploy config output

### DIFF
--- a/cmd/deploy/cmd/build.go
+++ b/cmd/deploy/cmd/build.go
@@ -13,6 +13,7 @@ import (
 	neturl "net/url"
 	"os"
 	"strings"
+	"time"
 )
 
 const (
@@ -302,6 +303,14 @@ func CollectCmdRun(cmd *cobra.Command, args []string) {
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "failed to convert deployment struct to YAML: %s\n", err.Error())
 		os.Exit(41)
+	}
+
+	_, err = fmt.Fprintf(outputFile, "# Generated: %s\n# Tool version: %s\n",
+		time.Now().Format(time.UnixDate),
+		VersionToString())
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "failed to write to output file: %s\n", err.Error())
+		os.Exit(42)
 	}
 
 	_, err = fmt.Fprintf(outputFile, "%s", yamlBuf)

--- a/cmd/deploy/cmd/version.go
+++ b/cmd/deploy/cmd/version.go
@@ -9,6 +9,7 @@ import (
 	"os"
 )
 
+// Version info variables are set in the Makefile
 var GitLastTag string
 var GitHead string
 var GitBranch string

--- a/cmd/deploy/cmd/version.go
+++ b/cmd/deploy/cmd/version.go
@@ -13,8 +13,12 @@ var GitLastTag string
 var GitHead string
 var GitBranch string
 
+func VersionToString() string {
+	return (fmt.Sprintf("%s (%s: %s)", GitLastTag, GitBranch, GitHead))
+}
+
 func VersionCmdRun(cmd *cobra.Command, args []string) {
-	fmt.Printf("Version: %s (%s: %s)\n", GitLastTag, GitBranch, GitHead)
+	fmt.Printf("Version: %s\n", VersionToString())
 	os.Exit(0)
 }
 


### PR DESCRIPTION
This update adds tool version info, along with the generation
timestamp, to the config yaml file generated by the deploy tool in a
comment block.

Signed-off-by: Don Penney <don.penney@windriver.com>