### PR TITLE
Update minimum required helm version to v2.16.10

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -46,12 +46,12 @@ The recommended installation method of the Deployment Manager is to use a Helm
 chart.  This ensures that the required CRD resources are installed before the
 Deployment Manager pods are created.  It also ensures that recommended default
 values for specific Kubernetes attributes are used.  The minimum required 
-version of Helm is v2.14.3 and can be installed on your workstation using the 
+version of Helm is v2.16.10 and can be installed on your workstation using the
 following commands.
  
 ```bash
-wget https://get.helm.sh/helm-v2.14.3-linux-amd64.tar.gz
-tar zxf helm-v2.14.3-linux-amd64.tar.gz
+wget https://get.helm.sh/helm-v2.16.10-linux-amd64.tar.gz
+tar zxf helm-v2.16.10-linux-amd64.tar.gz
 sudo cp linux-amd64/helm /usr/local/bin/
 ```
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -2,7 +2,7 @@ FROM golang:1.12.9
 
 # Install our current version of Helm.  We can probably upgrade to a new version
 # but this one has been tested and verified to work.
-RUN wget https://get.helm.sh/helm-v2.14.3-linux-amd64.tar.gz -q -O - | tar zx -C /bin --strip-components=1 linux-amd64/helm
+RUN wget https://get.helm.sh/helm-v2.16.10-linux-amd64.tar.gz -q -O - | tar zx -C /bin --strip-components=1 linux-amd64/helm
 
 # Install our required version of Kubebuilder.  We cannot upgrade to a later
 # version without significant effort.

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ GIT_HEAD := $(shell git rev-list -1 HEAD)
 GIT_LAST_TAG := $(shell git describe --abbrev=0 --tags)
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 
+HELM_CLIENT_VER := $(shell helm version --client --short 2>/dev/null | awk '{print $$NF}' | sed 's/^v//')
+HELM_CLIENT_VER_REL := $(shell echo ${HELM_CLIENT_VER} | awk -F. '{print $$1}')
+HELM_CLIENT_VER_MAJ := $(shell echo ${HELM_CLIENT_VER} | awk -F. '{print $$2}')
+
 DEPLOY_LDFLAGS := -X github.com/wind-river/cloud-platform-deployment-manager/cmd/deploy/cmd.GitLastTag=${GIT_LAST_TAG}
 DEPLOY_LDFLAGS += -X github.com/wind-river/cloud-platform-deployment-manager/cmd/deploy/cmd.GitHead=${GIT_HEAD}
 DEPLOY_LDFLAGS += -X github.com/wind-river/cloud-platform-deployment-manager/cmd/deploy/cmd.GitBranch=${GIT_BRANCH}
@@ -32,7 +36,7 @@ endif
 .PHONY: examples
 
 # Build all artifacts
-all: test manager tools helm-package docker-build examples
+all: helm-ver-check test manager tools helm-package docker-build examples
 
 # Publish all artifacts
 publish: helm-package docker-push
@@ -111,6 +115,13 @@ builder-run: builder-build
 		-v ${PWD}:/go/src/github.com/wind-river/cloud-platform-deployment-manager \
 		--rm ${BUILDER_IMG}
 
+# Check minimum helm version
+helm-ver-check:
+	@if [[ ${HELM_CLIENT_VER_REL} < 2 || ( ${HELM_CLIENT_VER_REL} == 2 && ${HELM_CLIENT_VER_MAJ} < 16 ) ]]; then
+		@echo "Minimum required helm client version is v2.16. Installed version is ${HELM_CLIENT_VER}"
+		@/bin/false
+	@fi
+
 # Check helm chart validity
 helm-lint: manifests
 	helm lint helm/wind-river-cloud-platform-deployment-manager
@@ -118,7 +129,7 @@ helm-lint: manifests
 # Create helm chart package
 .ONESHELL:
 SHELL = /bin/bash
-helm-package: helm-lint
+helm-package: helm-ver-check helm-lint
 	git update-index -q --ignore-submodules --refresh
 	if [[ $$(comm -12 <(git diff-index --name-only HEAD | sort -u) <(find helm/wind-river-cloud-platform-deployment-manager config | sort -u) | wc -l) -ne 0 || ${HELM_FORCE} -ne 0 ]]; then
 		helm package helm/wind-river-cloud-platform-deployment-manager --destination docs/charts;


### PR DESCRIPTION
An update in helm v2.16 fixed an issue generating charts where
symbolically linked directories are used. Earlier versions would end
up traversing the linked directories twice, resulting in a larger
charts tarball with extra unwanted files.

This commit updates the DEVELOPER guide to change the minimum helm
version to v2.16.10, and also adds a check to the Makefile to ensure
developers using an older helm version must update it.

In addition, the Dockerfile.builder is updated to use this helm
version.

Signed-off-by: Don Penney <don.penney@windriver.com>