### PR TITLE
Fix INSYNC for ceph backend network parameter

### DIFF
--- a/pkg/apis/starlingx/v1/constructors.go
+++ b/pkg/apis/starlingx/v1/constructors.go
@@ -969,6 +969,7 @@ func parseStorageBackendInfo(spec *SystemSpec, storageBackends []storagebackends
 		info := StorageBackend{
 			Name:              sb.Name,
 			Type:              sb.Backend,
+			Network:           &sb.Network,
 			ReplicationFactor: &rep,
 		}
 		result = append(result, info)


### PR DESCRIPTION
Values are not correctly populated in sysinv query.
A comparison is skipped if no value is present in the DM config file.
Both are issues that prevent INSYNC succesful computation.

Fill defaults for optional structures read from the DM config file.


Reference:
spec:
  storage:
    backends:
    - name: ceph-store
      type: ceph
      network: cluster-host

Tested:
1)
apply 'network: cluster-host' -> insync True
change to 'network: mgmg' -> insync False
change to '' -> insync False
change to 'network: cluster-host' -> insync True
2) apply '' -> insync True
change to 'network: mgmg' -> insync True
change to 'network: cluster-host' -> insync False
change to '' -> insync True


This work is based on:
https://review.opendev.org/c/starlingx/config/+/792785

This work is a fix on top of:
c2a43b9ca7d297cdf82aa74842f2f2ef87445592

Change needed for:
https://storyboard.openstack.org/#!/story/2008843

Signed-off-by: Dan Voiculeasa <dan.voiculeasa@windriver.com>