### PR TITLE
Add SAN to DM embedded cert.pem

### DIFF
--- a/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/generator/selfsigned.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/generator/selfsigned.go
@@ -72,10 +72,15 @@ func (cp *SelfSignedCertGenerator) Generate(commonName string) (*Artifacts, erro
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the private key: %v", err)
 	}
+	var dnsNames []string
+	altNames := cert.AltNames{
+		DNSNames: append(dnsNames, commonName),
+	}
 	signedCert, err := cert.NewSignedCert(
 		cert.Config{
 			CommonName: commonName,
 			Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			AltNames:   altNames,
 		},
 		key, signingCert, signingKey,
 	)


### PR DESCRIPTION
With kubernetes 1.19, certificates are required to have SAN entries.
This update allows DM to configure a system running kubernetes 1.19
by adding an alternative name field in the cert generator.

Signed-off-by: Melissa Wang <melissa.wang@windriver.com>