### PR TITLE
Bug fix: Support more than 2 storage nodes

### DIFF
--- a/pkg/controller/common/common.go
+++ b/pkg/controller/common/common.go
@@ -36,6 +36,10 @@ var (
 	// is no need to automatically requeue these events.
 	RetrySystemNotReady = reconcile.Result{Requeue: false}
 
+	// RetryCephPrimaryGroupNotReady should be used whenever a storage node needs to wait
+	// for the ceph primary storage group to finish its reconcile task.
+	RetryCephPrimaryGroupNotReady = reconcile.Result{Requeue: true}
+
 	// RetryMissingClient should be used for any object reconciliation that
 	// fails because of the platform client is missing or was reset.  The system
 	// controller is responsible for re-creating the client and it will kick


### PR DESCRIPTION
The issue was the second pair of storage nodes are
not configured if more than 2 storage nodes are
specified (Unlock fails)

The fix is adding a new state "RetryCephPrimaryGroupNotReady"
to wait to add second group of storage nodes until the first group
of storage nodes are configured as unlocked and available.

Tested by configure deployment nodes with designer DM container:
- SX (Not to have regression issues)
- DX (Not to have regression issues)
- Storage (4 Storage nodes, confirm storage-2 and storage-3 waited
           until storage-0 and storage-1 are available then both
           nodes are configured as expected)
