### PR TITLE
Fix helm init issue for builder

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -37,7 +37,7 @@ ENV PATH="${PATH}:/usr/local/kubebuilder/bin:/bin"
 WORKDIR /go/src/github.com/wind-river/cloud-platform-deployment-manager
 
 # Initialize helm within the container otherwise no helm commands will work.
-RUN helm init --client-only
+RUN helm init --stable-repo-url=https://charts.helm.sh/stable --client-only
 
 # The entry command can be overwritten when launched but by default these are
 # the build steps that we will be running.


### PR DESCRIPTION
The "helm init" command in the Dockerfile.builder is failing due to
the relocation of the stable repo. This updates the command to
specify the new location with the --stable-repo-url option to use
https://charts.helm.sh/stable

Signed-off-by: Don Penney <don.penney@windriver.com>