### PR TITLE
Update https & docker_registry certificate examples

### DIFF
--- a/examples/aio-dx-https-with-cert-manager.yaml
+++ b/examples/aio-dx-https-with-cert-manager.yaml
@@ -10,8 +10,8 @@ data:
   tls.key: ""
 kind: Secret
 metadata:
-  name: my-ica-cert-and-key
-  namespace: deployment
+  name: system-local-ca
+  namespace: cert-manager
 type: kubernetes.io/tls
 ---
 apiVersion: v1
@@ -37,6 +37,32 @@ type: Opaque
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
+  name: system-registry-local-certificate
+  namespace: deployment
+spec:
+  dnsNames:
+  - registry.local
+  - registry.central
+  duration: 2160h
+  ipAddresses:
+  - null
+  - null
+  issuerRef:
+    kind: ClusterIssuer
+    name: system-local-ca
+  renewBefore: 360h
+  secretName: system-registry-local-certificate
+  subject:
+    countries:
+    - null
+    organizationalUnits:
+    - WRCP-System
+    provinces:
+    - null
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
   name: system-restapi-gui-certificate
   namespace: deployment
 spec:
@@ -47,21 +73,25 @@ spec:
   ipAddresses:
   - null
   issuerRef:
-    kind: Issuer
-    name: my-ica-cert-and-key-issuer
-  organization:
-  - WRCP-System
+    kind: ClusterIssuer
+    name: system-local-ca
   renewBefore: 360h
   secretName: system-restapi-gui-certificate
+  subject:
+    countries:
+    - null
+    organizationalUnits:
+    - WRCP-System
+    provinces:
+    - null
 ---
 apiVersion: cert-manager.io/v1alpha2
-kind: Issuer
+kind: ClusterIssuer
 metadata:
-  name: my-ica-cert-and-key-issuer
-  namespace: deployment
+  name: system-local-ca
 spec:
   ca:
-    secretName: my-ica-cert-and-key
+    secretName: system-local-ca
 ---
 apiVersion: starlingx.windriver.com/v1
 kind: DataNetwork
@@ -225,6 +255,8 @@ spec:
   certificates:
   - secret: system-restapi-gui-certificate
     type: ssl
+  - secret: system-registry-local-certificate
+    type: docker_registry
   contact: info@windriver.com
   description: Virtual Box Standard System (HTTPS)
   location: vbox

--- a/examples/aio-dx/https-with-cert-manager/platform_certificate_certmanager.yaml
+++ b/examples/aio-dx/https-with-cert-manager/platform_certificate_certmanager.yaml
@@ -5,19 +5,19 @@ data:
   tls.key: ""
 kind: Secret
 metadata:
-  name: my-ica-cert-and-key
-  namespace: deployment
+  name: system-local-ca
+  namespace: cert-manager
 type: kubernetes.io/tls
 ---
 apiVersion: cert-manager.io/v1alpha2
-kind: Issuer
+kind: ClusterIssuer
 metadata:
-  name: my-ica-cert-and-key-issuer
-  namespace: deployment
+  name: system-local-ca
 spec:
   ca:
-    secretName: my-ica-cert-and-key
+    secretName: system-local-ca
 ---
+# StarlingX REST & GUI Certificate
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
@@ -26,14 +26,47 @@ metadata:
 spec:
   secretName: system-restapi-gui-certificate
   issuerRef:
-    name: my-ica-cert-and-key-issuer
-    kind: Issuer
-  duration: 2160h    # 90d 
+    name: system-local-ca
+    kind: ClusterIssuer
+  duration: 2160h    # 90d
   renewBefore: 360h  # 15d
-  commonName:
-  organization:
-  - Example-Org
+  commonName: null # Common Name
+  subject:
+    countries:
+    - null # Country
+    provinces:
+    - null # State/Province
+    organizationalUnits:
+    - WRCP-System
   ipAddresses:
-  -
+  -  null # OAM floating IP
   dnsNames:
-  -
+  - null # OAM IP or FQDN 
+---
+# StarlingX Docker Registry Certificate
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: system-registry-local-certificate
+  namespace: deployment
+spec:
+  secretName: system-registry-local-certificate
+  issuerRef:
+    name: system-local-ca
+    kind: ClusterIssuer
+  duration: 2160h    # 90d
+  renewBefore: 360h  # 15d
+  subject:
+    countries:
+    - null # Country
+    provinces:
+    - null # State/Province
+    organizationalUnits:
+    - WRCP-System
+  ipAddresses:
+  - null # oam floating IP address
+  - null # oam mgmt IP address
+  dnsNames:
+  - registry.local
+  - registry.central
+---

--- a/examples/aio-dx/https-with-cert-manager/platform_certificate_patch.yaml
+++ b/examples/aio-dx/https-with-cert-manager/platform_certificate_patch.yaml
@@ -8,5 +8,7 @@ metadata:
 spec:
   description: Virtual Box Standard System (HTTPS)
   certificates:
-    - type: ssl
-      secret: system-restapi-gui-certificate
+  - secret: system-restapi-gui-certificate
+    type: ssl
+  - secret: system-registry-local-certificate
+    type: docker_registry

--- a/examples/aio-sx-https-with-cert-manager.yaml
+++ b/examples/aio-sx-https-with-cert-manager.yaml
@@ -10,8 +10,8 @@ data:
   tls.key: ""
 kind: Secret
 metadata:
-  name: my-ica-cert-and-key
-  namespace: deployment
+  name: system-local-ca
+  namespace: cert-manager
 type: kubernetes.io/tls
 ---
 apiVersion: v1
@@ -37,31 +37,61 @@ type: Opaque
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
+  name: system-registry-local-certificate
+  namespace: deployment
+spec:
+  dnsNames:
+  - registry.local
+  - registry.central
+  duration: 2160h
+  ipAddresses:
+  - null
+  - null
+  issuerRef:
+    kind: ClusterIssuer
+    name: system-local-ca
+  renewBefore: 360h
+  secretName: system-registry-local-certificate
+  subject:
+    countries:
+    - null
+    organizationalUnits:
+    - WRCP-System
+    provinces:
+    - null
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
   name: system-restapi-gui-certificate
   namespace: deployment
 spec:
-  commonName: 10.10.10.3
+  commonName: null
   dnsNames:
-  - example-hostname.com
+  - null
   duration: 2160h
   ipAddresses:
-  - 10.10.10.3
+  - null
   issuerRef:
-    kind: Issuer
-    name: my-ica-cert-and-key-issuer
-  organization:
-  - WRCP-System
+    kind: ClusterIssuer
+    name: system-local-ca
   renewBefore: 360h
   secretName: system-restapi-gui-certificate
+  subject:
+    countries:
+    - null
+    organizationalUnits:
+    - WRCP-System
+    provinces:
+    - null
 ---
 apiVersion: cert-manager.io/v1alpha2
-kind: Issuer
+kind: ClusterIssuer
 metadata:
-  name: my-ica-cert-and-key-issuer
-  namespace: deployment
+  name: system-local-ca
 spec:
   ca:
-    secretName: my-ica-cert-and-key
+    secretName: system-local-ca
 ---
 apiVersion: starlingx.windriver.com/v1
 kind: DataNetwork
@@ -204,6 +234,8 @@ spec:
   certificates:
   - secret: system-restapi-gui-certificate
     type: ssl
+  - secret: system-registry-local-certificate
+    type: docker_registry
   contact: info@windriver.com
   description: Virtual Box Standard System (HTTPS)
   location: vbox

--- a/examples/aio-sx/https-with-cert-manager/platform_certificate_certmanager.yaml
+++ b/examples/aio-sx/https-with-cert-manager/platform_certificate_certmanager.yaml
@@ -5,19 +5,19 @@ data:
   tls.key: ""
 kind: Secret
 metadata:
-  name: my-ica-cert-and-key
-  namespace: deployment
+  name: system-local-ca
+  namespace: cert-manager
 type: kubernetes.io/tls
 ---
 apiVersion: cert-manager.io/v1alpha2
-kind: Issuer
+kind: ClusterIssuer
 metadata:
-  name: my-ica-cert-and-key-issuer
-  namespace: deployment
+  name: system-local-ca
 spec:
   ca:
-    secretName: my-ica-cert-and-key
+    secretName: system-local-ca
 ---
+# StarlingX REST & GUI Certificate
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
@@ -26,14 +26,47 @@ metadata:
 spec:
   secretName: system-restapi-gui-certificate
   issuerRef:
-    name: my-ica-cert-and-key-issuer
-    kind: Issuer
-  duration: 2160h    # 90d 
+    name: system-local-ca
+    kind: ClusterIssuer
+  duration: 2160h    # 90d
   renewBefore: 360h  # 15d
-  commonName: 10.10.10.3
-  organization:
-  - Example-Org
+  commonName: null # Common Name
+  subject:
+    countries:
+    - null # Country
+    provinces:
+    - null # State/Province
+    organizationalUnits:
+    - WRCP-System
   ipAddresses:
-  - 10.10.10.3
+  -  null # OAM floating IP
   dnsNames:
-  - example-hostname.com
+  - null # OAM IP or FQDN 
+---
+# StarlingX Docker Registry Certificate
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: system-registry-local-certificate
+  namespace: deployment
+spec:
+  secretName: system-registry-local-certificate
+  issuerRef:
+    name: system-local-ca
+    kind: ClusterIssuer
+  duration: 2160h    # 90d
+  renewBefore: 360h  # 15d
+  subject:
+    countries:
+    - null # Country
+    provinces:
+    - null # State/Province
+    organizationalUnits:
+    - WRCP-System
+  ipAddresses:
+  - null # oam floating IP address
+  - null # oam mgmt IP address
+  dnsNames:
+  - registry.local
+  - registry.central
+---

--- a/examples/aio-sx/https-with-cert-manager/platform_certificate_patch.yaml
+++ b/examples/aio-sx/https-with-cert-manager/platform_certificate_patch.yaml
@@ -8,5 +8,7 @@ metadata:
 spec:
   description: Virtual Box Standard System (HTTPS)
   certificates:
-    - type: ssl
-      secret: system-restapi-gui-certificate
+  - secret: system-restapi-gui-certificate
+    type: ssl
+  - secret: system-registry-local-certificate
+    type: docker_registry

--- a/examples/standard-https-with-cert-manager.yaml
+++ b/examples/standard-https-with-cert-manager.yaml
@@ -10,8 +10,8 @@ data:
   tls.key: ""
 kind: Secret
 metadata:
-  name: my-ica-cert-and-key
-  namespace: deployment
+  name: system-local-ca
+  namespace: cert-manager
 type: kubernetes.io/tls
 ---
 apiVersion: v1
@@ -35,6 +35,32 @@ type: Opaque
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
+  name: system-registry-local-certificate
+  namespace: deployment
+spec:
+  dnsNames:
+  - registry.local
+  - registry.central
+  duration: 2160h
+  ipAddresses:
+  - null
+  - null
+  issuerRef:
+    kind: ClusterIssuer
+    name: system-local-ca
+  renewBefore: 360h
+  secretName: system-registry-local-certificate
+  subject:
+    countries:
+    - null
+    organizationalUnits:
+    - WRCP-System
+    provinces:
+    - null
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
   name: system-restapi-gui-certificate
   namespace: deployment
 spec:
@@ -45,21 +71,25 @@ spec:
   ipAddresses:
   - null
   issuerRef:
-    kind: Issuer
-    name: my-ica-cert-and-key-issuer
-  organization:
-  - WRCP-System
+    kind: ClusterIssuer
+    name: system-local-ca
   renewBefore: 360h
   secretName: system-restapi-gui-certificate
+  subject:
+    countries:
+    - null
+    organizationalUnits:
+    - WRCP-System
+    provinces:
+    - null
 ---
 apiVersion: cert-manager.io/v1alpha2
-kind: Issuer
+kind: ClusterIssuer
 metadata:
-  name: my-ica-cert-and-key-issuer
-  namespace: deployment
+  name: system-local-ca
 spec:
   ca:
-    secretName: my-ica-cert-and-key
+    secretName: system-local-ca
 ---
 apiVersion: starlingx.windriver.com/v1
 kind: DataNetwork
@@ -273,8 +303,10 @@ metadata:
   namespace: deployment
 spec:
   certificates:
-  - secret: platform-certificate
+  - secret: system-restapi-gui-certificate
     type: ssl
+  - secret: system-registry-local-certificate
+    type: docker_registry
   contact: info@windriver.com
   description: Virtual Box Standard System (HTTPS)
   location: vbox

--- a/examples/standard/https-with-cert-manager/platform_certificate_certmanager.yaml
+++ b/examples/standard/https-with-cert-manager/platform_certificate_certmanager.yaml
@@ -5,19 +5,19 @@ data:
   tls.key: ""
 kind: Secret
 metadata:
-  name: my-ica-cert-and-key
-  namespace: deployment
+  name: system-local-ca
+  namespace: cert-manager
 type: kubernetes.io/tls
 ---
 apiVersion: cert-manager.io/v1alpha2
-kind: Issuer
+kind: ClusterIssuer
 metadata:
-  name: my-ica-cert-and-key-issuer
-  namespace: deployment
+  name: system-local-ca
 spec:
   ca:
-    secretName: my-ica-cert-and-key
+    secretName: system-local-ca
 ---
+# StarlingX REST & GUI Certificate
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
@@ -26,14 +26,47 @@ metadata:
 spec:
   secretName: system-restapi-gui-certificate
   issuerRef:
-    name: my-ica-cert-and-key-issuer
-    kind: Issuer
-  duration: 2160h    # 90d 
+    name: system-local-ca
+    kind: ClusterIssuer
+  duration: 2160h    # 90d
   renewBefore: 360h  # 15d
-  commonName: 
-  organization:
-  - Example-Org
+  commonName: null # Common Name
+  subject:
+    countries:
+    - null # Country
+    provinces:
+    - null # State/Province
+    organizationalUnits:
+    - WRCP-System
   ipAddresses:
-  - 
+  -  null # OAM floating IP
   dnsNames:
-  - 
+  - null # OAM IP or FQDN 
+---
+# StarlingX Docker Registry Certificate
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: system-registry-local-certificate
+  namespace: deployment
+spec:
+  secretName: system-registry-local-certificate
+  issuerRef:
+    name: system-local-ca
+    kind: ClusterIssuer
+  duration: 2160h    # 90d
+  renewBefore: 360h  # 15d
+  subject:
+    countries:
+    - null # Country
+    provinces:
+    - null # State/Province
+    organizationalUnits:
+    - WRCP-System
+  ipAddresses:
+  - null # oam floating IP address
+  - null # oam mgmt IP address
+  dnsNames:
+  - registry.local
+  - registry.central
+---

--- a/examples/standard/https-with-cert-manager/platform_certificate_patch.yaml
+++ b/examples/standard/https-with-cert-manager/platform_certificate_patch.yaml
@@ -8,5 +8,7 @@ metadata:
 spec:
   description: Virtual Box Standard System (HTTPS)
   certificates:
-    - type: ssl
-      secret: platform-certificate
+  - secret: system-restapi-gui-certificate
+    type: ssl
+  - secret: system-registry-local-certificate
+    type: docker_registry


### PR DESCRIPTION
This commit updates the examples with using ClusterIssuers rather than domain-specific issuers (in-line with new customer documentation). Docker_registry certificate configuration also added to examples.
