### PR TITLE
Update minimum required helm version to v2.16.10

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -46,12 +46,12 @@ The recommended installation method of the Deployment Manager is to use a Helm
 chart.  This ensures that the required CRD resources are installed before the
 Deployment Manager pods are created.  It also ensures that recommended default
 values for specific Kubernetes attributes are used.  The minimum required 
-version of Helm is v2.14.3 and can be installed on your workstation using the 
+version of Helm is v2.16.10 and can be installed on your workstation using the
 following commands.
  
 ```bash
-wget https://get.helm.sh/helm-v2.14.3-linux-amd64.tar.gz
-tar zxf helm-v2.14.3-linux-amd64.tar.gz
+wget https://get.helm.sh/helm-v2.16.10-linux-amd64.tar.gz
+tar zxf helm-v2.16.10-linux-amd64.tar.gz
 sudo cp linux-amd64/helm /usr/local/bin/
 ```
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -2,7 +2,7 @@ FROM golang:1.12.9
 
 # Install our current version of Helm.  We can probably upgrade to a new version
 # but this one has been tested and verified to work.
-RUN wget https://get.helm.sh/helm-v2.14.3-linux-amd64.tar.gz -q -O - | tar zx -C /bin --strip-components=1 linux-amd64/helm
+RUN wget https://get.helm.sh/helm-v2.16.10-linux-amd64.tar.gz -q -O - | tar zx -C /bin --strip-components=1 linux-amd64/helm
 
 # Install our required version of Kubebuilder.  We cannot upgrade to a later
 # version without significant effort.


### PR DESCRIPTION
An update in helm v2.16 fixed an issue generating charts where
symbolically linked directories are used. Earlier versions would end
up traversing the linked directories twice, resulting in a larger
charts tarball with extra unwanted files.

This commit updates the DEVELOPER guide to change the minimum helm
version to v2.16.10, and also adds a check to the Makefile to ensure
developers using an older helm version must update it.

In addition, the Dockerfile.builder is updated to use this helm
version.

Signed-off-by: Don Penney <don.penney@windriver.com>