### PR TITLE
Update hugepage count parsing

### DIFF
--- a/pkg/apis/starlingx/v1/constructors.go
+++ b/pkg/apis/starlingx/v1/constructors.go
@@ -240,9 +240,13 @@ func parseMemoryInfo(profile *HostProfileSpec, host v1info.HostInfo) error {
 
 			// VM memory allocations
 			vm2m := MemoryFunctionInfo{
-				Function:  memory.MemoryFunctionVM,
-				PageSize:  string(PageSize2M),
-				PageCount: m.VM2MHugepagesCount,
+				Function: memory.MemoryFunctionVM,
+				PageSize: string(PageSize2M),
+			}
+			if m.VM2MHugepagesPending == nil {
+				vm2m.PageCount = m.VM2MHugepagesCount
+			} else {
+				vm2m.PageCount = *m.VM2MHugepagesPending
 			}
 
 			if m.VSwitchHugepagesSize == PageSize2M.Megabytes() {
@@ -263,9 +267,13 @@ func parseMemoryInfo(profile *HostProfileSpec, host v1info.HostInfo) error {
 			info.Functions = append(info.Functions, vm2m)
 
 			vm1g := MemoryFunctionInfo{
-				Function:  memory.MemoryFunctionVM,
-				PageSize:  string(PageSize1G),
-				PageCount: m.VM1GHugepagesCount,
+				Function: memory.MemoryFunctionVM,
+				PageSize: string(PageSize1G),
+			}
+			if m.VM1GHugepagesPending == nil {
+				vm1g.PageCount = m.VM1GHugepagesCount
+			} else {
+				vm1g.PageCount = *m.VM1GHugepagesPending
 			}
 			info.Functions = append(info.Functions, vm1g)
 		}


### PR DESCRIPTION
The memory reconciliation is checking the pending hugepage count data,
to account for memory configuration that has been issued but not yet
completed. The parsing of current config, however, was not doing the
same. As a result, after initial unlock, the hugepage count from the
system could be coming back as 0 with a change pending, but this will
just look as though the system has a current config of 0 hugepages.
This causes the host to remain out-of-sync, as it doesn't match
expected ocnfiguration.

This update applies the same logic in the memory parser as the
reconciler, setting the hugepage count based on pending data first, if
available, and to the actual hugepage count if no update is pending.

Signed-off-by: Don Penney <don.penney@windriver.com>