### PR TITLE
Remove SNMP temporary fix

### DIFF
--- a/pkg/platform/info.go
+++ b/pkg/platform/info.go
@@ -147,18 +147,14 @@ func (in *SystemInfo) PopulateSystemInfo(client *gophercloud.ServiceClient) erro
 
 	in.SNMPCommunities, err = snmpCommunity.ListSNMPCommunities(client)
 	if err != nil {
-		if !strings.Contains(err.Error(), "Resource not found") {
-			err = errors.Wrap(err, "failed to get SNMP community list")
-			return err
-		}
+		err = errors.Wrap(err, "failed to get SNMP community list")
+		return err
 	}
 
 	in.SNMPTrapDestinations, err = snmpTrapDest.ListSNMPTrapDests(client)
 	if err != nil {
-		if !strings.Contains(err.Error(), "Resource not found") {
-			err = errors.Wrap(err, "failed to get SNMP trap destination list")
-			return err
-		}
+		err = errors.Wrap(err, "failed to get SNMP trap destination list")
+		return err
 	}
 
 	in.FileSystems, err = controllerFilesystems.ListFileSystems(client)


### PR DESCRIPTION
The temporary fix for avoiding SNMP error that occured when SNMP
was not host-based was removed, since SNMP removal patchback
will keep SNMP host-based APIs, but with empty functionality.
Then if patchback is not applied, then behavior remains.

Signed-off-by: Jose Infanzon <jose.infanzon@windriver.com>