### PR TITLE
Add retries to ssl certificate check

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -163,7 +163,7 @@
 
 [[projects]]
   branch = "starlingx"
-  digest = "1:fb9fdcccb933891fbd72eb004903699bec342b9d1d53848aca9731ff57cf497a"
+  digest = "1:b337aad723196c99f02bc84dfc29a064822a5015c6fc8005e712244b44ee47f5"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -213,7 +213,7 @@
     "starlingx/inventory/v1/volumegroups",
   ]
   pruneopts = "T"
-  revision = "7a885a8d266e4f6fde3260ccf7538a5c28b233ca"
+  revision = "5ecbca2671f0b94b96f9658ed5d91174b3506530"
   source = "https://github.com/wind-river/gophercloud"
 
 [[projects]]

--- a/pkg/controller/system/system_controller.go
+++ b/pkg/controller/system/system_controller.go
@@ -48,6 +48,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	"strconv"
 	"strings"
+	"time"
 )
 
 var log = logf.Log.WithName("controller").WithName("system")
@@ -150,12 +151,21 @@ func (r *ReconcileSystem) installRootCertificates(instance *starlingxv1.System) 
 			return err
 		}
 
-		caBytes, ok := secret.Data[starlingxv1.SecretCaCertKey]
+		var caBytes []byte
+		var ok bool
+		numRetries := 30
+		for iter := 0; iter < numRetries; iter++ {
+			caBytes, ok = secret.Data[starlingxv1.SecretCaCertKey]
+			if !ok {
+				log.Info("Platform certificate CA not ready/available", "name", c.Secret)
+				time.Sleep(5 * time.Second)
+			} else {
+				log.Info("Platform certificate CA ready!")
+				break
+			}
+		}
 		if !ok {
-			// This can be valid as long as the target certificate is signed
-			// by a known CA certificate; otherwise once the target certificate
-			// is installed we will not be able to verify the TLS session.
-			log.Info("platform certificate without a CA certificate; ignoring", "name", c.Secret)
+			log.Info("Continuing deployment without a CA certificate", "name", c.Secret)
 			continue
 		}
 

--- a/vendor/github.com/gophercloud/gophercloud/starlingx/inventory/v1/certificates/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/starlingx/inventory/v1/certificates/requests.go
@@ -82,6 +82,12 @@ func Create(c *gophercloud.ServiceClient, opts CertificateOpts) (r CreateResult)
 		return r
 	}
 
+	err = w.WriteField("force", "true")
+	if err != nil {
+		r.Err = err
+		return r
+	}
+
 	if opts.Passphrase != nil {
 		err = w.WriteField("passphrase", *opts.Passphrase)
 		if err != nil {

--- a/vendor/github.com/gophercloud/gophercloud/starlingx/inventory/v1/certificates/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/starlingx/inventory/v1/certificates/results.go
@@ -53,9 +53,9 @@ type DeleteResult struct {
 // response format of certificate install API.
 type CreateResponse struct {
 	Certificate []*Certificate `json:"certificates,omitempty"`
-	Body        string       `json:"body"`
-	Success     string       `json:"success"`
-	Error       string       `json:"error"`
+	Body        string         `json:"body"`
+	Success     string         `json:"success"`
+	Error       string         `json:"error"`
 }
 
 // Certificate defines the data associated to a single Certificate instance.

--- a/vendor/github.com/gophercloud/gophercloud/starlingx/inventory/v1/storagebackends/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/starlingx/inventory/v1/storagebackends/results.go
@@ -42,7 +42,7 @@ type DeleteResult struct {
 // Capabilities defines the set of system or resource capabilities associated to
 // this resource.
 type Capabilities struct {
-	Replication string `json:"replication,omitempty"`
+	Replication    string `json:"replication,omitempty"`
 	MinReplication string `json:"min_replication,omitempty"`
 }
 


### PR DESCRIPTION
When DM tries to install ssl certificate, instead of
reporting error immediately if secret is not found, we
retry and log messages before reporting errors.

Signed-off-by: 5abeelwr <sabeel.ansari@windriver.com>