### PR TITLE
Fix range error in deploy for platformnetworks

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -483,7 +483,7 @@ func (db *DeploymentBuilder) buildPlatformNetworks(d *Deployment) error {
 				// element is part of a slice, we sort it and then use
 				// sort.SearchStrings to look for the element.
 				index := sort.SearchStrings(always_generate_networks, n.Type)
-				if always_generate_networks[index] != n.Type {
+				if index >= len(always_generate_networks) || always_generate_networks[index] != n.Type {
 					skip = true
 				}
 				network_type = n.Type


### PR DESCRIPTION
The following error is seen when running deploy in a system with
non-storage platform networks created:

building platform network configurations
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/wind-river/cloud-platform-deployment-manager/pkg/build.(*DeploymentBuilder).buildPlatformNetworks(0xc0003ffb40, 0xc0002ad500, 0x12bfcce, 0x29)
        /go/src/github.com/wind-river/cloud-platform-deployment-manager/pkg/build/build.go:486 +0x70d
github.com/wind-river/cloud-platform-deployment-manager/pkg/build.(*DeploymentBuilder).Build(0xc0003ffb40, 0xc00039fc20, 0x2, 0x2)
        /go/src/github.com/wind-river/cloud-platform-deployment-manager/pkg/build/build.go:164 +0x457

This occurs due to a check that is indexing into a list of network
types, based on a search result, but not checking that the index
returned by the search is within the existing list elements. As a
result, a non-storage network type is causing the list to be accessed
outside the range.

This update adds a check against the length of the list.

Signed-off-by: Don Penney <don.penney@windriver.com>