### PR TITLE
Allow for absence of SNMP resources

### DIFF
--- a/pkg/platform/info.go
+++ b/pkg/platform/info.go
@@ -147,14 +147,18 @@ func (in *SystemInfo) PopulateSystemInfo(client *gophercloud.ServiceClient) erro
 
 	in.SNMPCommunities, err = snmpCommunity.ListSNMPCommunities(client)
 	if err != nil {
-		err = errors.Wrap(err, "failed to get SNMP community list")
-		return err
+		if !strings.Contains(err.Error(), "Resource not found") {
+			err = errors.Wrap(err, "failed to get SNMP community list")
+			return err
+		}
 	}
 
 	in.SNMPTrapDestinations, err = snmpTrapDest.ListSNMPTrapDests(client)
 	if err != nil {
-		err = errors.Wrap(err, "failed to get SNMP trap destination list")
-		return err
+		if !strings.Contains(err.Error(), "Resource not found") {
+			err = errors.Wrap(err, "failed to get SNMP trap destination list")
+			return err
+		}
 	}
 
 	in.FileSystems, err = controllerFilesystems.ListFileSystems(client)


### PR DESCRIPTION
The on-host SNMP support has been removed from StarlingX. As such, the
queries for those resources has been updated to be optional

Signed-off-by: Don Penney <don.penney@windriver.com>