### PR TITLE
Add retries for applying the deployment-config

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -107,5 +107,9 @@
 
         - name: Apply Deployment Configuration File
           shell: KUBECONFIG=/etc/kubernetes/admin.conf /bin/kubectl apply -f deployment-config.yaml
+          register: apply_deployment_config
+          retries: 5
+          delay: 10
+          until: apply_deployment_config.rc == 0
 
       when: deployment_config is defined


### PR DESCRIPTION
In environments where it may take longer for DM to restart, the 10
second timeout is not enough when waiting for DM to be ready. This
change updates the playbook to retry with delays when applying the
deployment-config.

Signed-off-by: Melissa Wang <melissa.wang@windriver.com>