### PR TITLE
Update deploy tool to populate ptp per instance config

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ building system endpoint secret configuration
 building certificate secret configurations
 building data network configurations
 building platform network configurations
+building PTP instance configurations
+building PTP interface configurations
 building host and profile configurations
 ...Building host configuration for "controller-0"
 ...Building host profile configuration for "controller-0"


### PR DESCRIPTION
This commit updates the deploy tool to correctly populate the ptp
instances, ptp interfaces and the host profile with those ptp per
instance configurations.

Test:
Deployed an AIOSX system with the PTP instances, interfaces and
parameters configured. Use the new deploy binary to generate the
deployment configurations with "./deploy build -n deployment -s vbox
--minimal-config". The new deployment-config.yaml contains those
PTP-related resources correctly configured.

Signed-off-by: Yuxing Jiang <yuxing.jiang@windriver.com>