### PR TITLE
Fix service parameters blocking system resource from going insync

### DIFF
--- a/pkg/apis/starlingx/v1/constructors.go
+++ b/pkg/apis/starlingx/v1/constructors.go
@@ -906,10 +906,12 @@ func parseServiceParameterInfo(spec *SystemSpec, serviceParams []serviceparamete
 
 	for _, sp := range serviceParams {
 		info := ServiceParameterInfo{
-			Service:    sp.Service,
-			Section:    sp.Section,
-			ParamName:  sp.ParamName,
-			ParamValue: sp.ParamValue,
+			Service:     sp.Service,
+			Section:     sp.Section,
+			ParamName:   sp.ParamName,
+			ParamValue:  sp.ParamValue,
+			Resource:    sp.Resource,
+			Personality: sp.Personality,
 		}
 
 		result = append(result, info)

--- a/pkg/apis/starlingx/v1/system_types.go
+++ b/pkg/apis/starlingx/v1/system_types.go
@@ -336,6 +336,11 @@ func (in TrapDestInfo) IsKeyEqual(x TrapDestInfo) bool {
 	return in.Community == x.Community
 }
 
+// IsKeyEqual compares two ServiceParameter if they mostly match
+func (in ServiceParameterInfo) IsKeyEqual(x ServiceParameterInfo) bool {
+	return in.Service == x.Service && in.Section == x.Section && in.ParamName == x.ParamName && in.Personality == x.Personality && in.Resource == x.Resource
+}
+
 // SystemStatus defines the observed state of System
 type SystemStatus struct {
 	// ID defines the unique identifier assigned by the system.

--- a/pkg/apis/starlingx/v1/system_types.go
+++ b/pkg/apis/starlingx/v1/system_types.go
@@ -338,7 +338,14 @@ func (in TrapDestInfo) IsKeyEqual(x TrapDestInfo) bool {
 
 // IsKeyEqual compares two ServiceParameter if they mostly match
 func (in ServiceParameterInfo) IsKeyEqual(x ServiceParameterInfo) bool {
-	return in.Service == x.Service && in.Section == x.Section && in.ParamName == x.ParamName && in.Personality == x.Personality && in.Resource == x.Resource
+	if in.Service == x.Service && in.Section == x.Section && in.ParamName == x.ParamName {
+		if (in.Personality == x.Personality) || (in.Personality != nil && x.Personality != nil && *in.Personality == *x.Personality) {
+			if (in.Resource == x.Resource) || (in.Resource != nil && x.Resource != nil && *in.Resource == *x.Resource) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // SystemStatus defines the observed state of System

--- a/pkg/controller/system/system_controller.go
+++ b/pkg/controller/system/system_controller.go
@@ -1145,6 +1145,7 @@ func (r *ReconcileSystem) ReconcileRequired(instance *starlingxv1.System, spec *
 		}
 	}
 
+	log.V(2).Info("A System Reconcile is required")
 	return nil, true
 }
 


### PR DESCRIPTION
The system service parameters were not merging with the spec, so the
insync was never completing.

Also, the personality and resource fields were omitted, so any new
service parameters that added a personality or a resource would
not go insync either.

Signed-off-by: albailey <Al.Bailey@windriver.com>