### PR TITLE
Support config for processors on cores other than 0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -163,7 +163,7 @@
 
 [[projects]]
   branch = "starlingx"
-  digest = "1:45373722137b4773fe5672fcfba7b3d44ab579251054c67855b4ec6e933d2635"
+  digest = "1:7650dcdcbc2d6e91b5be2df2855e50bf1797796e0da288b0f1699f99b938eecd"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -211,7 +211,7 @@
     "starlingx/inventory/v1/volumegroups",
   ]
   pruneopts = "T"
-  revision = "abb36b6ec2ac52a474ec3a1d6830b5ae4204c0b6"
+  revision = "269029da6074e283b3ccb7ecb925c066e90a615c"
   source = "https://github.com/wind-river/gophercloud"
 
 [[projects]]

--- a/pkg/apis/starlingx/v1/constructors.go
+++ b/pkg/apis/starlingx/v1/constructors.go
@@ -170,7 +170,7 @@ func parseProcessorInfo(profile *HostProfileSpec, host v1info.HostInfo) error {
 
 		if f, ok := nodes[c.Processor]; !ok {
 			nodes[c.Processor] = map[string]int{function: 1}
-			if profile.HasWorkerSubFunction() && function != cpus.CPUFunctionVSwitch {
+			if profile.HasWorkerSubFunction() && function != cpus.CPUFunctionVSwitch && c.Processor == 0 {
 				// Always add the vswitch function since if it is set to 0
 				// it won't show up in the list and will be missing from the
 				// profile that we create.

--- a/vendor/github.com/gophercloud/gophercloud/starlingx/inventory/v1/cpus/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/starlingx/inventory/v1/cpus/results.go
@@ -42,15 +42,15 @@ type CPU struct {
 	// Processor is the processor package number.  A host usually has 1 or 2
 	// processors but that number could be higher.  Each is usually associated
 	// to a seperate NUMA socket.
-	Processor int `json:"processor"`
+	Processor int `json:"numa_node"`
 
 	// LogicalCore is the logical core number of the core.  If hypher-threading
 	// is disabled then this may map directly to the physical core number.
-	LogicalCore int `json:"logical_core"`
+	LogicalCore int `json:"cpu"`
 
 	// PhysicalCore is the physical core number.  If hyper-threading is enabled
 	// then multiple logical cores will share the same physical core.
-	PhysicalCore int `json:"physical_core"`
+	PhysicalCore int `json:"core"`
 
 	// Thread is the hyper-threading thread number.
 	Thread int `json:"thread"`


### PR DESCRIPTION
This update pulls in a gophercloud fix for CPU fields to support
configuration of processors on cores other than 0. In addition, this
update extends the automatic vswitch processor config mapping to only
be done for core-0.

Signed-off-by: Don Penney <don.penney@windriver.com>