### PR TITLE
Update certificate reconciliation

### DIFF
--- a/pkg/apis/starlingx/v1/system_types.go
+++ b/pkg/apis/starlingx/v1/system_types.go
@@ -63,6 +63,12 @@ func (in *CertificateInfo) DeepEqual(other *CertificateInfo) bool {
 	return false
 }
 
+// IsKeyEqual compares two CertificateInfo list elements and determines
+// if they refer to the same instance.
+func (in CertificateInfo) IsKeyEqual(x CertificateInfo) bool {
+	return in.Type == x.Type
+}
+
 // PrivateKeyExpected determines whether a certificate requires a private key
 // to be supplied to the system API.
 func (in *CertificateInfo) PrivateKeyExpected() bool {

--- a/pkg/controller/system/system_controller.go
+++ b/pkg/controller/system/system_controller.go
@@ -874,7 +874,11 @@ func (r *ReconcileSystem) ReconcileCertificates(client *gophercloud.ServiceClien
 				return err
 			}
 
-			log.Info(fmt.Sprintf("skipping %q certificate %q from system", c.Type, c.Secret))
+			// If we don't find the corresponding secret, this is most likely
+			// a certificate installed outside the scope of deployment-manager
+			// and will be ignored here.
+			msg := fmt.Sprintf("skipping %q certificate %q from system", c.Type, c.Secret)
+			r.WarningEvent(instance, common.ResourceDependency, msg)
 			continue
 		}
 

--- a/pkg/controller/system/system_controller.go
+++ b/pkg/controller/system/system_controller.go
@@ -874,9 +874,8 @@ func (r *ReconcileSystem) ReconcileCertificates(client *gophercloud.ServiceClien
 				return err
 			}
 
-			msg := fmt.Sprintf("waiting for %q certificate %q to be created", c.Type, c.Secret)
-			r.WarningEvent(instance, common.ResourceDependency, msg)
-			return common.NewMissingKubernetesResource(msg)
+			log.Info(fmt.Sprintf("skipping %q certificate %q from system", c.Type, c.Secret))
+			continue
 		}
 
 		pemBlock, ok := secret.Data[starlingxv1.SecretCertKey]
@@ -1294,14 +1293,6 @@ func (r *ReconcileSystem) ReconcileResource(client *gophercloud.ServiceClient, i
 		r.NormalEvent(instance, common.ResourceCreated,
 			"system defaults collected and stored")
 	}
-
-	// NOTE(alegacy): The defaults collected may include certificate info
-	// and since the API does not return the private key we are unable to
-	// build a true representation of what the system looks like and that
-	// means we cannot reconcile it back to the original state.  Remove the
-	// certificate info so that we do not fail when trying to find the
-	// matching Secret.
-	defaults.Certificates = nil
 
 	// Same problem applies to the License file attribute
 	defaults.License = nil


### PR DESCRIPTION
This update adds an IsKeyEqual method for CertificateInfo and updates
the reconciler to allow for proper syncing when the deployment config
includes a platform certificate.

Signed-off-by: Don Penney <don.penney@windriver.com>