### PR TITLE
Add support for multiple CA certificates

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -213,7 +213,7 @@
     "starlingx/inventory/v1/volumegroups",
   ]
   pruneopts = "T"
-  revision = "9a97d9a2ef3ac06c3a6e00e8ff2c48520186faee"
+  revision = "abb0f022084ae9d905c97d757cd5950ec722dd12"
   source = "https://github.com/wind-river/gophercloud"
 
 [[projects]]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -163,7 +163,7 @@
 
 [[projects]]
   branch = "starlingx"
-  digest = "1:649e83ea0746773c9dbd0d0e98d7a79ba8592bde668721aeb9daf3405f496f87"
+  digest = "1:61b9e4081a60f4879344e118b71c2b6c7379657c00a1ac2b9db6f63d4785fd5b"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -213,7 +213,7 @@
     "starlingx/inventory/v1/volumegroups",
   ]
   pruneopts = "T"
-  revision = "5c05fcd85598ad3de38e5cc706e8b770997e0f79"
+  revision = "9a97d9a2ef3ac06c3a6e00e8ff2c48520186faee"
   source = "https://github.com/wind-river/gophercloud"
 
 [[projects]]

--- a/pkg/apis/starlingx/v1/constructors.go
+++ b/pkg/apis/starlingx/v1/constructors.go
@@ -897,7 +897,8 @@ func parseCertificateInfo(spec *SystemSpec, certificates []certificates.Certific
 			Type: c.Type,
 			// Use a fixed naming so that we can document how we auto-generate
 			// a full system description for cloning purposes
-			Secret: autoGenerateCertName(c.Type, index),
+			Secret:    autoGenerateCertName(c.Type, index),
+			Signature: c.Signature,
 		}
 
 		result = append(result, cert)

--- a/pkg/apis/starlingx/v1/system_types.go
+++ b/pkg/apis/starlingx/v1/system_types.go
@@ -57,7 +57,7 @@ type CertificateInfo struct {
 // point to a Secret named by the system.
 func (in *CertificateInfo) DeepEqual(other *CertificateInfo) bool {
 	if other != nil {
-		return in.Type == other.Type
+		return (in.Type == other.Type) && (in.Secret == other.Secret)
 	}
 
 	return false
@@ -66,7 +66,7 @@ func (in *CertificateInfo) DeepEqual(other *CertificateInfo) bool {
 // IsKeyEqual compares two CertificateInfo list elements and determines
 // if they refer to the same instance.
 func (in CertificateInfo) IsKeyEqual(x CertificateInfo) bool {
-	return in.Type == x.Type
+	return (in.Type == x.Type) && (in.Secret == x.Secret)
 }
 
 // PrivateKeyExpected determines whether a certificate requires a private key

--- a/pkg/controller/system/system_controller.go
+++ b/pkg/controller/system/system_controller.go
@@ -963,7 +963,6 @@ func (r *ReconcileSystem) ReconcileCertificates(client *gophercloud.ServiceClien
 		}
 
 		info.Certificates = result
-
 	}
 
 	return nil

--- a/pkg/controller/system/system_controller.go
+++ b/pkg/controller/system/system_controller.go
@@ -850,7 +850,7 @@ func (r *ReconcileSystem) PrivateKeyTranmissionAllowed(client *gophercloud.Servi
 func (r *ReconcileSystem) ReconcileCertificates(client *gophercloud.ServiceClient, instance *starlingxv1.System, spec *starlingxv1.SystemSpec, info *v1info.SystemInfo) error {
 
 	var cert *x509.Certificate
-	var resultList []*certificates.Certificate
+	var certificateList []*certificates.Certificate
 
 	if !config.IsReconcilerEnabled(config.Certificate) {
 		return nil
@@ -878,6 +878,7 @@ func (r *ReconcileSystem) ReconcileCertificates(client *gophercloud.ServiceClien
 			// If we don't find the corresponding secret, this is most likely
 			// a certificate installed outside the scope of deployment-manager
 			// and will be ignored here.
+
 			msg := fmt.Sprintf("skipping %q certificate %q from system", c.Type, c.Secret)
 			r.WarningEvent(instance, common.ResourceDependency, msg)
 			continue
@@ -940,15 +941,15 @@ func (r *ReconcileSystem) ReconcileCertificates(client *gophercloud.ServiceClien
 
 			log.Info("installing certificate", "signature", signature)
 
-			resultList, err = certificates.Create(client, opts).Extract()
+			certificateList, err = certificates.Create(client, opts).Extract()
 
 			if err != nil {
 				err = perrors.Wrapf(err, "failed to create certificate: %s", common.FormatStruct(opts))
 				return err
 			}
-			for _, res := range resultList {
+			for _, certificate := range certificateList {
 				r.NormalEvent(instance, common.ResourceCreated,
-					"certificate %q has been installed", res.Signature)
+					"certificate %q has been installed", certificate.Signature)
 			}
 			updated = true
 		}
@@ -1275,6 +1276,65 @@ func MergeSystemSpecs(a, b *starlingxv1.SystemSpec) (*starlingxv1.SystemSpec, er
 	return a, nil
 }
 
+func (r *ReconcileSystem) GetCertificateSignatures(instance *starlingxv1.System) error {
+	var cert *x509.Certificate
+	result := make([]starlingxv1.CertificateInfo, 0)
+
+	// Certificates cannot be deleted once they are installed so look at the
+	// list of certificates coming from the user and add any that are missing
+	// from the system.
+	for _, c := range *instance.Spec.Certificates {
+		secret := v1.Secret{}
+
+		secretName := types.NamespacedName{Namespace: instance.Namespace, Name: c.Secret}
+		err := r.Get(context.TODO(), secretName, &secret)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				err = perrors.Wrap(err, "failed to get certificate secret")
+				return err
+			}
+
+			// If we don't find the corresponding secret, this is most likely
+			// a certificate installed outside the scope of deployment-manager
+			// and will be ignored here.
+			msg := fmt.Sprintf("skipping %q certificate %q from system", c.Type, c.Secret)
+			r.WarningEvent(instance, common.ResourceDependency, msg)
+		}
+
+		pemBlock, ok := secret.Data[starlingxv1.SecretCertKey]
+		if !ok {
+			msg := fmt.Sprintf("missing %q key in certificate secret %s",
+				starlingxv1.SecretCertKey, c.Secret)
+			return common.NewUserDataError(msg)
+		}
+
+		block, _ := pem.Decode(pemBlock)
+		if block == nil {
+			msg := fmt.Sprintf("unexpected certificate contents in secret %s", c.Secret)
+			return common.NewUserDataError(msg)
+		}
+
+		cert, err = x509.ParseCertificate(block.Bytes)
+		if cert == nil || err != nil {
+			msg := fmt.Sprintf("corrupt certificate contents in secret %s", c.Secret)
+			return common.NewUserDataError(msg)
+		}
+
+		// Determine the "signature" based on the certificate type and the
+		// serial number reported by the system API
+		signature := fmt.Sprintf("%s_%d", c.Type, cert.SerialNumber)
+
+		certificate := starlingxv1.CertificateInfo{
+			Type:      c.Type,
+			Secret:    c.Secret,
+			Signature: signature,
+		}
+		result = append(result, certificate)
+	}
+	*instance.Spec.Certificates = result
+	return nil
+}
+
 // ReconcileResource interacts with the system API in order to reconcile the
 // state of a data network with the state stored in the k8s database.
 func (r *ReconcileSystem) ReconcileResource(client *gophercloud.ServiceClient, instance *starlingxv1.System) (err error) {
@@ -1302,6 +1362,11 @@ func (r *ReconcileSystem) ReconcileResource(client *gophercloud.ServiceClient, i
 
 	// Same problem applies to the License file attribute
 	defaults.License = nil
+
+	err = r.GetCertificateSignatures(instance)
+	if err != nil {
+		return err
+	}
 
 	// Merge the system defaults with the desired attributes so that any
 	// optional attributes not filled in by the user default to how the system

--- a/vendor/github.com/gophercloud/gophercloud/starlingx/inventory/v1/certificates/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/starlingx/inventory/v1/certificates/results.go
@@ -25,7 +25,7 @@ type CreateResult struct {
 	commonResult
 }
 
-func (r CreateResult) Extract() (*Certificate, error) {
+func (r CreateResult) Extract() ([]*Certificate, error) {
 	var s CreateResponse
 	err := r.ExtractInto(&s)
 	if s.Error != "" {
@@ -52,7 +52,7 @@ type DeleteResult struct {
 // CertificateResponse defines a special wrapper to deal with the non-standard
 // response format of certificate install API.
 type CreateResponse struct {
-	Certificate *Certificate `json:"certificates,omitempty"`
+	Certificate []*Certificate `json:"certificates,omitempty"`
 	Body        string       `json:"body"`
 	Success     string       `json:"success"`
 	Error       string       `json:"error"`


### PR DESCRIPTION
This change allows multiple CA certificates to be installed by
specifying them in the deployment config.

Signed-off-by: Melissa Wang <melissa.wang@windriver.com>