### PR TITLE
Add support for TPM certs

### DIFF
--- a/pkg/apis/starlingx/v1/system_types.go
+++ b/pkg/apis/starlingx/v1/system_types.go
@@ -429,7 +429,7 @@ func init() {
 func (in *System) HTTPSEnabled() bool {
 	if in.Spec.Certificates != nil {
 		for _, c := range *in.Spec.Certificates {
-			if c.Type == PlatformCertificate {
+			if (c.Type == PlatformCertificate) || (c.Type == TPMCertificate) {
 				return true
 			}
 		}


### PR DESCRIPTION
Reconciler error would occur when attempting to install a certificate
with TPM configured, claiming that HTTPS is not enabled even though
tpm_mode inclues the HTTPS certificate. An extra check was added for
accepting certificates of TPM type.

Signed-off-by: Melissa Wang <melissa.wang@windriver.com>