### PR TITLE
Add retry loop in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,10 @@ publish: helm-package docker-push
 
 # Run tests
 test: generate fmt vet manifests helm-lint
-	go test ./pkg/... ./cmd/... -coverprofile cover.out
+	for idx in $$(seq 1 3) ; do \
+		echo "Trial #$${idx}" ; \
+		(go test ./pkg/... ./cmd/... -coverprofile cover.out) && break ; \
+	done
 
 # Build manager binary
 manager: generate fmt vet

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,14 @@ publish: helm-package docker-push
 
 # Run tests
 test: generate fmt vet manifests helm-lint
+	# Retry up to 3 times in case of intermittent control-plane failure
 	for idx in $$(seq 1 3) ; do \
 		echo "Trial #$${idx}" ; \
-		(go test ./pkg/... ./cmd/... -coverprofile cover.out) && break ; \
+		go test ./pkg/... ./cmd/... -coverprofile cover.out && break ; \
+		if [ "$$idx" -lt "3" ]; then
+			echo "Retrying after 1 second..."
+			sleep 1
+		fi
 	done
 
 # Build manager binary


### PR DESCRIPTION
Retry "go test" up to 3 times in case of encountering an intermittent issue
where the control plane fails to start

Signed-off-by: Melissa Wang <melissa.wang@windriver.com>