### PR TITLE
Bug fix: fix error in NewPTPInterface

### DIFF
--- a/pkg/apis/starlingx/v1/constructors.go
+++ b/pkg/apis/starlingx/v1/constructors.go
@@ -1368,7 +1368,7 @@ func NewPTPInterface(name string, namespace string, PTPint ptpinterfaces.PTPInte
 	ptpInterface := PtpInterface{
 		TypeMeta: v1types.TypeMeta{
 			APIVersion: APIVersion,
-			Kind:       KindPTPInstance,
+			Kind:       KindPTPInterface,
 		},
 		ObjectMeta: v1types.ObjectMeta{
 			Name:      name,


### PR DESCRIPTION
This commit is a bug fix to fix an error in the NewPTPInterface func,
the kind of a new PTP Interface should be the PtpInterface rather than
the PtpInstance.

Tested by generate the deployment configuration with the new DM image.
The kind of PTP interface is corrected in the new configuration.

Signed-off-by: Yuxing Jiang <yuxing.jiang@windriver.com>
(cherry picked from commit dda40289941efc81f60177d53be1f254ea5da6e6)