### PR TITLE
Migrate helm CRDs from apiversion v1beta1 to v1

### DIFF
--- a/config/crds/starlingx_v1_datanetwork.yaml
+++ b/config/crds/starlingx_v1_datanetwork.yaml
@@ -1,129 +1,135 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    controller-tools.k8s.io: "1.0"
+    controller-tools.k8s.io: '1.0'
   name: datanetworks.starlingx.windriver.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.type
-    description: The data network encapsulation type.
-    name: type
-    type: string
-  - JSONPath: .status.inSync
-    description: The current synchronization state.
-    name: insync
-    type: boolean
-  - JSONPath: .status.reconciled
-    description: The current reconciliation state.
-    name: reconciled
-    type: boolean
   group: starlingx.windriver.com
   names:
     kind: DataNetwork
     plural: datanetworks
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            description:
-              description: Description defines a user define description which explains
-                the purpose of the data network.
-              type: string
-            mtu:
-              description: MTU defines the maximum transmit unit for any virtual network
-                derived from this data network.
-              format: int64
-              maximum: 9216
-              minimum: 576
-              type: integer
-            type:
-              description: Type defines the encapsulation method used for the data
-                network.
-              enum:
-              - flat
-              - vlan
-              - vxlan
-              type: string
-            vxlan:
-              description: VxLan defines VxLAN specific attributes for the data network.
-              properties:
-                endpointMode:
-                  description: EndpointMode defines the endpoint port learning mode
-                    for the data network network.  The dynamic mode allows the virtual
-                    network to use multicast addressing when transmitting a packet
-                    to an unknown endpoint to dynamically discover that node's VTEP
-                    IP address.   The static mode requires that all VTEP IP addresses
-                    be programmed into the virtual switch in advance and any packets
-                    destined to an unknown endpoint are dropped.
-                  enum:
-                  - static
-                  - dynamic
-                  type: string
-                multicastGroup:
-                  description: MulticastGroup defines the multicast IP address to
-                    be used for the data network.
-                  type: string
-                ttl:
-                  description: TTL defines the time-to-live value to assign to the
-                    data network.
-                  format: int64
-                  maximum: 255
-                  minimum: 1
-                  type: integer
-                udpPortNumber:
-                  description: UDPPortNumber defines the UDP protocol number to be
-                    used for the data network.  The IANA or Legacy port number values
-                    can be used.
-                  enum:
-                  - 4789
-                  - 8472
-                  format: int64
-                  type: integer
-              type: object
-          required:
-          - type
-          type: object
-        status:
-          properties:
-            id:
-              description: ID defines the system assigned unique identifier.  This
-                will only exist once this resource has been provisioned into the system.
-              type: string
-            inSync:
-              description: Defines whether the resource has been provisioned on the
-                target system.
-              type: boolean
-            reconciled:
-              description: Reconciled defines whether the host has been successfully
-                reconciled at least once.  If further changes are made they will be
-                ignored by the reconciler.
-              type: boolean
-          required:
-          - reconciled
-          - inSync
-          type: object
-  version: v1
+  versions:
+  - additionalPrinterColumns:
+    - description: The data network encapsulation type.
+      jsonPath: .spec.type
+      name: type
+      type: string
+    - description: The current synchronization state.
+      jsonPath: .status.inSync
+      name: insync
+      type: boolean
+    - description: The current reconciliation state.
+      jsonPath: .status.reconciled
+      name: reconciled
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              description:
+                description: Description defines a user define description which explains
+                  the purpose of the data network.
+                type: string
+              mtu:
+                description: MTU defines the maximum transmit unit for any virtual
+                  network derived from this data network.
+                format: int64
+                maximum: 9216
+                minimum: 576
+                type: integer
+              type:
+                description: Type defines the encapsulation method used for the data
+                  network.
+                enum:
+                - flat
+                - vlan
+                - vxlan
+                type: string
+              vxlan:
+                description: VxLan defines VxLAN specific attributes for the data
+                  network.
+                properties:
+                  endpointMode:
+                    description: EndpointMode defines the endpoint port learning mode
+                      for the data network network.  The dynamic mode allows the virtual
+                      network to use multicast addressing when transmitting a packet
+                      to an unknown endpoint to dynamically discover that node's VTEP
+                      IP address.   The static mode requires that all VTEP IP addresses
+                      be programmed into the virtual switch in advance and any packets
+                      destined to an unknown endpoint are dropped.
+                    enum:
+                    - static
+                    - dynamic
+                    type: string
+                  multicastGroup:
+                    description: MulticastGroup defines the multicast IP address to
+                      be used for the data network.
+                    type: string
+                  ttl:
+                    description: TTL defines the time-to-live value to assign to the
+                      data network.
+                    format: int64
+                    maximum: 255
+                    minimum: 1
+                    type: integer
+                  udpPortNumber:
+                    description: UDPPortNumber defines the UDP protocol number to
+                      be used for the data network.  The IANA or Legacy port number
+                      values can be used.
+                    enum:
+                    - 4789
+                    - 8472
+                    format: int64
+                    type: integer
+                type: object
+            required:
+            - type
+            type: object
+          status:
+            properties:
+              id:
+                description: ID defines the system assigned unique identifier.  This
+                  will only exist once this resource has been provisioned into the
+                  system.
+                type: string
+              inSync:
+                description: Defines whether the resource has been provisioned on
+                  the target system.
+                type: boolean
+              reconciled:
+                description: Reconciled defines whether the host has been successfully
+                  reconciled at least once.  If further changes are made they will
+                  be ignored by the reconciler.
+                type: boolean
+            required:
+            - reconciled
+            - inSync
+            type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
-    kind: ""
-    plural: ""
+    kind: ''
+    plural: ''
   conditions: []
   storedVersions: []

--- a/config/crds/starlingx_v1_host.yaml
+++ b/config/crds/starlingx_v1_host.yaml
@@ -1,1073 +1,1084 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    controller-tools.k8s.io: "1.0"
+    controller-tools.k8s.io: '1.0'
   name: hosts.starlingx.windriver.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.administrativeState
-    description: The administrative state of the host.
-    name: administrative
-    type: string
-  - JSONPath: .status.operationalStatus
-    description: The operational status of the host.
-    name: operational
-    type: string
-  - JSONPath: .status.availabilityStatus
-    description: The availability status of the host.
-    name: availability
-    type: string
-  - JSONPath: .spec.profile
-    description: The configuration profile of the host.
-    name: profile
-    type: string
-  - JSONPath: .status.inSync
-    description: The current synchronization state.
-    name: insync
-    type: boolean
-  - JSONPath: .status.reconciled
-    description: The current reconciliation state.
-    name: reconciled
-    type: boolean
   group: starlingx.windriver.com
   names:
     kind: Host
     plural: hosts
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            match:
-              description: Match defines the attributes used to match a system host
-                resource to a host CR definition.
-              properties:
-                boardManagement:
-                  description: 'BoardManagement defines the board management attributes
-                    that can be used to match a system host resource to a system CR
-                    definition. NOTE:  Not yet supported.'
-                  properties:
-                    address:
-                      description: Address defines the board management IP address.
-                      type: string
-                    type:
-                      description: Type defines the board management type
-                      enum:
-                      - none
-                      - bmc
-                      - dynamic
-                      - ipmi
-                      - redfish
-                      type: string
-                  type: object
-                bootMAC:
-                  description: BootMAC defines the MAC address that a host used to
-                    perform the initial software installation.
-                  pattern: ^([0-9a-fA-Z]{2}[:-]){5}([0-9a-fA-Z]{2})$
-                  type: string
-                dmi:
-                  description: 'DMI defines the Desktop Management Interface attributes
-                    that can be used to match a system host resource to a system CR
-                    definition. NOTE:  Not yet supported.'
-                  properties:
-                    assetTag:
-                      description: AssetTag defines the board asset tag as stored
-                        in the DMI block.
-                      maxLength: 255
-                      type: string
-                    serialNumber:
-                      description: SerialNumber defines the board serial number as
-                        stored in the DMI block.
-                      maxLength: 255
-                      type: string
-                  type: object
-              type: object
-            overrides:
-              description: Overrides defines a set of HostProfile attributes that
-                must be overridden from the base HostProfile before configuring the
-                host.  The schema for this field is intentionally a copy of the full
-                HostProfileSpec schema so that any HostProfile attribute can be overridden
-                on a per-host basis.  For example, it may be necessary to define IP
-                addresses that are unique to each host, or to override storage device
-                paths if the installed devices does not align completely with the
-                HostProfile pointed to by the "profile" attribute.
-              properties:
-                addresses:
-                  description: Addresses defines the list of addresses to be configured
-                    against this host.  Addresses are specific to a single host therefore
-                    they should only be specified if this profile is only going to
-                    be used to configure a single host.
-                  items:
+  versions:
+  - additionalPrinterColumns:
+    - description: The administrative state of the host.
+      jsonPath: .status.administrativeState
+      name: administrative
+      type: string
+    - description: The operational status of the host.
+      jsonPath: .status.operationalStatus
+      name: operational
+      type: string
+    - description: The availability status of the host.
+      jsonPath: .status.availabilityStatus
+      name: availability
+      type: string
+    - description: The configuration profile of the host.
+      jsonPath: .spec.profile
+      name: profile
+      type: string
+    - description: The current synchronization state.
+      jsonPath: .status.inSync
+      name: insync
+      type: boolean
+    - description: The current reconciliation state.
+      jsonPath: .status.reconciled
+      name: reconciled
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              match:
+                description: Match defines the attributes used to match a system host
+                  resource to a host CR definition.
+                properties:
+                  boardManagement:
+                    description: 'BoardManagement defines the board management attributes
+                      that can be used to match a system host resource to a system
+                      CR definition. NOTE:  Not yet supported.'
                     properties:
                       address:
-                        description: Address defines the IPv4 or IPv6 address value.
+                        description: Address defines the board management IP address.
                         type: string
-                      interface:
-                        description: Interface is a reference to the interface name
-                          against which to configure the address.
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_\.]+$
+                      type:
+                        description: Type defines the board management type
+                        enum:
+                        - none
+                        - bmc
+                        - dynamic
+                        - ipmi
+                        - redfish
                         type: string
-                      prefix:
-                        description: Prefix defines the IP address network prefix
-                          length.
-                        format: int64
-                        maximum: 128
-                        minimum: 1
-                        type: integer
-                    required:
-                    - interface
-                    - address
-                    - prefix
                     type: object
-                  type: array
-                administrativeState:
-                  description: AdministrativeState defines the desired administrative
-                    state of the host
-                  enum:
-                  - locked
-                  - unlocked
-                  type: string
-                base:
-                  description: 'Base defines the name of another HostProfile from
-                    which to inherit attributes.  HostProfiles can be structured in
-                    a hierarchy so that many HostProfiles can inherit generic attributes
-                    from a parent HostProfile. This hierarchy can be defined in multiple
-                    layers; with lower layers overriding attributes set in higher
-                    layers.  At configuration time, before a Host is configured, the
-                    hierarchy of HostProfile resources is flattened to produce a single
-                    composite profile that represents the final attributes as they
-                    are overridden down the HostProfile hierarchy.  Once the HostProfile
-                    hierarchy is flattened to a composite profile.  The Deployment
-                    Manager will further refine the profile to create a final HostProfile
-                    which serves as the final configuration for the Host resource.  To
-                    create the final HostProfile, the Deployment Manages merges the
-                    composite profile with the initial default host attributes, and
-                    then merges the individual host overrides into that result.  The
-                    process can be illustrated as follows:          Host Defaults      +---------------------+            |                                      \            |                                       \         Base
-                    Profile        +                       \            |                 \                       \           ...                  +
-                    Composite Profile ----+  Final Profile            |                 /                        /      Personality
-                    Profile(s) +                        /            |                                        /            |                                       /           Host                                    /            |                                     /            |                                    /         Host
-                    Overrides       +-----------------+  Merging two HostProfileSpec
-                    resources consists of merging the attributes of a higher precedence
-                    profile into the attributes of a lower precedences profile.  The
-                    rules for merging attributes are as follows.    1) A nil pointer
-                    is always overwritten by a non-nil pointer.    2) Two non-nil
-                    pointers are merged together according to the underlying      type.    2a)
-                    If the type pointed to is a primitive type (e.g., int, bool,       string,
-                    etc) then the higher precedence value is used).    2b) If the
-                    type pointed to is a structure then this same merge       procedure
-                    is repeated recursively on each field of the structure       with
-                    these same rules applying to each field.    2c) If the type pointed
-                    to is a slice/array then rule (3) is used.    2d) If the type
-                    pointed to is a map then higher precedence value is       used
-                    and the entire map is overwritten.    3) Two slices are merged
-                    together using the following sub-rules.    3a) If the elements
-                    of slices define the KeyEqual() method then an       attempt is
-                    made to try to merge equivalent element using this same       merge
-                    strategy.  Elements from the higher precedence list that do       not
-                    have an equivalent in the lower precedence list are appended to       the
-                    list.  Elements appearing in the lower precedence list but not       in
-                    the higher precedence list are kept intact.    3b) If the elements
-                    of the slices do not define the KeyEqual() method       then they
-                    are simply concatenated together.    3c) An empty slice is handled
-                    as a special case that deletes the       contents of the lower
-                    precedence slice.  Do not confuse an empty       slice with a
-                    nil slice pointer.'
-                  type: string
-                boardManagement:
-                  description: BoardManagement defines the attributes specific to
-                    the board management controller configuration.
-                  properties:
-                    address:
-                      description: Address defines the IP address or hostname of the
-                        board management interface.  An address is specific to a host
-                        therefore this should only be set if the profile is only going
-                        to be used to configure a single host; otherwise it should
-                        be set as a per-host override.
-                      type: string
-                    credentials:
-                      description: Credentials defines the authentication credentials
-                        for the board management interface.  This is left as optional
-                        so that the address can be overridden on a per-host basis
-                        without worrying about overwriting the type or credentials.
+                  bootMAC:
+                    description: BootMAC defines the MAC address that a host used
+                      to perform the initial software installation.
+                    pattern: ^([0-9a-fA-Z]{2}[:-]){5}([0-9a-fA-Z]{2})$
+                    type: string
+                  dmi:
+                    description: 'DMI defines the Desktop Management Interface attributes
+                      that can be used to match a system host resource to a system
+                      CR definition. NOTE:  Not yet supported.'
+                    properties:
+                      assetTag:
+                        description: AssetTag defines the board asset tag as stored
+                          in the DMI block.
+                        maxLength: 255
+                        type: string
+                      serialNumber:
+                        description: SerialNumber defines the board serial number
+                          as stored in the DMI block.
+                        maxLength: 255
+                        type: string
+                    type: object
+                type: object
+              overrides:
+                description: Overrides defines a set of HostProfile attributes that
+                  must be overridden from the base HostProfile before configuring
+                  the host.  The schema for this field is intentionally a copy of
+                  the full HostProfileSpec schema so that any HostProfile attribute
+                  can be overridden on a per-host basis.  For example, it may be necessary
+                  to define IP addresses that are unique to each host, or to override
+                  storage device paths if the installed devices does not align completely
+                  with the HostProfile pointed to by the "profile" attribute.
+                properties:
+                  addresses:
+                    description: Addresses defines the list of addresses to be configured
+                      against this host.  Addresses are specific to a single host
+                      therefore they should only be specified if this profile is only
+                      going to be used to configure a single host.
+                    items:
                       properties:
-                        password:
-                          description: Password defines the attributes specific to
-                            password based authentication.
-                          properties:
-                            secret:
-                              description: Secret defines the name of the secret which
-                                contains the username and password for the board management
-                                controller.
-                              type: string
-                          required:
-                          - secret
-                          type: object
+                        address:
+                          description: Address defines the IPv4 or IPv6 address value.
+                          type: string
+                        interface:
+                          description: Interface is a reference to the interface name
+                            against which to configure the address.
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_\.]+$
+                          type: string
+                        prefix:
+                          description: Prefix defines the IP address network prefix
+                            length.
+                          format: int64
+                          maximum: 128
+                          minimum: 1
+                          type: integer
+                      required:
+                      - interface
+                      - address
+                      - prefix
                       type: object
-                    type:
-                      description: Type defines the board management controller type.  This
-                        is left as optional so that the address can be overridden
-                        on a per-host basis without worrying about overwriting the
-                        type or credentials.
-                      enum:
-                      - none
-                      - bmc
-                      - dynamic
-                      - ipmi
-                      - redfish
-                      type: string
-                  type: object
-                bootDevice:
-                  description: BootDevice defines the absolute device path of the
-                    device to be used for installation.
-                  maxLength: 4095
-                  pattern: ^/dev/.+$
-                  type: string
-                bootMAC:
-                  description: BootMAC defines the MAC address that a host uses to
-                    perform the initial software installation.  This is only applicable
-                    for statically provisioned hosts and should be set on each hosts
-                    via the overrides attributes.
-                  pattern: ^([0-9a-fA-Z]{2}[:-]){5}([0-9a-fA-Z]{2})$
-                  type: string
-                clockSynchronization:
-                  description: ClockSynchronization defines the clock synchronization
-                    source of the host resource.
-                  enum:
-                  - ntp
-                  - ptp
-                  type: string
-                console:
-                  description: Console defines the installation output device.
-                  pattern: ^(|tty[0-9]+|ttyS[0-9]+(,\d+([a-zA-Z0-9]+)?)?|ttyUSB[0-9]+(,\d+([a-zA-Z0-9]+))?|lp[0-9]+)$
-                  type: string
-                installOutput:
-                  description: InstallOutput defines the install output method.  The
-                    graphical mode is only suitable when the console attribute is
-                    set to a graphical terminal. The text mode can be used with both
-                    serial and graphical console configurations.
-                  enum:
-                  - text
-                  - graphical
-                  type: string
-                interfaces:
-                  description: Interfaces defines the list of interfaces to be configured
-                    against this host.
-                  properties:
-                    bond:
-                      description: Bond defines the list of Bond interfaces to be
-                        configured on a host.
-                      items:
+                    type: array
+                  administrativeState:
+                    description: AdministrativeState defines the desired administrative
+                      state of the host
+                    enum:
+                    - locked
+                    - unlocked
+                    type: string
+                  base:
+                    description: 'Base defines the name of another HostProfile from
+                      which to inherit attributes.  HostProfiles can be structured
+                      in a hierarchy so that many HostProfiles can inherit generic
+                      attributes from a parent HostProfile. This hierarchy can be
+                      defined in multiple layers; with lower layers overriding attributes
+                      set in higher layers.  At configuration time, before a Host
+                      is configured, the hierarchy of HostProfile resources is flattened
+                      to produce a single composite profile that represents the final
+                      attributes as they are overridden down the HostProfile hierarchy.  Once
+                      the HostProfile hierarchy is flattened to a composite profile.  The
+                      Deployment Manager will further refine the profile to create
+                      a final HostProfile which serves as the final configuration
+                      for the Host resource.  To create the final HostProfile, the
+                      Deployment Manages merges the composite profile with the initial
+                      default host attributes, and then merges the individual host
+                      overrides into that result.  The process can be illustrated
+                      as follows:          Host Defaults      +---------------------+            |                                      \            |                                       \         Base
+                      Profile        +                       \            |                 \                       \           ...                  +
+                      Composite Profile ----+  Final Profile            |                 /                        /      Personality
+                      Profile(s) +                        /            |                                        /            |                                       /           Host                                    /            |                                     /            |                                    /         Host
+                      Overrides       +-----------------+  Merging two HostProfileSpec
+                      resources consists of merging the attributes of a higher precedence
+                      profile into the attributes of a lower precedences profile.  The
+                      rules for merging attributes are as follows.    1) A nil pointer
+                      is always overwritten by a non-nil pointer.    2) Two non-nil
+                      pointers are merged together according to the underlying      type.    2a)
+                      If the type pointed to is a primitive type (e.g., int, bool,       string,
+                      etc) then the higher precedence value is used).    2b) If the
+                      type pointed to is a structure then this same merge       procedure
+                      is repeated recursively on each field of the structure       with
+                      these same rules applying to each field.    2c) If the type
+                      pointed to is a slice/array then rule (3) is used.    2d) If
+                      the type pointed to is a map then higher precedence value is       used
+                      and the entire map is overwritten.    3) Two slices are merged
+                      together using the following sub-rules.    3a) If the elements
+                      of slices define the KeyEqual() method then an       attempt
+                      is made to try to merge equivalent element using this same       merge
+                      strategy.  Elements from the higher precedence list that do       not
+                      have an equivalent in the lower precedence list are appended
+                      to       the list.  Elements appearing in the lower precedence
+                      list but not       in the higher precedence list are kept intact.    3b)
+                      If the elements of the slices do not define the KeyEqual() method       then
+                      they are simply concatenated together.    3c) An empty slice
+                      is handled as a special case that deletes the       contents
+                      of the lower precedence slice.  Do not confuse an empty       slice
+                      with a nil slice pointer.'
+                    type: string
+                  boardManagement:
+                    description: BoardManagement defines the attributes specific to
+                      the board management controller configuration.
+                    properties:
+                      address:
+                        description: Address defines the IP address or hostname of
+                          the board management interface.  An address is specific
+                          to a host therefore this should only be set if the profile
+                          is only going to be used to configure a single host; otherwise
+                          it should be set as a per-host override.
+                        type: string
+                      credentials:
+                        description: Credentials defines the authentication credentials
+                          for the board management interface.  This is left as optional
+                          so that the address can be overridden on a per-host basis
+                          without worrying about overwriting the type or credentials.
                         properties:
-                          class:
-                            description: Class defines the intended usage of this
-                              interface by the system.
-                            enum:
-                            - platform
-                            - data
-                            - pci-sriov
-                            - pci-passthrough
-                            - none
-                            type: string
-                          dataNetworks:
-                            description: DataNetworks defines the list of data networks
-                              to be configured against this interface.
-                            items:
-                              maxLength: 255
-                              pattern: ^[a-zA-Z0-9\-_]+$
-                              type: string
-                            maxLength: 255
-                            pattern: ^[a-zA-Z0-9\-_]+$
-                            type: array
-                          members:
-                            description: Members defines the list of interfaces which,
-                              together, make up the Bond interface.
-                            items:
-                              maxLength: 255
-                              pattern: ^[a-zA-Z0-9\-_\.]+$
-                              type: string
-                            maxLength: 255
-                            pattern: ^[a-zA-Z0-9\-_\.]+$
-                            type: array
-                          mode:
-                            description: Mode defines the Bond interface aggregation
-                              mode.
-                            enum:
-                            - balanced
-                            - active_standby
-                            - 802.3ad
-                            type: string
-                          mtu:
-                            description: MTU defines the maximum transmit unit for
-                              this interface.
-                            format: int64
-                            maximum: 9216
-                            minimum: 576
-                            type: integer
-                          name:
-                            description: Name defines the name of the interface to
-                              be configured.
-                            maxLength: 255
-                            pattern: ^[a-zA-Z0-9\-_\.]+$
-                            type: string
-                          platformNetworks:
-                            description: PlatformNetworks defines the list of platform
-                              networks to be configured against this interface.
-                            items:
-                              maxLength: 255
-                              pattern: ^[a-zA-Z0-9\-_]+$
-                              type: string
-                            maxLength: 255
-                            pattern: ^[a-zA-Z0-9\-_]+$
-                            type: array
-                          primaryReselect:
-                            description: PrimaryReselect defines the reselection policy
-                              for the Bond interface. Only applicable for active_standby
-                              mode.
-                            type: string
-                          ptpInterfaces:
-                            description: PtpInterfaces defines the ptp interfaces
-                              to be configured against this interface.
-                            items:
-                              maxLength: 255
-                              pattern: ^[a-zA-Z0-9\-_]+$
-                              type: string
-                            maxLength: 255
-                            pattern: ^[a-zA-Z0-9\-_]+$
-                            type: array
-                          ptpRole:
-                            description: PTPRole defines the ptp role as master, slave,
-                              or none
-                            enum:
-                            - master
-                            - slave
-                            - none
-                            type: string
-                          transmitHashPolicy:
-                            description: TransmitHashPolicy defines the transmit interface
-                              selection policy for the Bond interface.  Only applicable
-                              for 802.3ad and balanced modes.
-                            enum:
-                            - layer2
-                            - layer2+3
-                            type: string
-                        required:
-                        - name
-                        - class
-                        - members
-                        - mode
-                        type: object
-                      type: array
-                    ethernet:
-                      description: Ethernet defines the list of ethernet interfaces
-                        to be configured on a host.
-                      items:
-                        properties:
-                          class:
-                            description: Class defines the intended usage of this
-                              interface by the system.
-                            enum:
-                            - platform
-                            - data
-                            - pci-sriov
-                            - pci-passthrough
-                            - none
-                            type: string
-                          dataNetworks:
-                            description: DataNetworks defines the list of data networks
-                              to be configured against this interface.
-                            items:
-                              maxLength: 255
-                              pattern: ^[a-zA-Z0-9\-_]+$
-                              type: string
-                            maxLength: 255
-                            pattern: ^[a-zA-Z0-9\-_]+$
-                            type: array
-                          lower:
-                            description: Lower defines the interface name over which
-                              this ethernet interface is to be configured.
-                            pattern: ^[a-zA-Z0-9\-_\.]+$
-                            type: string
-                          mtu:
-                            description: MTU defines the maximum transmit unit for
-                              this interface.
-                            format: int64
-                            maximum: 9216
-                            minimum: 576
-                            type: integer
-                          name:
-                            description: Name defines the name of the interface to
-                              be configured.
-                            maxLength: 255
-                            pattern: ^[a-zA-Z0-9\-_\.]+$
-                            type: string
-                          platformNetworks:
-                            description: PlatformNetworks defines the list of platform
-                              networks to be configured against this interface.
-                            items:
-                              maxLength: 255
-                              pattern: ^[a-zA-Z0-9\-_]+$
-                              type: string
-                            maxLength: 255
-                            pattern: ^[a-zA-Z0-9\-_]+$
-                            type: array
-                          port:
-                            description: Port defines the attributes identifying the
-                              underlying port which defines this Ethernet interface.
+                          password:
+                            description: Password defines the attributes specific
+                              to password based authentication.
                             properties:
-                              name:
-                                description: SystemName defines the device name of
-                                  the Ethernet port.
+                              secret:
+                                description: Secret defines the name of the secret
+                                  which contains the username and password for the
+                                  board management controller.
+                                type: string
+                            required:
+                            - secret
+                            type: object
+                        type: object
+                      type:
+                        description: Type defines the board management controller
+                          type.  This is left as optional so that the address can
+                          be overridden on a per-host basis without worrying about
+                          overwriting the type or credentials.
+                        enum:
+                        - none
+                        - bmc
+                        - dynamic
+                        - ipmi
+                        - redfish
+                        type: string
+                    type: object
+                  bootDevice:
+                    description: BootDevice defines the absolute device path of the
+                      device to be used for installation.
+                    maxLength: 4095
+                    pattern: ^/dev/.+$
+                    type: string
+                  bootMAC:
+                    description: BootMAC defines the MAC address that a host uses
+                      to perform the initial software installation.  This is only
+                      applicable for statically provisioned hosts and should be set
+                      on each hosts via the overrides attributes.
+                    pattern: ^([0-9a-fA-Z]{2}[:-]){5}([0-9a-fA-Z]{2})$
+                    type: string
+                  clockSynchronization:
+                    description: ClockSynchronization defines the clock synchronization
+                      source of the host resource.
+                    enum:
+                    - ntp
+                    - ptp
+                    type: string
+                  console:
+                    description: Console defines the installation output device.
+                    pattern: ^(|tty[0-9]+|ttyS[0-9]+(,\d+([a-zA-Z0-9]+)?)?|ttyUSB[0-9]+(,\d+([a-zA-Z0-9]+))?|lp[0-9]+)$
+                    type: string
+                  installOutput:
+                    description: InstallOutput defines the install output method.  The
+                      graphical mode is only suitable when the console attribute is
+                      set to a graphical terminal. The text mode can be used with
+                      both serial and graphical console configurations.
+                    enum:
+                    - text
+                    - graphical
+                    type: string
+                  interfaces:
+                    description: Interfaces defines the list of interfaces to be configured
+                      against this host.
+                    properties:
+                      bond:
+                        description: Bond defines the list of Bond interfaces to be
+                          configured on a host.
+                        items:
+                          properties:
+                            class:
+                              description: Class defines the intended usage of this
+                                interface by the system.
+                              enum:
+                              - platform
+                              - data
+                              - pci-sriov
+                              - pci-passthrough
+                              - none
+                              type: string
+                            dataNetworks:
+                              description: DataNetworks defines the list of data networks
+                                to be configured against this interface.
+                              items:
                                 maxLength: 255
                                 pattern: ^[a-zA-Z0-9\-_]+$
                                 type: string
-                            required:
-                            - name
-                            type: object
-                          ptpInterfaces:
-                            description: PtpInterfaces defines the ptp interfaces
-                              to be configured against this interface.
-                            items:
                               maxLength: 255
                               pattern: ^[a-zA-Z0-9\-_]+$
-                              type: string
-                            maxLength: 255
-                            pattern: ^[a-zA-Z0-9\-_]+$
-                            type: array
-                          ptpRole:
-                            description: PTPRole defines the ptp role as master, slave,
-                              or none
-                            enum:
-                            - master
-                            - slave
-                            - none
-                            type: string
-                          vfCount:
-                            description: VFCount defines the number of SRIOV VF interfaces
-                              to be allocated.  Only applicable if the interface class
-                              is set to "pci-sriov".
-                            format: int64
-                            maximum: 128
-                            minimum: 1
-                            type: integer
-                          vfDriver:
-                            description: VFDriver defines the device driver to be
-                              associated with each individual SRIOV VF interface allocated.  Only
-                              applicable if the interface class is set to "pci-sriov".
-                            type: string
-                        required:
-                        - name
-                        - class
-                        - port
-                        type: object
-                      type: array
-                    vf:
-                      description: VF defines the list of SR-IOV VF interfaces to
-                        be configured on a host.
-                      items:
-                        properties:
-                          class:
-                            description: Class defines the intended usage of this
-                              interface by the system.
-                            enum:
-                            - platform
-                            - data
-                            - pci-sriov
-                            - pci-passthrough
-                            - none
-                            type: string
-                          dataNetworks:
-                            description: DataNetworks defines the list of data networks
-                              to be configured against this interface.
-                            items:
-                              maxLength: 255
-                              pattern: ^[a-zA-Z0-9\-_]+$
-                              type: string
-                            maxLength: 255
-                            pattern: ^[a-zA-Z0-9\-_]+$
-                            type: array
-                          lower:
-                            description: Lower defines the interface name over which
-                              this VF interface is to be configured.
-                            pattern: ^[a-zA-Z0-9\-_\.]+$
-                            type: string
-                          maxTxRate:
-                            description: MaxTxRate defines the maximum tx rate of
-                              SRIOV VF interfaces. Only applicable if the interface
-                              class is set to "pci-sriov" and interface type is set
-                              to "vf".
-                            format: int64
-                            type: integer
-                          mtu:
-                            description: MTU defines the maximum transmit unit for
-                              this interface.
-                            format: int64
-                            maximum: 9216
-                            minimum: 576
-                            type: integer
-                          name:
-                            description: Name defines the name of the interface to
-                              be configured.
-                            maxLength: 255
-                            pattern: ^[a-zA-Z0-9\-_\.]+$
-                            type: string
-                          platformNetworks:
-                            description: PlatformNetworks defines the list of platform
-                              networks to be configured against this interface.
-                            items:
-                              maxLength: 255
-                              pattern: ^[a-zA-Z0-9\-_]+$
-                              type: string
-                            maxLength: 255
-                            pattern: ^[a-zA-Z0-9\-_]+$
-                            type: array
-                          ptpInterfaces:
-                            description: PtpInterfaces defines the ptp interfaces
-                              to be configured against this interface.
-                            items:
-                              maxLength: 255
-                              pattern: ^[a-zA-Z0-9\-_]+$
-                              type: string
-                            maxLength: 255
-                            pattern: ^[a-zA-Z0-9\-_]+$
-                            type: array
-                          ptpRole:
-                            description: PTPRole defines the ptp role as master, slave,
-                              or none
-                            enum:
-                            - master
-                            - slave
-                            - none
-                            type: string
-                          vfCount:
-                            description: VFCount defines the number of SRIOV virtual
-                              functions for this VF interface.
-                            format: int64
-                            maximum: 256
-                            minimum: 1
-                            type: integer
-                          vfDriver:
-                            description: VFDriver defines the device driver to be
-                              associated with each individual SRIOV VF interface allocated.  Only
-                              applicable if the interface class is set to "pci-sriov".
-                            type: string
-                        required:
-                        - name
-                        - class
-                        - lower
-                        - vfCount
-                        type: object
-                      type: array
-                    vlan:
-                      description: VLAN defines the list of VLAN interfaces to be
-                        configured on a host.
-                      items:
-                        properties:
-                          class:
-                            description: Class defines the intended usage of this
-                              interface by the system.
-                            enum:
-                            - platform
-                            - data
-                            - pci-sriov
-                            - pci-passthrough
-                            - none
-                            type: string
-                          dataNetworks:
-                            description: DataNetworks defines the list of data networks
-                              to be configured against this interface.
-                            items:
-                              maxLength: 255
-                              pattern: ^[a-zA-Z0-9\-_]+$
-                              type: string
-                            maxLength: 255
-                            pattern: ^[a-zA-Z0-9\-_]+$
-                            type: array
-                          lower:
-                            description: Lower defines the interface name over which
-                              this VLAN interface is to be configured.
-                            pattern: ^[a-zA-Z0-9\-_\.]+$
-                            type: string
-                          mtu:
-                            description: MTU defines the maximum transmit unit for
-                              this interface.
-                            format: int64
-                            maximum: 9216
-                            minimum: 576
-                            type: integer
-                          name:
-                            description: Name defines the name of the interface to
-                              be configured.
-                            maxLength: 255
-                            pattern: ^[a-zA-Z0-9\-_\.]+$
-                            type: string
-                          platformNetworks:
-                            description: PlatformNetworks defines the list of platform
-                              networks to be configured against this interface.
-                            items:
-                              maxLength: 255
-                              pattern: ^[a-zA-Z0-9\-_]+$
-                              type: string
-                            maxLength: 255
-                            pattern: ^[a-zA-Z0-9\-_]+$
-                            type: array
-                          ptpInterfaces:
-                            description: PtpInterfaces defines the ptp interfaces
-                              to be configured against this interface.
-                            items:
-                              maxLength: 255
-                              pattern: ^[a-zA-Z0-9\-_]+$
-                              type: string
-                            maxLength: 255
-                            pattern: ^[a-zA-Z0-9\-_]+$
-                            type: array
-                          ptpRole:
-                            description: PTPRole defines the ptp role as master, slave,
-                              or none
-                            enum:
-                            - master
-                            - slave
-                            - none
-                            type: string
-                          vid:
-                            description: VID defines the VLAN ID value to be assigned
-                              to this VLAN interface.
-                            format: int64
-                            maximum: 4095
-                            minimum: 1
-                            type: integer
-                        required:
-                        - name
-                        - class
-                        - lower
-                        - vid
-                        type: object
-                      type: array
-                  type: object
-                labels:
-                  description: Labels defines the set of labels to be applied to the
-                    kubernetes node resources that is running on this host.
-                  type: object
-                location:
-                  description: Location defines the physical location of the host
-                    in the data centre.
-                  type: string
-                maxCPUFrequency:
-                  description: MaxCPUFrequency defines the maximum limit of the CPU
-                    frequency set on the host.
-                  pattern: ^[1-9][0-9]*$
-                  type: string
-                memory:
-                  description: Memory defines the memory allocations for each function
-                    across all NUMA sockets/nodes.
-                  items:
-                    properties:
-                      functions:
-                        description: Functions defines a list of function specific
-                          allocations for the given NUMA socket/node.
-                        items:
-                          properties:
-                            function:
-                              description: Function defines the function for which
-                                to allocate a number of cores.
-                              enum:
-                              - platform
-                              - vm
-                              - vswitch
-                              type: string
-                            pageCount:
-                              description: PageCount defines the number of pages to
-                                allocate to a specific function.
-                              format: int64
-                              type: integer
-                            pageSize:
-                              description: PageSize defines the size of individual
-                                memory pages to be allocated to a specific function.  For
-                                platform allocations the 4KB page size is the only
-                                valid choice.
-                              enum:
-                              - 4KB
-                              - 2MB
-                              - 1GB
-                              type: string
-                          required:
-                          - function
-                          - pageSize
-                          - pageCount
-                          type: object
-                        type: array
-                      node:
-                        description: Node defines the NUMA node number for which to
-                          allocate a number of functions.
-                        format: int64
-                        maximum: 7
-                        minimum: 0
-                        type: integer
-                    required:
-                    - node
-                    - functions
-                    type: object
-                  type: array
-                personality:
-                  description: Personality defines the role to be assigned to the
-                    host
-                  enum:
-                  - controller
-                  - worker
-                  - storage
-                  - controller-worker
-                  type: string
-                powerOn:
-                  description: PowerOn defines the initial power state of the node
-                    if static provisioning is being used.
-                  type: boolean
-                processors:
-                  description: Processors defines the core allocations for each function
-                    across all NUMA sockets/nodes.
-                  items:
-                    properties:
-                      functions:
-                        description: Functions defines a list of function specific
-                          allocations for the given NUMA socket/node.
-                        items:
-                          properties:
-                            count:
-                              description: Count defines the number of cores to allocate
-                                to a specific function.
-                              format: int64
-                              maximum: 64
-                              minimum: 0
-                              type: integer
-                            function:
-                              description: Function defines the function for which
-                                to allocate a number of cores.
-                              enum:
-                              - platform
-                              - shared
-                              - vswitch
-                              - application-isolated
-                              - application
-                              type: string
-                          required:
-                          - function
-                          - count
-                          type: object
-                        type: array
-                      node:
-                        description: Node defines the NUMA node number for which to
-                          allocate a number of functions.
-                        format: int64
-                        maximum: 7
-                        minimum: 0
-                        type: integer
-                    required:
-                    - node
-                    - functions
-                    type: object
-                  type: array
-                provisioningMode:
-                  description: ProvisioningMode defines whether a host is provisioned
-                    dynamically when it appears in system host inventory or whether
-                    it is provisioned statically and powered up explicitly.  Statically
-                    provisioned hosts require that the user supply a boot MAC address,
-                    board management IP address, and a management IP address if the
-                    management network is configured for static address assignment.
-                  enum:
-                  - static
-                  - dynamic
-                  type: string
-                ptpInstances:
-                  description: PtpInstances defines the list of ptp instance to be
-                    configured against this interface.
-                  items:
-                    maxLength: 255
-                    pattern: ^[a-zA-Z0-9\-_]+$
-                    type: string
-                  maxLength: 255
-                  pattern: ^[a-zA-Z0-9\-_]+$
-                  type: array
-                rootDevice:
-                  description: RootDevice defines the absolute device path of the
-                    device to be used as the root file system.
-                  maxLength: 4095
-                  pattern: ^/dev/.+$
-                  type: string
-                routes:
-                  description: Routes defines the list of routes to be configured
-                    against this host. Routes require that the target interface be
-                    configured with a suitable address (e.g., one that allows reachability
-                    to next hop device(s)) therefore the host must be configured with
-                    valid addresses or configured to for automatic address assignment
-                    from a platform network.
-                  items:
-                    properties:
-                      gateway:
-                        description: Gateway defines the next hop gateway IP address.
-                        type: string
-                      interface:
-                        description: Interface is a reference to the interface name
-                          against which to configure the route.
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_\.]+$
-                        type: string
-                      metric:
-                        description: Metric defines the route preference metric for
-                          this route.
-                        format: int64
-                        maximum: 255
-                        minimum: 1
-                        type: integer
-                      prefix:
-                        description: Prefix defines the destination network address
-                          prefix length.
-                        format: int64
-                        maximum: 128
-                        minimum: 0
-                        type: integer
-                      subnet:
-                        description: Subnet defines the destination network address
-                          subnet.
-                        type: string
-                    required:
-                    - interface
-                    - subnet
-                    - prefix
-                    - gateway
-                    type: object
-                  type: array
-                storage:
-                  description: Storage defines the storage attributes for the host
-                  properties:
-                    filesystems:
-                      description: FileSystems defines the list of file systems to
-                        be defined on the host.
-                      items:
-                        properties:
-                          name:
-                            description: Name defines the system defined name of the
-                              filesystem resource.  Each filesystem name may only
-                              be applicable to a subset of host personalities. Refer
-                              to StarlingX documentation for more information.
-                            enum:
-                            - backup
-                            - docker
-                            - scratch
-                            - kubelet
-                            type: string
-                          size:
-                            format: int64
-                            minimum: 1
-                            type: integer
-                        required:
-                        - name
-                        - size
-                        type: object
-                      type: array
-                    monitor:
-                      description: Monitor defines whether a Ceph storage monitor
-                        should be enabled on a node.
-                      properties:
-                        size:
-                          description: Size represents the storage allocated to the
-                            monitor in gibibytes
-                          format: int64
-                          maximum: 40
-                          minimum: 20
-                          type: integer
-                      type: object
-                    osds:
-                      description: OSDs defines the list of OSD devices to be created
-                        on the host.  This is only applicable to storage related nodes.
-                      items:
-                        properties:
-                          cluster:
-                            description: ClusterName defines the storage cluster to
-                              which the OSD device should be assigned.  By default
-                              this is the "ceph_cluster".
-                            maxLength: 255
-                            type: string
-                          function:
-                            description: Function defines the function to be assigned
-                              to the OSD device.
-                            enum:
-                            - osd
-                            - journal
-                            type: string
-                          journal:
-                            description: Journal defines another OSD device to be
-                              used as the journal for this OSD device.
-                            properties:
-                              location:
-                                description: "Location defines\tthe OSD device path
-                                  to be used as the Journal OSD for this logical device."
+                              type: array
+                            members:
+                              description: Members defines the list of interfaces
+                                which, together, make up the Bond interface.
+                              items:
                                 maxLength: 255
+                                pattern: ^[a-zA-Z0-9\-_\.]+$
                                 type: string
-                              size:
-                                description: Size defines the size of the OSD journal
-                                  in gibibytes.
-                                format: int64
-                                minimum: 1
-                                type: integer
-                            required:
-                            - location
-                            - size
-                            type: object
-                          path:
-                            description: Path defines the disk device path to use
-                              as backing for the OSD device.
-                            maxLength: 4095
-                            pattern: ^/dev/.+$
-                            type: string
-                        required:
-                        - function
-                        - path
-                        type: object
-                      type: array
-                    volumeGroups:
-                      description: VolumeGroups defines the list of volume groups
-                        to be created on the host.
-                      items:
-                        properties:
-                          concurrentDiskOperations:
-                            description: ConcurrentDiskOperations defines the number
-                              of concurrent disk operations permitted.
-                            format: int64
-                            minimum: 1
-                            type: integer
-                          lvmType:
-                            description: LVMType defines the provisioning type for
-                              volumes defines with 'Type' set to 'lvm'.
-                            enum:
-                            - thin
-                            - thick
-                            type: string
-                          name:
-                            description: SystemName defines the name of the logical
-                              volume group
-                            maxLength: 255
-                            pattern: ^[a-zA-Z0-9\-_]+$
-                            type: string
-                          physicalVolumes:
-                            description: PhysicalVolumes defines the list of volumes
-                              to be created on the host.
-                            items:
+                              maxLength: 255
+                              pattern: ^[a-zA-Z0-9\-_\.]+$
+                              type: array
+                            mode:
+                              description: Mode defines the Bond interface aggregation
+                                mode.
+                              enum:
+                              - balanced
+                              - active_standby
+                              - 802.3ad
+                              type: string
+                            mtu:
+                              description: MTU defines the maximum transmit unit for
+                                this interface.
+                              format: int64
+                              maximum: 9216
+                              minimum: 576
+                              type: integer
+                            name:
+                              description: Name defines the name of the interface
+                                to be configured.
+                              maxLength: 255
+                              pattern: ^[a-zA-Z0-9\-_\.]+$
+                              type: string
+                            platformNetworks:
+                              description: PlatformNetworks defines the list of platform
+                                networks to be configured against this interface.
+                              items:
+                                maxLength: 255
+                                pattern: ^[a-zA-Z0-9\-_]+$
+                                type: string
+                              maxLength: 255
+                              pattern: ^[a-zA-Z0-9\-_]+$
+                              type: array
+                            primaryReselect:
+                              description: PrimaryReselect defines the reselection
+                                policy for the Bond interface. Only applicable for
+                                active_standby mode.
+                              type: string
+                            ptpInterfaces:
+                              description: PtpInterfaces defines the ptp interfaces
+                                to be configured against this interface.
+                              items:
+                                maxLength: 255
+                                pattern: ^[a-zA-Z0-9\-_]+$
+                                type: string
+                              maxLength: 255
+                              pattern: ^[a-zA-Z0-9\-_]+$
+                              type: array
+                            ptpRole:
+                              description: PTPRole defines the ptp role as master,
+                                slave, or none
+                              enum:
+                              - master
+                              - slave
+                              - none
+                              type: string
+                            transmitHashPolicy:
+                              description: TransmitHashPolicy defines the transmit
+                                interface selection policy for the Bond interface.  Only
+                                applicable for 802.3ad and balanced modes.
+                              enum:
+                              - layer2
+                              - layer2+3
+                              type: string
+                          required:
+                          - name
+                          - class
+                          - members
+                          - mode
+                          type: object
+                        type: array
+                      ethernet:
+                        description: Ethernet defines the list of ethernet interfaces
+                          to be configured on a host.
+                        items:
+                          properties:
+                            class:
+                              description: Class defines the intended usage of this
+                                interface by the system.
+                              enum:
+                              - platform
+                              - data
+                              - pci-sriov
+                              - pci-passthrough
+                              - none
+                              type: string
+                            dataNetworks:
+                              description: DataNetworks defines the list of data networks
+                                to be configured against this interface.
+                              items:
+                                maxLength: 255
+                                pattern: ^[a-zA-Z0-9\-_]+$
+                                type: string
+                              maxLength: 255
+                              pattern: ^[a-zA-Z0-9\-_]+$
+                              type: array
+                            lower:
+                              description: Lower defines the interface name over which
+                                this ethernet interface is to be configured.
+                              pattern: ^[a-zA-Z0-9\-_\.]+$
+                              type: string
+                            mtu:
+                              description: MTU defines the maximum transmit unit for
+                                this interface.
+                              format: int64
+                              maximum: 9216
+                              minimum: 576
+                              type: integer
+                            name:
+                              description: Name defines the name of the interface
+                                to be configured.
+                              maxLength: 255
+                              pattern: ^[a-zA-Z0-9\-_\.]+$
+                              type: string
+                            platformNetworks:
+                              description: PlatformNetworks defines the list of platform
+                                networks to be configured against this interface.
+                              items:
+                                maxLength: 255
+                                pattern: ^[a-zA-Z0-9\-_]+$
+                                type: string
+                              maxLength: 255
+                              pattern: ^[a-zA-Z0-9\-_]+$
+                              type: array
+                            port:
+                              description: Port defines the attributes identifying
+                                the underlying port which defines this Ethernet interface.
                               properties:
-                                path:
-                                  description: Path defines the device path backing
-                                    the physical volume.  If 'Type' is set as disk
-                                    then this attribute refers to the absolute path
-                                    of a disk device.  If 'Type' is set as partition
-                                    then it refers to the device path of the disk
-                                    onto which this partition will be created.
+                                name:
+                                  description: SystemName defines the device name
+                                    of the Ethernet port.
                                   maxLength: 255
-                                  type: string
-                                size:
-                                  description: Size defines the size of the disk partition
-                                    in gibibytes.  This should be omitted if the path
-                                    refers to a disk.
-                                  format: int64
-                                  minimum: 1
-                                  type: integer
-                                type:
-                                  description: Type defines the type of physical volume.
-                                  enum:
-                                  - disk
-                                  - partition
+                                  pattern: ^[a-zA-Z0-9\-_]+$
                                   type: string
                               required:
-                              - type
-                              - path
+                              - name
                               type: object
-                            type: array
-                        required:
-                        - name
-                        - physicalVolumes
-                        type: object
-                      type: array
-                  type: object
-                subfunctions:
-                  description: SubFunctionList defines the set of subfunctions to
-                    be provisioned on the node at time of initial provisioning.
-                  items:
+                            ptpInterfaces:
+                              description: PtpInterfaces defines the ptp interfaces
+                                to be configured against this interface.
+                              items:
+                                maxLength: 255
+                                pattern: ^[a-zA-Z0-9\-_]+$
+                                type: string
+                              maxLength: 255
+                              pattern: ^[a-zA-Z0-9\-_]+$
+                              type: array
+                            ptpRole:
+                              description: PTPRole defines the ptp role as master,
+                                slave, or none
+                              enum:
+                              - master
+                              - slave
+                              - none
+                              type: string
+                            vfCount:
+                              description: VFCount defines the number of SRIOV VF
+                                interfaces to be allocated.  Only applicable if the
+                                interface class is set to "pci-sriov".
+                              format: int64
+                              maximum: 128
+                              minimum: 1
+                              type: integer
+                            vfDriver:
+                              description: VFDriver defines the device driver to be
+                                associated with each individual SRIOV VF interface
+                                allocated.  Only applicable if the interface class
+                                is set to "pci-sriov".
+                              type: string
+                          required:
+                          - name
+                          - class
+                          - port
+                          type: object
+                        type: array
+                      vf:
+                        description: VF defines the list of SR-IOV VF interfaces to
+                          be configured on a host.
+                        items:
+                          properties:
+                            class:
+                              description: Class defines the intended usage of this
+                                interface by the system.
+                              enum:
+                              - platform
+                              - data
+                              - pci-sriov
+                              - pci-passthrough
+                              - none
+                              type: string
+                            dataNetworks:
+                              description: DataNetworks defines the list of data networks
+                                to be configured against this interface.
+                              items:
+                                maxLength: 255
+                                pattern: ^[a-zA-Z0-9\-_]+$
+                                type: string
+                              maxLength: 255
+                              pattern: ^[a-zA-Z0-9\-_]+$
+                              type: array
+                            lower:
+                              description: Lower defines the interface name over which
+                                this VF interface is to be configured.
+                              pattern: ^[a-zA-Z0-9\-_\.]+$
+                              type: string
+                            maxTxRate:
+                              description: MaxTxRate defines the maximum tx rate of
+                                SRIOV VF interfaces. Only applicable if the interface
+                                class is set to "pci-sriov" and interface type is
+                                set to "vf".
+                              format: int64
+                              type: integer
+                            mtu:
+                              description: MTU defines the maximum transmit unit for
+                                this interface.
+                              format: int64
+                              maximum: 9216
+                              minimum: 576
+                              type: integer
+                            name:
+                              description: Name defines the name of the interface
+                                to be configured.
+                              maxLength: 255
+                              pattern: ^[a-zA-Z0-9\-_\.]+$
+                              type: string
+                            platformNetworks:
+                              description: PlatformNetworks defines the list of platform
+                                networks to be configured against this interface.
+                              items:
+                                maxLength: 255
+                                pattern: ^[a-zA-Z0-9\-_]+$
+                                type: string
+                              maxLength: 255
+                              pattern: ^[a-zA-Z0-9\-_]+$
+                              type: array
+                            ptpInterfaces:
+                              description: PtpInterfaces defines the ptp interfaces
+                                to be configured against this interface.
+                              items:
+                                maxLength: 255
+                                pattern: ^[a-zA-Z0-9\-_]+$
+                                type: string
+                              maxLength: 255
+                              pattern: ^[a-zA-Z0-9\-_]+$
+                              type: array
+                            ptpRole:
+                              description: PTPRole defines the ptp role as master,
+                                slave, or none
+                              enum:
+                              - master
+                              - slave
+                              - none
+                              type: string
+                            vfCount:
+                              description: VFCount defines the number of SRIOV virtual
+                                functions for this VF interface.
+                              format: int64
+                              maximum: 256
+                              minimum: 1
+                              type: integer
+                            vfDriver:
+                              description: VFDriver defines the device driver to be
+                                associated with each individual SRIOV VF interface
+                                allocated.  Only applicable if the interface class
+                                is set to "pci-sriov".
+                              type: string
+                          required:
+                          - name
+                          - class
+                          - lower
+                          - vfCount
+                          type: object
+                        type: array
+                      vlan:
+                        description: VLAN defines the list of VLAN interfaces to be
+                          configured on a host.
+                        items:
+                          properties:
+                            class:
+                              description: Class defines the intended usage of this
+                                interface by the system.
+                              enum:
+                              - platform
+                              - data
+                              - pci-sriov
+                              - pci-passthrough
+                              - none
+                              type: string
+                            dataNetworks:
+                              description: DataNetworks defines the list of data networks
+                                to be configured against this interface.
+                              items:
+                                maxLength: 255
+                                pattern: ^[a-zA-Z0-9\-_]+$
+                                type: string
+                              maxLength: 255
+                              pattern: ^[a-zA-Z0-9\-_]+$
+                              type: array
+                            lower:
+                              description: Lower defines the interface name over which
+                                this VLAN interface is to be configured.
+                              pattern: ^[a-zA-Z0-9\-_\.]+$
+                              type: string
+                            mtu:
+                              description: MTU defines the maximum transmit unit for
+                                this interface.
+                              format: int64
+                              maximum: 9216
+                              minimum: 576
+                              type: integer
+                            name:
+                              description: Name defines the name of the interface
+                                to be configured.
+                              maxLength: 255
+                              pattern: ^[a-zA-Z0-9\-_\.]+$
+                              type: string
+                            platformNetworks:
+                              description: PlatformNetworks defines the list of platform
+                                networks to be configured against this interface.
+                              items:
+                                maxLength: 255
+                                pattern: ^[a-zA-Z0-9\-_]+$
+                                type: string
+                              maxLength: 255
+                              pattern: ^[a-zA-Z0-9\-_]+$
+                              type: array
+                            ptpInterfaces:
+                              description: PtpInterfaces defines the ptp interfaces
+                                to be configured against this interface.
+                              items:
+                                maxLength: 255
+                                pattern: ^[a-zA-Z0-9\-_]+$
+                                type: string
+                              maxLength: 255
+                              pattern: ^[a-zA-Z0-9\-_]+$
+                              type: array
+                            ptpRole:
+                              description: PTPRole defines the ptp role as master,
+                                slave, or none
+                              enum:
+                              - master
+                              - slave
+                              - none
+                              type: string
+                            vid:
+                              description: VID defines the VLAN ID value to be assigned
+                                to this VLAN interface.
+                              format: int64
+                              maximum: 4095
+                              minimum: 1
+                              type: integer
+                          required:
+                          - name
+                          - class
+                          - lower
+                          - vid
+                          type: object
+                        type: array
+                    type: object
+                  labels:
+                    description: Labels defines the set of labels to be applied to
+                      the kubernetes node resources that is running on this host.
+                    type: object
+                  location:
+                    description: Location defines the physical location of the host
+                      in the data centre.
+                    type: string
+                  maxCPUFrequency:
+                    description: MaxCPUFrequency defines the maximum limit of the
+                      CPU frequency set on the host.
+                    pattern: ^[1-9][0-9]*$
+                    type: string
+                  memory:
+                    description: Memory defines the memory allocations for each function
+                      across all NUMA sockets/nodes.
+                    items:
+                      properties:
+                        functions:
+                          description: Functions defines a list of function specific
+                            allocations for the given NUMA socket/node.
+                          items:
+                            properties:
+                              function:
+                                description: Function defines the function for which
+                                  to allocate a number of cores.
+                                enum:
+                                - platform
+                                - vm
+                                - vswitch
+                                type: string
+                              pageCount:
+                                description: PageCount defines the number of pages
+                                  to allocate to a specific function.
+                                format: int64
+                                type: integer
+                              pageSize:
+                                description: PageSize defines the size of individual
+                                  memory pages to be allocated to a specific function.  For
+                                  platform allocations the 4KB page size is the only
+                                  valid choice.
+                                enum:
+                                - 4KB
+                                - 2MB
+                                - 1GB
+                                type: string
+                            required:
+                            - function
+                            - pageSize
+                            - pageCount
+                            type: object
+                          type: array
+                        node:
+                          description: Node defines the NUMA node number for which
+                            to allocate a number of functions.
+                          format: int64
+                          maximum: 7
+                          minimum: 0
+                          type: integer
+                      required:
+                      - node
+                      - functions
+                      type: object
+                    type: array
+                  personality:
+                    description: Personality defines the role to be assigned to the
+                      host
                     enum:
                     - controller
                     - worker
                     - storage
-                    - lowlatency
+                    - controller-worker
                     type: string
-                  type: array
-              type: object
-            profile:
-              description: Profile defines the name of the HostProfile to use as a
-                configuration template for the host.  A host may point to a single
-                HostProfile resource or may point to a chain or hierarchy of HostProfile
-                resources.  At configuration time the Deployment Manager will flatten
-                the Host attributes defined in the hierarchy of HostProfiles and produce
-                a final composite profile that represents the intended configuration
-                state of an individual Host resources.  This composite profile also
-                include any individual host specific attributes defined in the "overrides"
-                attribute defined below.
-              type: string
-          required:
-          - profile
-          type: object
-        status:
-          properties:
-            administrativeState:
-              description: AdministrativeState is the last known administrative state
-                of the host.
-              type: string
-            availabilityStatus:
-              description: AvailabilityStatus is the last known availability status
-                of the host.
-              type: string
-            defaults:
-              description: Defaults defines the configuration attributed collected
-                before applying any user configuration values.
-              type: string
-            id:
-              description: ID defines the system assigned unique identifier.  This
-                will only exist once this resource has been provisioned into the system.
-              type: string
-            inSync:
-              description: InSync defines whether the desired state matches the operational
-                state.
-              type: boolean
-            operationalStatus:
-              description: OperationalStatus is the last known operational status
-                of the host.
-              type: string
-            reconciled:
-              description: Reconciled defines whether the host has been successfully
-                reconciled at least once.  If further changes are made they will be
-                ignored by the reconciler.
-              type: boolean
-          required:
-          - inSync
-          - reconciled
-          type: object
-  version: v1
+                  powerOn:
+                    description: PowerOn defines the initial power state of the node
+                      if static provisioning is being used.
+                    type: boolean
+                  processors:
+                    description: Processors defines the core allocations for each
+                      function across all NUMA sockets/nodes.
+                    items:
+                      properties:
+                        functions:
+                          description: Functions defines a list of function specific
+                            allocations for the given NUMA socket/node.
+                          items:
+                            properties:
+                              count:
+                                description: Count defines the number of cores to
+                                  allocate to a specific function.
+                                format: int64
+                                maximum: 64
+                                minimum: 0
+                                type: integer
+                              function:
+                                description: Function defines the function for which
+                                  to allocate a number of cores.
+                                enum:
+                                - platform
+                                - shared
+                                - vswitch
+                                - application-isolated
+                                - application
+                                type: string
+                            required:
+                            - function
+                            - count
+                            type: object
+                          type: array
+                        node:
+                          description: Node defines the NUMA node number for which
+                            to allocate a number of functions.
+                          format: int64
+                          maximum: 7
+                          minimum: 0
+                          type: integer
+                      required:
+                      - node
+                      - functions
+                      type: object
+                    type: array
+                  provisioningMode:
+                    description: ProvisioningMode defines whether a host is provisioned
+                      dynamically when it appears in system host inventory or whether
+                      it is provisioned statically and powered up explicitly.  Statically
+                      provisioned hosts require that the user supply a boot MAC address,
+                      board management IP address, and a management IP address if
+                      the management network is configured for static address assignment.
+                    enum:
+                    - static
+                    - dynamic
+                    type: string
+                  ptpInstances:
+                    description: PtpInstances defines the list of ptp instance to
+                      be configured against this interface.
+                    items:
+                      maxLength: 255
+                      pattern: ^[a-zA-Z0-9\-_]+$
+                      type: string
+                    maxLength: 255
+                    pattern: ^[a-zA-Z0-9\-_]+$
+                    type: array
+                  rootDevice:
+                    description: RootDevice defines the absolute device path of the
+                      device to be used as the root file system.
+                    maxLength: 4095
+                    pattern: ^/dev/.+$
+                    type: string
+                  routes:
+                    description: Routes defines the list of routes to be configured
+                      against this host. Routes require that the target interface
+                      be configured with a suitable address (e.g., one that allows
+                      reachability to next hop device(s)) therefore the host must
+                      be configured with valid addresses or configured to for automatic
+                      address assignment from a platform network.
+                    items:
+                      properties:
+                        gateway:
+                          description: Gateway defines the next hop gateway IP address.
+                          type: string
+                        interface:
+                          description: Interface is a reference to the interface name
+                            against which to configure the route.
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_\.]+$
+                          type: string
+                        metric:
+                          description: Metric defines the route preference metric
+                            for this route.
+                          format: int64
+                          maximum: 255
+                          minimum: 1
+                          type: integer
+                        prefix:
+                          description: Prefix defines the destination network address
+                            prefix length.
+                          format: int64
+                          maximum: 128
+                          minimum: 0
+                          type: integer
+                        subnet:
+                          description: Subnet defines the destination network address
+                            subnet.
+                          type: string
+                      required:
+                      - interface
+                      - subnet
+                      - prefix
+                      - gateway
+                      type: object
+                    type: array
+                  storage:
+                    description: Storage defines the storage attributes for the host
+                    properties:
+                      filesystems:
+                        description: FileSystems defines the list of file systems
+                          to be defined on the host.
+                        items:
+                          properties:
+                            name:
+                              description: Name defines the system defined name of
+                                the filesystem resource.  Each filesystem name may
+                                only be applicable to a subset of host personalities.
+                                Refer to StarlingX documentation for more information.
+                              enum:
+                              - backup
+                              - docker
+                              - scratch
+                              - kubelet
+                              type: string
+                            size:
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - name
+                          - size
+                          type: object
+                        type: array
+                      monitor:
+                        description: Monitor defines whether a Ceph storage monitor
+                          should be enabled on a node.
+                        properties:
+                          size:
+                            description: Size represents the storage allocated to
+                              the monitor in gibibytes
+                            format: int64
+                            maximum: 40
+                            minimum: 20
+                            type: integer
+                        type: object
+                      osds:
+                        description: OSDs defines the list of OSD devices to be created
+                          on the host.  This is only applicable to storage related
+                          nodes.
+                        items:
+                          properties:
+                            cluster:
+                              description: ClusterName defines the storage cluster
+                                to which the OSD device should be assigned.  By default
+                                this is the "ceph_cluster".
+                              maxLength: 255
+                              type: string
+                            function:
+                              description: Function defines the function to be assigned
+                                to the OSD device.
+                              enum:
+                              - osd
+                              - journal
+                              type: string
+                            journal:
+                              description: Journal defines another OSD device to be
+                                used as the journal for this OSD device.
+                              properties:
+                                location:
+                                  description: "Location defines\tthe OSD device path\
+                                    \ to be used as the Journal OSD for this logical\
+                                    \ device."
+                                  maxLength: 255
+                                  type: string
+                                size:
+                                  description: Size defines the size of the OSD journal
+                                    in gibibytes.
+                                  format: int64
+                                  minimum: 1
+                                  type: integer
+                              required:
+                              - location
+                              - size
+                              type: object
+                            path:
+                              description: Path defines the disk device path to use
+                                as backing for the OSD device.
+                              maxLength: 4095
+                              pattern: ^/dev/.+$
+                              type: string
+                          required:
+                          - function
+                          - path
+                          type: object
+                        type: array
+                      volumeGroups:
+                        description: VolumeGroups defines the list of volume groups
+                          to be created on the host.
+                        items:
+                          properties:
+                            concurrentDiskOperations:
+                              description: ConcurrentDiskOperations defines the number
+                                of concurrent disk operations permitted.
+                              format: int64
+                              minimum: 1
+                              type: integer
+                            lvmType:
+                              description: LVMType defines the provisioning type for
+                                volumes defines with 'Type' set to 'lvm'.
+                              enum:
+                              - thin
+                              - thick
+                              type: string
+                            name:
+                              description: SystemName defines the name of the logical
+                                volume group
+                              maxLength: 255
+                              pattern: ^[a-zA-Z0-9\-_]+$
+                              type: string
+                            physicalVolumes:
+                              description: PhysicalVolumes defines the list of volumes
+                                to be created on the host.
+                              items:
+                                properties:
+                                  path:
+                                    description: Path defines the device path backing
+                                      the physical volume.  If 'Type' is set as disk
+                                      then this attribute refers to the absolute path
+                                      of a disk device.  If 'Type' is set as partition
+                                      then it refers to the device path of the disk
+                                      onto which this partition will be created.
+                                    maxLength: 255
+                                    type: string
+                                  size:
+                                    description: Size defines the size of the disk
+                                      partition in gibibytes.  This should be omitted
+                                      if the path refers to a disk.
+                                    format: int64
+                                    minimum: 1
+                                    type: integer
+                                  type:
+                                    description: Type defines the type of physical
+                                      volume.
+                                    enum:
+                                    - disk
+                                    - partition
+                                    type: string
+                                required:
+                                - type
+                                - path
+                                type: object
+                              type: array
+                          required:
+                          - name
+                          - physicalVolumes
+                          type: object
+                        type: array
+                    type: object
+                  subfunctions:
+                    description: SubFunctionList defines the set of subfunctions to
+                      be provisioned on the node at time of initial provisioning.
+                    items:
+                      enum:
+                      - controller
+                      - worker
+                      - storage
+                      - lowlatency
+                      type: string
+                    type: array
+                type: object
+              profile:
+                description: Profile defines the name of the HostProfile to use as
+                  a configuration template for the host.  A host may point to a single
+                  HostProfile resource or may point to a chain or hierarchy of HostProfile
+                  resources.  At configuration time the Deployment Manager will flatten
+                  the Host attributes defined in the hierarchy of HostProfiles and
+                  produce a final composite profile that represents the intended configuration
+                  state of an individual Host resources.  This composite profile also
+                  include any individual host specific attributes defined in the "overrides"
+                  attribute defined below.
+                type: string
+            required:
+            - profile
+            type: object
+          status:
+            properties:
+              administrativeState:
+                description: AdministrativeState is the last known administrative
+                  state of the host.
+                type: string
+              availabilityStatus:
+                description: AvailabilityStatus is the last known availability status
+                  of the host.
+                type: string
+              defaults:
+                description: Defaults defines the configuration attributed collected
+                  before applying any user configuration values.
+                type: string
+              id:
+                description: ID defines the system assigned unique identifier.  This
+                  will only exist once this resource has been provisioned into the
+                  system.
+                type: string
+              inSync:
+                description: InSync defines whether the desired state matches the
+                  operational state.
+                type: boolean
+              operationalStatus:
+                description: OperationalStatus is the last known operational status
+                  of the host.
+                type: string
+              reconciled:
+                description: Reconciled defines whether the host has been successfully
+                  reconciled at least once.  If further changes are made they will
+                  be ignored by the reconciler.
+                type: boolean
+            required:
+            - inSync
+            - reconciled
+            type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
-    kind: ""
-    plural: ""
+    kind: ''
+    plural: ''
   conditions: []
   storedVersions: []

--- a/config/crds/starlingx_v1_hostprofile.yaml
+++ b/config/crds/starlingx_v1_hostprofile.yaml
@@ -1,939 +1,947 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    controller-tools.k8s.io: "1.0"
+    controller-tools.k8s.io: '1.0'
   name: hostprofiles.starlingx.windriver.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.base
-    description: The parent host profile.
-    name: base
-    type: string
   group: starlingx.windriver.com
   names:
     kind: HostProfile
     plural: hostprofiles
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            addresses:
-              description: Addresses defines the list of addresses to be configured
-                against this host.  Addresses are specific to a single host therefore
-                they should only be specified if this profile is only going to be
-                used to configure a single host.
-              items:
+  versions:
+  - additionalPrinterColumns:
+    - description: The parent host profile.
+      jsonPath: .spec.base
+      name: base
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              addresses:
+                description: Addresses defines the list of addresses to be configured
+                  against this host.  Addresses are specific to a single host therefore
+                  they should only be specified if this profile is only going to be
+                  used to configure a single host.
+                items:
+                  properties:
+                    address:
+                      description: Address defines the IPv4 or IPv6 address value.
+                      type: string
+                    interface:
+                      description: Interface is a reference to the interface name
+                        against which to configure the address.
+                      maxLength: 255
+                      pattern: ^[a-zA-Z0-9\-_\.]+$
+                      type: string
+                    prefix:
+                      description: Prefix defines the IP address network prefix length.
+                      format: int64
+                      maximum: 128
+                      minimum: 1
+                      type: integer
+                  required:
+                  - interface
+                  - address
+                  - prefix
+                  type: object
+                type: array
+              administrativeState:
+                description: AdministrativeState defines the desired administrative
+                  state of the host
+                enum:
+                - locked
+                - unlocked
+                type: string
+              base:
+                description: 'Base defines the name of another HostProfile from which
+                  to inherit attributes.  HostProfiles can be structured in a hierarchy
+                  so that many HostProfiles can inherit generic attributes from a
+                  parent HostProfile. This hierarchy can be defined in multiple layers;
+                  with lower layers overriding attributes set in higher layers.  At
+                  configuration time, before a Host is configured, the hierarchy of
+                  HostProfile resources is flattened to produce a single composite
+                  profile that represents the final attributes as they are overridden
+                  down the HostProfile hierarchy.  Once the HostProfile hierarchy
+                  is flattened to a composite profile.  The Deployment Manager will
+                  further refine the profile to create a final HostProfile which serves
+                  as the final configuration for the Host resource.  To create the
+                  final HostProfile, the Deployment Manages merges the composite profile
+                  with the initial default host attributes, and then merges the individual
+                  host overrides into that result.  The process can be illustrated
+                  as follows:          Host Defaults      +---------------------+            |                                      \            |                                       \         Base
+                  Profile        +                       \            |                 \                       \           ...                  +
+                  Composite Profile ----+  Final Profile            |                 /                        /      Personality
+                  Profile(s) +                        /            |                                        /            |                                       /           Host                                    /            |                                     /            |                                    /         Host
+                  Overrides       +-----------------+  Merging two HostProfileSpec
+                  resources consists of merging the attributes of a higher precedence
+                  profile into the attributes of a lower precedences profile.  The
+                  rules for merging attributes are as follows.    1) A nil pointer
+                  is always overwritten by a non-nil pointer.    2) Two non-nil pointers
+                  are merged together according to the underlying      type.    2a)
+                  If the type pointed to is a primitive type (e.g., int, bool,       string,
+                  etc) then the higher precedence value is used).    2b) If the type
+                  pointed to is a structure then this same merge       procedure is
+                  repeated recursively on each field of the structure       with these
+                  same rules applying to each field.    2c) If the type pointed to
+                  is a slice/array then rule (3) is used.    2d) If the type pointed
+                  to is a map then higher precedence value is       used and the entire
+                  map is overwritten.    3) Two slices are merged together using the
+                  following sub-rules.    3a) If the elements of slices define the
+                  KeyEqual() method then an       attempt is made to try to merge
+                  equivalent element using this same       merge strategy.  Elements
+                  from the higher precedence list that do       not have an equivalent
+                  in the lower precedence list are appended to       the list.  Elements
+                  appearing in the lower precedence list but not       in the higher
+                  precedence list are kept intact.    3b) If the elements of the slices
+                  do not define the KeyEqual() method       then they are simply concatenated
+                  together.    3c) An empty slice is handled as a special case that
+                  deletes the       contents of the lower precedence slice.  Do not
+                  confuse an empty       slice with a nil slice pointer.'
+                type: string
+              boardManagement:
+                description: BoardManagement defines the attributes specific to the
+                  board management controller configuration.
                 properties:
                   address:
-                    description: Address defines the IPv4 or IPv6 address value.
+                    description: Address defines the IP address or hostname of the
+                      board management interface.  An address is specific to a host
+                      therefore this should only be set if the profile is only going
+                      to be used to configure a single host; otherwise it should be
+                      set as a per-host override.
                     type: string
-                  interface:
-                    description: Interface is a reference to the interface name against
-                      which to configure the address.
-                    maxLength: 255
-                    pattern: ^[a-zA-Z0-9\-_\.]+$
-                    type: string
-                  prefix:
-                    description: Prefix defines the IP address network prefix length.
-                    format: int64
-                    maximum: 128
-                    minimum: 1
-                    type: integer
-                required:
-                - interface
-                - address
-                - prefix
-                type: object
-              type: array
-            administrativeState:
-              description: AdministrativeState defines the desired administrative
-                state of the host
-              enum:
-              - locked
-              - unlocked
-              type: string
-            base:
-              description: 'Base defines the name of another HostProfile from which
-                to inherit attributes.  HostProfiles can be structured in a hierarchy
-                so that many HostProfiles can inherit generic attributes from a parent
-                HostProfile. This hierarchy can be defined in multiple layers; with
-                lower layers overriding attributes set in higher layers.  At configuration
-                time, before a Host is configured, the hierarchy of HostProfile resources
-                is flattened to produce a single composite profile that represents
-                the final attributes as they are overridden down the HostProfile hierarchy.  Once
-                the HostProfile hierarchy is flattened to a composite profile.  The
-                Deployment Manager will further refine the profile to create a final
-                HostProfile which serves as the final configuration for the Host resource.  To
-                create the final HostProfile, the Deployment Manages merges the composite
-                profile with the initial default host attributes, and then merges
-                the individual host overrides into that result.  The process can be
-                illustrated as follows:          Host Defaults      +---------------------+            |                                      \            |                                       \         Base
-                Profile        +                       \            |                 \                       \           ...                  +
-                Composite Profile ----+  Final Profile            |                 /                        /      Personality
-                Profile(s) +                        /            |                                        /            |                                       /           Host                                    /            |                                     /            |                                    /         Host
-                Overrides       +-----------------+  Merging two HostProfileSpec resources
-                consists of merging the attributes of a higher precedence profile
-                into the attributes of a lower precedences profile.  The rules for
-                merging attributes are as follows.    1) A nil pointer is always overwritten
-                by a non-nil pointer.    2) Two non-nil pointers are merged together
-                according to the underlying      type.    2a) If the type pointed
-                to is a primitive type (e.g., int, bool,       string, etc) then the
-                higher precedence value is used).    2b) If the type pointed to is
-                a structure then this same merge       procedure is repeated recursively
-                on each field of the structure       with these same rules applying
-                to each field.    2c) If the type pointed to is a slice/array then
-                rule (3) is used.    2d) If the type pointed to is a map then higher
-                precedence value is       used and the entire map is overwritten.    3)
-                Two slices are merged together using the following sub-rules.    3a)
-                If the elements of slices define the KeyEqual() method then an       attempt
-                is made to try to merge equivalent element using this same       merge
-                strategy.  Elements from the higher precedence list that do       not
-                have an equivalent in the lower precedence list are appended to       the
-                list.  Elements appearing in the lower precedence list but not       in
-                the higher precedence list are kept intact.    3b) If the elements
-                of the slices do not define the KeyEqual() method       then they
-                are simply concatenated together.    3c) An empty slice is handled
-                as a special case that deletes the       contents of the lower precedence
-                slice.  Do not confuse an empty       slice with a nil slice pointer.'
-              type: string
-            boardManagement:
-              description: BoardManagement defines the attributes specific to the
-                board management controller configuration.
-              properties:
-                address:
-                  description: Address defines the IP address or hostname of the board
-                    management interface.  An address is specific to a host therefore
-                    this should only be set if the profile is only going to be used
-                    to configure a single host; otherwise it should be set as a per-host
-                    override.
-                  type: string
-                credentials:
-                  description: Credentials defines the authentication credentials
-                    for the board management interface.  This is left as optional
-                    so that the address can be overridden on a per-host basis without
-                    worrying about overwriting the type or credentials.
-                  properties:
-                    password:
-                      description: Password defines the attributes specific to password
-                        based authentication.
-                      properties:
-                        secret:
-                          description: Secret defines the name of the secret which
-                            contains the username and password for the board management
-                            controller.
-                          type: string
-                      required:
-                      - secret
-                      type: object
-                  type: object
-                type:
-                  description: Type defines the board management controller type.  This
-                    is left as optional so that the address can be overridden on a
-                    per-host basis without worrying about overwriting the type or
-                    credentials.
-                  enum:
-                  - none
-                  - bmc
-                  - dynamic
-                  - ipmi
-                  - redfish
-                  type: string
-              type: object
-            bootDevice:
-              description: BootDevice defines the absolute device path of the device
-                to be used for installation.
-              maxLength: 4095
-              pattern: ^/dev/.+$
-              type: string
-            bootMAC:
-              description: BootMAC defines the MAC address that a host uses to perform
-                the initial software installation.  This is only applicable for statically
-                provisioned hosts and should be set on each hosts via the overrides
-                attributes.
-              pattern: ^([0-9a-fA-Z]{2}[:-]){5}([0-9a-fA-Z]{2})$
-              type: string
-            clockSynchronization:
-              description: ClockSynchronization defines the clock synchronization
-                source of the host resource.
-              enum:
-              - ntp
-              - ptp
-              type: string
-            console:
-              description: Console defines the installation output device.
-              pattern: ^(|tty[0-9]+|ttyS[0-9]+(,\d+([a-zA-Z0-9]+)?)?|ttyUSB[0-9]+(,\d+([a-zA-Z0-9]+))?|lp[0-9]+)$
-              type: string
-            installOutput:
-              description: InstallOutput defines the install output method.  The graphical
-                mode is only suitable when the console attribute is set to a graphical
-                terminal. The text mode can be used with both serial and graphical
-                console configurations.
-              enum:
-              - text
-              - graphical
-              type: string
-            interfaces:
-              description: Interfaces defines the list of interfaces to be configured
-                against this host.
-              properties:
-                bond:
-                  description: Bond defines the list of Bond interfaces to be configured
-                    on a host.
-                  items:
+                  credentials:
+                    description: Credentials defines the authentication credentials
+                      for the board management interface.  This is left as optional
+                      so that the address can be overridden on a per-host basis without
+                      worrying about overwriting the type or credentials.
                     properties:
-                      class:
-                        description: Class defines the intended usage of this interface
-                          by the system.
-                        enum:
-                        - platform
-                        - data
-                        - pci-sriov
-                        - pci-passthrough
-                        - none
-                        type: string
-                      dataNetworks:
-                        description: DataNetworks defines the list of data networks
-                          to be configured against this interface.
-                        items:
-                          maxLength: 255
-                          pattern: ^[a-zA-Z0-9\-_]+$
-                          type: string
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_]+$
-                        type: array
-                      members:
-                        description: Members defines the list of interfaces which,
-                          together, make up the Bond interface.
-                        items:
-                          maxLength: 255
-                          pattern: ^[a-zA-Z0-9\-_\.]+$
-                          type: string
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_\.]+$
-                        type: array
-                      mode:
-                        description: Mode defines the Bond interface aggregation mode.
-                        enum:
-                        - balanced
-                        - active_standby
-                        - 802.3ad
-                        type: string
-                      mtu:
-                        description: MTU defines the maximum transmit unit for this
-                          interface.
-                        format: int64
-                        maximum: 9216
-                        minimum: 576
-                        type: integer
-                      name:
-                        description: Name defines the name of the interface to be
-                          configured.
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_\.]+$
-                        type: string
-                      platformNetworks:
-                        description: PlatformNetworks defines the list of platform
-                          networks to be configured against this interface.
-                        items:
-                          maxLength: 255
-                          pattern: ^[a-zA-Z0-9\-_]+$
-                          type: string
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_]+$
-                        type: array
-                      primaryReselect:
-                        description: PrimaryReselect defines the reselection policy
-                          for the Bond interface. Only applicable for active_standby
-                          mode.
-                        type: string
-                      ptpInterfaces:
-                        description: PtpInterfaces defines the ptp interfaces to be
-                          configured against this interface.
-                        items:
-                          maxLength: 255
-                          pattern: ^[a-zA-Z0-9\-_]+$
-                          type: string
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_]+$
-                        type: array
-                      ptpRole:
-                        description: PTPRole defines the ptp role as master, slave,
-                          or none
-                        enum:
-                        - master
-                        - slave
-                        - none
-                        type: string
-                      transmitHashPolicy:
-                        description: TransmitHashPolicy defines the transmit interface
-                          selection policy for the Bond interface.  Only applicable
-                          for 802.3ad and balanced modes.
-                        enum:
-                        - layer2
-                        - layer2+3
-                        type: string
-                    required:
-                    - name
-                    - class
-                    - members
-                    - mode
-                    type: object
-                  type: array
-                ethernet:
-                  description: Ethernet defines the list of ethernet interfaces to
-                    be configured on a host.
-                  items:
-                    properties:
-                      class:
-                        description: Class defines the intended usage of this interface
-                          by the system.
-                        enum:
-                        - platform
-                        - data
-                        - pci-sriov
-                        - pci-passthrough
-                        - none
-                        type: string
-                      dataNetworks:
-                        description: DataNetworks defines the list of data networks
-                          to be configured against this interface.
-                        items:
-                          maxLength: 255
-                          pattern: ^[a-zA-Z0-9\-_]+$
-                          type: string
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_]+$
-                        type: array
-                      lower:
-                        description: Lower defines the interface name over which this
-                          ethernet interface is to be configured.
-                        pattern: ^[a-zA-Z0-9\-_\.]+$
-                        type: string
-                      mtu:
-                        description: MTU defines the maximum transmit unit for this
-                          interface.
-                        format: int64
-                        maximum: 9216
-                        minimum: 576
-                        type: integer
-                      name:
-                        description: Name defines the name of the interface to be
-                          configured.
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_\.]+$
-                        type: string
-                      platformNetworks:
-                        description: PlatformNetworks defines the list of platform
-                          networks to be configured against this interface.
-                        items:
-                          maxLength: 255
-                          pattern: ^[a-zA-Z0-9\-_]+$
-                          type: string
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_]+$
-                        type: array
-                      port:
-                        description: Port defines the attributes identifying the underlying
-                          port which defines this Ethernet interface.
+                      password:
+                        description: Password defines the attributes specific to password
+                          based authentication.
                         properties:
-                          name:
-                            description: SystemName defines the device name of the
-                              Ethernet port.
+                          secret:
+                            description: Secret defines the name of the secret which
+                              contains the username and password for the board management
+                              controller.
+                            type: string
+                        required:
+                        - secret
+                        type: object
+                    type: object
+                  type:
+                    description: Type defines the board management controller type.  This
+                      is left as optional so that the address can be overridden on
+                      a per-host basis without worrying about overwriting the type
+                      or credentials.
+                    enum:
+                    - none
+                    - bmc
+                    - dynamic
+                    - ipmi
+                    - redfish
+                    type: string
+                type: object
+              bootDevice:
+                description: BootDevice defines the absolute device path of the device
+                  to be used for installation.
+                maxLength: 4095
+                pattern: ^/dev/.+$
+                type: string
+              bootMAC:
+                description: BootMAC defines the MAC address that a host uses to perform
+                  the initial software installation.  This is only applicable for
+                  statically provisioned hosts and should be set on each hosts via
+                  the overrides attributes.
+                pattern: ^([0-9a-fA-Z]{2}[:-]){5}([0-9a-fA-Z]{2})$
+                type: string
+              clockSynchronization:
+                description: ClockSynchronization defines the clock synchronization
+                  source of the host resource.
+                enum:
+                - ntp
+                - ptp
+                type: string
+              console:
+                description: Console defines the installation output device.
+                pattern: ^(|tty[0-9]+|ttyS[0-9]+(,\d+([a-zA-Z0-9]+)?)?|ttyUSB[0-9]+(,\d+([a-zA-Z0-9]+))?|lp[0-9]+)$
+                type: string
+              installOutput:
+                description: InstallOutput defines the install output method.  The
+                  graphical mode is only suitable when the console attribute is set
+                  to a graphical terminal. The text mode can be used with both serial
+                  and graphical console configurations.
+                enum:
+                - text
+                - graphical
+                type: string
+              interfaces:
+                description: Interfaces defines the list of interfaces to be configured
+                  against this host.
+                properties:
+                  bond:
+                    description: Bond defines the list of Bond interfaces to be configured
+                      on a host.
+                    items:
+                      properties:
+                        class:
+                          description: Class defines the intended usage of this interface
+                            by the system.
+                          enum:
+                          - platform
+                          - data
+                          - pci-sriov
+                          - pci-passthrough
+                          - none
+                          type: string
+                        dataNetworks:
+                          description: DataNetworks defines the list of data networks
+                            to be configured against this interface.
+                          items:
                             maxLength: 255
                             pattern: ^[a-zA-Z0-9\-_]+$
                             type: string
-                        required:
-                        - name
-                        type: object
-                      ptpInterfaces:
-                        description: PtpInterfaces defines the ptp interfaces to be
-                          configured against this interface.
-                        items:
                           maxLength: 255
                           pattern: ^[a-zA-Z0-9\-_]+$
-                          type: string
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_]+$
-                        type: array
-                      ptpRole:
-                        description: PTPRole defines the ptp role as master, slave,
-                          or none
-                        enum:
-                        - master
-                        - slave
-                        - none
-                        type: string
-                      vfCount:
-                        description: VFCount defines the number of SRIOV VF interfaces
-                          to be allocated.  Only applicable if the interface class
-                          is set to "pci-sriov".
-                        format: int64
-                        maximum: 128
-                        minimum: 1
-                        type: integer
-                      vfDriver:
-                        description: VFDriver defines the device driver to be associated
-                          with each individual SRIOV VF interface allocated.  Only
-                          applicable if the interface class is set to "pci-sriov".
-                        type: string
-                    required:
-                    - name
-                    - class
-                    - port
-                    type: object
-                  type: array
-                vf:
-                  description: VF defines the list of SR-IOV VF interfaces to be configured
-                    on a host.
-                  items:
-                    properties:
-                      class:
-                        description: Class defines the intended usage of this interface
-                          by the system.
-                        enum:
-                        - platform
-                        - data
-                        - pci-sriov
-                        - pci-passthrough
-                        - none
-                        type: string
-                      dataNetworks:
-                        description: DataNetworks defines the list of data networks
-                          to be configured against this interface.
-                        items:
-                          maxLength: 255
-                          pattern: ^[a-zA-Z0-9\-_]+$
-                          type: string
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_]+$
-                        type: array
-                      lower:
-                        description: Lower defines the interface name over which this
-                          VF interface is to be configured.
-                        pattern: ^[a-zA-Z0-9\-_\.]+$
-                        type: string
-                      maxTxRate:
-                        description: MaxTxRate defines the maximum tx rate of SRIOV
-                          VF interfaces. Only applicable if the interface class is
-                          set to "pci-sriov" and interface type is set to "vf".
-                        format: int64
-                        type: integer
-                      mtu:
-                        description: MTU defines the maximum transmit unit for this
-                          interface.
-                        format: int64
-                        maximum: 9216
-                        minimum: 576
-                        type: integer
-                      name:
-                        description: Name defines the name of the interface to be
-                          configured.
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_\.]+$
-                        type: string
-                      platformNetworks:
-                        description: PlatformNetworks defines the list of platform
-                          networks to be configured against this interface.
-                        items:
-                          maxLength: 255
-                          pattern: ^[a-zA-Z0-9\-_]+$
-                          type: string
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_]+$
-                        type: array
-                      ptpInterfaces:
-                        description: PtpInterfaces defines the ptp interfaces to be
-                          configured against this interface.
-                        items:
-                          maxLength: 255
-                          pattern: ^[a-zA-Z0-9\-_]+$
-                          type: string
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_]+$
-                        type: array
-                      ptpRole:
-                        description: PTPRole defines the ptp role as master, slave,
-                          or none
-                        enum:
-                        - master
-                        - slave
-                        - none
-                        type: string
-                      vfCount:
-                        description: VFCount defines the number of SRIOV virtual functions
-                          for this VF interface.
-                        format: int64
-                        maximum: 256
-                        minimum: 1
-                        type: integer
-                      vfDriver:
-                        description: VFDriver defines the device driver to be associated
-                          with each individual SRIOV VF interface allocated.  Only
-                          applicable if the interface class is set to "pci-sriov".
-                        type: string
-                    required:
-                    - name
-                    - class
-                    - lower
-                    - vfCount
-                    type: object
-                  type: array
-                vlan:
-                  description: VLAN defines the list of VLAN interfaces to be configured
-                    on a host.
-                  items:
-                    properties:
-                      class:
-                        description: Class defines the intended usage of this interface
-                          by the system.
-                        enum:
-                        - platform
-                        - data
-                        - pci-sriov
-                        - pci-passthrough
-                        - none
-                        type: string
-                      dataNetworks:
-                        description: DataNetworks defines the list of data networks
-                          to be configured against this interface.
-                        items:
-                          maxLength: 255
-                          pattern: ^[a-zA-Z0-9\-_]+$
-                          type: string
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_]+$
-                        type: array
-                      lower:
-                        description: Lower defines the interface name over which this
-                          VLAN interface is to be configured.
-                        pattern: ^[a-zA-Z0-9\-_\.]+$
-                        type: string
-                      mtu:
-                        description: MTU defines the maximum transmit unit for this
-                          interface.
-                        format: int64
-                        maximum: 9216
-                        minimum: 576
-                        type: integer
-                      name:
-                        description: Name defines the name of the interface to be
-                          configured.
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_\.]+$
-                        type: string
-                      platformNetworks:
-                        description: PlatformNetworks defines the list of platform
-                          networks to be configured against this interface.
-                        items:
-                          maxLength: 255
-                          pattern: ^[a-zA-Z0-9\-_]+$
-                          type: string
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_]+$
-                        type: array
-                      ptpInterfaces:
-                        description: PtpInterfaces defines the ptp interfaces to be
-                          configured against this interface.
-                        items:
-                          maxLength: 255
-                          pattern: ^[a-zA-Z0-9\-_]+$
-                          type: string
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_]+$
-                        type: array
-                      ptpRole:
-                        description: PTPRole defines the ptp role as master, slave,
-                          or none
-                        enum:
-                        - master
-                        - slave
-                        - none
-                        type: string
-                      vid:
-                        description: VID defines the VLAN ID value to be assigned
-                          to this VLAN interface.
-                        format: int64
-                        maximum: 4095
-                        minimum: 1
-                        type: integer
-                    required:
-                    - name
-                    - class
-                    - lower
-                    - vid
-                    type: object
-                  type: array
-              type: object
-            labels:
-              description: Labels defines the set of labels to be applied to the kubernetes
-                node resources that is running on this host.
-              type: object
-            location:
-              description: Location defines the physical location of the host in the
-                data centre.
-              type: string
-            maxCPUFrequency:
-              description: MaxCPUFrequency defines the maximum limit of the CPU frequency
-                set on the host.
-              pattern: ^[1-9][0-9]*$
-              type: string
-            memory:
-              description: Memory defines the memory allocations for each function
-                across all NUMA sockets/nodes.
-              items:
-                properties:
-                  functions:
-                    description: Functions defines a list of function specific allocations
-                      for the given NUMA socket/node.
-                    items:
-                      properties:
-                        function:
-                          description: Function defines the function for which to
-                            allocate a number of cores.
-                          enum:
-                          - platform
-                          - vm
-                          - vswitch
-                          type: string
-                        pageCount:
-                          description: PageCount defines the number of pages to allocate
-                            to a specific function.
-                          format: int64
-                          type: integer
-                        pageSize:
-                          description: PageSize defines the size of individual memory
-                            pages to be allocated to a specific function.  For platform
-                            allocations the 4KB page size is the only valid choice.
-                          enum:
-                          - 4KB
-                          - 2MB
-                          - 1GB
-                          type: string
-                      required:
-                      - function
-                      - pageSize
-                      - pageCount
-                      type: object
-                    type: array
-                  node:
-                    description: Node defines the NUMA node number for which to allocate
-                      a number of functions.
-                    format: int64
-                    maximum: 7
-                    minimum: 0
-                    type: integer
-                required:
-                - node
-                - functions
-                type: object
-              type: array
-            personality:
-              description: Personality defines the role to be assigned to the host
-              enum:
-              - controller
-              - worker
-              - storage
-              - controller-worker
-              type: string
-            powerOn:
-              description: PowerOn defines the initial power state of the node if
-                static provisioning is being used.
-              type: boolean
-            processors:
-              description: Processors defines the core allocations for each function
-                across all NUMA sockets/nodes.
-              items:
-                properties:
-                  functions:
-                    description: Functions defines a list of function specific allocations
-                      for the given NUMA socket/node.
-                    items:
-                      properties:
-                        count:
-                          description: Count defines the number of cores to allocate
-                            to a specific function.
-                          format: int64
-                          maximum: 64
-                          minimum: 0
-                          type: integer
-                        function:
-                          description: Function defines the function for which to
-                            allocate a number of cores.
-                          enum:
-                          - platform
-                          - shared
-                          - vswitch
-                          - application-isolated
-                          - application
-                          type: string
-                      required:
-                      - function
-                      - count
-                      type: object
-                    type: array
-                  node:
-                    description: Node defines the NUMA node number for which to allocate
-                      a number of functions.
-                    format: int64
-                    maximum: 7
-                    minimum: 0
-                    type: integer
-                required:
-                - node
-                - functions
-                type: object
-              type: array
-            provisioningMode:
-              description: ProvisioningMode defines whether a host is provisioned
-                dynamically when it appears in system host inventory or whether it
-                is provisioned statically and powered up explicitly.  Statically provisioned
-                hosts require that the user supply a boot MAC address, board management
-                IP address, and a management IP address if the management network
-                is configured for static address assignment.
-              enum:
-              - static
-              - dynamic
-              type: string
-            ptpInstances:
-              description: PtpInstances defines the list of ptp instance to be configured
-                against this interface.
-              items:
-                maxLength: 255
-                pattern: ^[a-zA-Z0-9\-_]+$
-                type: string
-              maxLength: 255
-              pattern: ^[a-zA-Z0-9\-_]+$
-              type: array
-            rootDevice:
-              description: RootDevice defines the absolute device path of the device
-                to be used as the root file system.
-              maxLength: 4095
-              pattern: ^/dev/.+$
-              type: string
-            routes:
-              description: Routes defines the list of routes to be configured against
-                this host. Routes require that the target interface be configured
-                with a suitable address (e.g., one that allows reachability to next
-                hop device(s)) therefore the host must be configured with valid addresses
-                or configured to for automatic address assignment from a platform
-                network.
-              items:
-                properties:
-                  gateway:
-                    description: Gateway defines the next hop gateway IP address.
-                    type: string
-                  interface:
-                    description: Interface is a reference to the interface name against
-                      which to configure the route.
-                    maxLength: 255
-                    pattern: ^[a-zA-Z0-9\-_\.]+$
-                    type: string
-                  metric:
-                    description: Metric defines the route preference metric for this
-                      route.
-                    format: int64
-                    maximum: 255
-                    minimum: 1
-                    type: integer
-                  prefix:
-                    description: Prefix defines the destination network address prefix
-                      length.
-                    format: int64
-                    maximum: 128
-                    minimum: 0
-                    type: integer
-                  subnet:
-                    description: Subnet defines the destination network address subnet.
-                    type: string
-                required:
-                - interface
-                - subnet
-                - prefix
-                - gateway
-                type: object
-              type: array
-            storage:
-              description: Storage defines the storage attributes for the host
-              properties:
-                filesystems:
-                  description: FileSystems defines the list of file systems to be
-                    defined on the host.
-                  items:
-                    properties:
-                      name:
-                        description: Name defines the system defined name of the filesystem
-                          resource.  Each filesystem name may only be applicable to
-                          a subset of host personalities. Refer to StarlingX documentation
-                          for more information.
-                        enum:
-                        - backup
-                        - docker
-                        - scratch
-                        - kubelet
-                        type: string
-                      size:
-                        format: int64
-                        minimum: 1
-                        type: integer
-                    required:
-                    - name
-                    - size
-                    type: object
-                  type: array
-                monitor:
-                  description: Monitor defines whether a Ceph storage monitor should
-                    be enabled on a node.
-                  properties:
-                    size:
-                      description: Size represents the storage allocated to the monitor
-                        in gibibytes
-                      format: int64
-                      maximum: 40
-                      minimum: 20
-                      type: integer
-                  type: object
-                osds:
-                  description: OSDs defines the list of OSD devices to be created
-                    on the host.  This is only applicable to storage related nodes.
-                  items:
-                    properties:
-                      cluster:
-                        description: ClusterName defines the storage cluster to which
-                          the OSD device should be assigned.  By default this is the
-                          "ceph_cluster".
-                        maxLength: 255
-                        type: string
-                      function:
-                        description: Function defines the function to be assigned
-                          to the OSD device.
-                        enum:
-                        - osd
-                        - journal
-                        type: string
-                      journal:
-                        description: Journal defines another OSD device to be used
-                          as the journal for this OSD device.
-                        properties:
-                          location:
-                            description: "Location defines\tthe OSD device path to
-                              be used as the Journal OSD for this logical device."
+                          type: array
+                        members:
+                          description: Members defines the list of interfaces which,
+                            together, make up the Bond interface.
+                          items:
                             maxLength: 255
+                            pattern: ^[a-zA-Z0-9\-_\.]+$
                             type: string
-                          size:
-                            description: Size defines the size of the OSD journal
-                              in gibibytes.
-                            format: int64
-                            minimum: 1
-                            type: integer
-                        required:
-                        - location
-                        - size
-                        type: object
-                      path:
-                        description: Path defines the disk device path to use as backing
-                          for the OSD device.
-                        maxLength: 4095
-                        pattern: ^/dev/.+$
-                        type: string
-                    required:
-                    - function
-                    - path
-                    type: object
-                  type: array
-                volumeGroups:
-                  description: VolumeGroups defines the list of volume groups to be
-                    created on the host.
-                  items:
-                    properties:
-                      concurrentDiskOperations:
-                        description: ConcurrentDiskOperations defines the number of
-                          concurrent disk operations permitted.
-                        format: int64
-                        minimum: 1
-                        type: integer
-                      lvmType:
-                        description: LVMType defines the provisioning type for volumes
-                          defines with 'Type' set to 'lvm'.
-                        enum:
-                        - thin
-                        - thick
-                        type: string
-                      name:
-                        description: SystemName defines the name of the logical volume
-                          group
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_]+$
-                        type: string
-                      physicalVolumes:
-                        description: PhysicalVolumes defines the list of volumes to
-                          be created on the host.
-                        items:
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_\.]+$
+                          type: array
+                        mode:
+                          description: Mode defines the Bond interface aggregation
+                            mode.
+                          enum:
+                          - balanced
+                          - active_standby
+                          - 802.3ad
+                          type: string
+                        mtu:
+                          description: MTU defines the maximum transmit unit for this
+                            interface.
+                          format: int64
+                          maximum: 9216
+                          minimum: 576
+                          type: integer
+                        name:
+                          description: Name defines the name of the interface to be
+                            configured.
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_\.]+$
+                          type: string
+                        platformNetworks:
+                          description: PlatformNetworks defines the list of platform
+                            networks to be configured against this interface.
+                          items:
+                            maxLength: 255
+                            pattern: ^[a-zA-Z0-9\-_]+$
+                            type: string
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_]+$
+                          type: array
+                        primaryReselect:
+                          description: PrimaryReselect defines the reselection policy
+                            for the Bond interface. Only applicable for active_standby
+                            mode.
+                          type: string
+                        ptpInterfaces:
+                          description: PtpInterfaces defines the ptp interfaces to
+                            be configured against this interface.
+                          items:
+                            maxLength: 255
+                            pattern: ^[a-zA-Z0-9\-_]+$
+                            type: string
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_]+$
+                          type: array
+                        ptpRole:
+                          description: PTPRole defines the ptp role as master, slave,
+                            or none
+                          enum:
+                          - master
+                          - slave
+                          - none
+                          type: string
+                        transmitHashPolicy:
+                          description: TransmitHashPolicy defines the transmit interface
+                            selection policy for the Bond interface.  Only applicable
+                            for 802.3ad and balanced modes.
+                          enum:
+                          - layer2
+                          - layer2+3
+                          type: string
+                      required:
+                      - name
+                      - class
+                      - members
+                      - mode
+                      type: object
+                    type: array
+                  ethernet:
+                    description: Ethernet defines the list of ethernet interfaces
+                      to be configured on a host.
+                    items:
+                      properties:
+                        class:
+                          description: Class defines the intended usage of this interface
+                            by the system.
+                          enum:
+                          - platform
+                          - data
+                          - pci-sriov
+                          - pci-passthrough
+                          - none
+                          type: string
+                        dataNetworks:
+                          description: DataNetworks defines the list of data networks
+                            to be configured against this interface.
+                          items:
+                            maxLength: 255
+                            pattern: ^[a-zA-Z0-9\-_]+$
+                            type: string
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_]+$
+                          type: array
+                        lower:
+                          description: Lower defines the interface name over which
+                            this ethernet interface is to be configured.
+                          pattern: ^[a-zA-Z0-9\-_\.]+$
+                          type: string
+                        mtu:
+                          description: MTU defines the maximum transmit unit for this
+                            interface.
+                          format: int64
+                          maximum: 9216
+                          minimum: 576
+                          type: integer
+                        name:
+                          description: Name defines the name of the interface to be
+                            configured.
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_\.]+$
+                          type: string
+                        platformNetworks:
+                          description: PlatformNetworks defines the list of platform
+                            networks to be configured against this interface.
+                          items:
+                            maxLength: 255
+                            pattern: ^[a-zA-Z0-9\-_]+$
+                            type: string
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_]+$
+                          type: array
+                        port:
+                          description: Port defines the attributes identifying the
+                            underlying port which defines this Ethernet interface.
                           properties:
-                            path:
-                              description: Path defines the device path backing the
-                                physical volume.  If 'Type' is set as disk then this
-                                attribute refers to the absolute path of a disk device.  If
-                                'Type' is set as partition then it refers to the device
-                                path of the disk onto which this partition will be
-                                created.
+                            name:
+                              description: SystemName defines the device name of the
+                                Ethernet port.
                               maxLength: 255
-                              type: string
-                            size:
-                              description: Size defines the size of the disk partition
-                                in gibibytes.  This should be omitted if the path
-                                refers to a disk.
-                              format: int64
-                              minimum: 1
-                              type: integer
-                            type:
-                              description: Type defines the type of physical volume.
-                              enum:
-                              - disk
-                              - partition
+                              pattern: ^[a-zA-Z0-9\-_]+$
                               type: string
                           required:
-                          - type
-                          - path
+                          - name
                           type: object
-                        type: array
-                    required:
-                    - name
-                    - physicalVolumes
-                    type: object
-                  type: array
-              type: object
-            subfunctions:
-              description: SubFunctionList defines the set of subfunctions to be provisioned
-                on the node at time of initial provisioning.
-              items:
+                        ptpInterfaces:
+                          description: PtpInterfaces defines the ptp interfaces to
+                            be configured against this interface.
+                          items:
+                            maxLength: 255
+                            pattern: ^[a-zA-Z0-9\-_]+$
+                            type: string
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_]+$
+                          type: array
+                        ptpRole:
+                          description: PTPRole defines the ptp role as master, slave,
+                            or none
+                          enum:
+                          - master
+                          - slave
+                          - none
+                          type: string
+                        vfCount:
+                          description: VFCount defines the number of SRIOV VF interfaces
+                            to be allocated.  Only applicable if the interface class
+                            is set to "pci-sriov".
+                          format: int64
+                          maximum: 128
+                          minimum: 1
+                          type: integer
+                        vfDriver:
+                          description: VFDriver defines the device driver to be associated
+                            with each individual SRIOV VF interface allocated.  Only
+                            applicable if the interface class is set to "pci-sriov".
+                          type: string
+                      required:
+                      - name
+                      - class
+                      - port
+                      type: object
+                    type: array
+                  vf:
+                    description: VF defines the list of SR-IOV VF interfaces to be
+                      configured on a host.
+                    items:
+                      properties:
+                        class:
+                          description: Class defines the intended usage of this interface
+                            by the system.
+                          enum:
+                          - platform
+                          - data
+                          - pci-sriov
+                          - pci-passthrough
+                          - none
+                          type: string
+                        dataNetworks:
+                          description: DataNetworks defines the list of data networks
+                            to be configured against this interface.
+                          items:
+                            maxLength: 255
+                            pattern: ^[a-zA-Z0-9\-_]+$
+                            type: string
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_]+$
+                          type: array
+                        lower:
+                          description: Lower defines the interface name over which
+                            this VF interface is to be configured.
+                          pattern: ^[a-zA-Z0-9\-_\.]+$
+                          type: string
+                        maxTxRate:
+                          description: MaxTxRate defines the maximum tx rate of SRIOV
+                            VF interfaces. Only applicable if the interface class
+                            is set to "pci-sriov" and interface type is set to "vf".
+                          format: int64
+                          type: integer
+                        mtu:
+                          description: MTU defines the maximum transmit unit for this
+                            interface.
+                          format: int64
+                          maximum: 9216
+                          minimum: 576
+                          type: integer
+                        name:
+                          description: Name defines the name of the interface to be
+                            configured.
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_\.]+$
+                          type: string
+                        platformNetworks:
+                          description: PlatformNetworks defines the list of platform
+                            networks to be configured against this interface.
+                          items:
+                            maxLength: 255
+                            pattern: ^[a-zA-Z0-9\-_]+$
+                            type: string
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_]+$
+                          type: array
+                        ptpInterfaces:
+                          description: PtpInterfaces defines the ptp interfaces to
+                            be configured against this interface.
+                          items:
+                            maxLength: 255
+                            pattern: ^[a-zA-Z0-9\-_]+$
+                            type: string
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_]+$
+                          type: array
+                        ptpRole:
+                          description: PTPRole defines the ptp role as master, slave,
+                            or none
+                          enum:
+                          - master
+                          - slave
+                          - none
+                          type: string
+                        vfCount:
+                          description: VFCount defines the number of SRIOV virtual
+                            functions for this VF interface.
+                          format: int64
+                          maximum: 256
+                          minimum: 1
+                          type: integer
+                        vfDriver:
+                          description: VFDriver defines the device driver to be associated
+                            with each individual SRIOV VF interface allocated.  Only
+                            applicable if the interface class is set to "pci-sriov".
+                          type: string
+                      required:
+                      - name
+                      - class
+                      - lower
+                      - vfCount
+                      type: object
+                    type: array
+                  vlan:
+                    description: VLAN defines the list of VLAN interfaces to be configured
+                      on a host.
+                    items:
+                      properties:
+                        class:
+                          description: Class defines the intended usage of this interface
+                            by the system.
+                          enum:
+                          - platform
+                          - data
+                          - pci-sriov
+                          - pci-passthrough
+                          - none
+                          type: string
+                        dataNetworks:
+                          description: DataNetworks defines the list of data networks
+                            to be configured against this interface.
+                          items:
+                            maxLength: 255
+                            pattern: ^[a-zA-Z0-9\-_]+$
+                            type: string
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_]+$
+                          type: array
+                        lower:
+                          description: Lower defines the interface name over which
+                            this VLAN interface is to be configured.
+                          pattern: ^[a-zA-Z0-9\-_\.]+$
+                          type: string
+                        mtu:
+                          description: MTU defines the maximum transmit unit for this
+                            interface.
+                          format: int64
+                          maximum: 9216
+                          minimum: 576
+                          type: integer
+                        name:
+                          description: Name defines the name of the interface to be
+                            configured.
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_\.]+$
+                          type: string
+                        platformNetworks:
+                          description: PlatformNetworks defines the list of platform
+                            networks to be configured against this interface.
+                          items:
+                            maxLength: 255
+                            pattern: ^[a-zA-Z0-9\-_]+$
+                            type: string
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_]+$
+                          type: array
+                        ptpInterfaces:
+                          description: PtpInterfaces defines the ptp interfaces to
+                            be configured against this interface.
+                          items:
+                            maxLength: 255
+                            pattern: ^[a-zA-Z0-9\-_]+$
+                            type: string
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_]+$
+                          type: array
+                        ptpRole:
+                          description: PTPRole defines the ptp role as master, slave,
+                            or none
+                          enum:
+                          - master
+                          - slave
+                          - none
+                          type: string
+                        vid:
+                          description: VID defines the VLAN ID value to be assigned
+                            to this VLAN interface.
+                          format: int64
+                          maximum: 4095
+                          minimum: 1
+                          type: integer
+                      required:
+                      - name
+                      - class
+                      - lower
+                      - vid
+                      type: object
+                    type: array
+                type: object
+              labels:
+                description: Labels defines the set of labels to be applied to the
+                  kubernetes node resources that is running on this host.
+                type: object
+              location:
+                description: Location defines the physical location of the host in
+                  the data centre.
+                type: string
+              maxCPUFrequency:
+                description: MaxCPUFrequency defines the maximum limit of the CPU
+                  frequency set on the host.
+                pattern: ^[1-9][0-9]*$
+                type: string
+              memory:
+                description: Memory defines the memory allocations for each function
+                  across all NUMA sockets/nodes.
+                items:
+                  properties:
+                    functions:
+                      description: Functions defines a list of function specific allocations
+                        for the given NUMA socket/node.
+                      items:
+                        properties:
+                          function:
+                            description: Function defines the function for which to
+                              allocate a number of cores.
+                            enum:
+                            - platform
+                            - vm
+                            - vswitch
+                            type: string
+                          pageCount:
+                            description: PageCount defines the number of pages to
+                              allocate to a specific function.
+                            format: int64
+                            type: integer
+                          pageSize:
+                            description: PageSize defines the size of individual memory
+                              pages to be allocated to a specific function.  For platform
+                              allocations the 4KB page size is the only valid choice.
+                            enum:
+                            - 4KB
+                            - 2MB
+                            - 1GB
+                            type: string
+                        required:
+                        - function
+                        - pageSize
+                        - pageCount
+                        type: object
+                      type: array
+                    node:
+                      description: Node defines the NUMA node number for which to
+                        allocate a number of functions.
+                      format: int64
+                      maximum: 7
+                      minimum: 0
+                      type: integer
+                  required:
+                  - node
+                  - functions
+                  type: object
+                type: array
+              personality:
+                description: Personality defines the role to be assigned to the host
                 enum:
                 - controller
                 - worker
                 - storage
-                - lowlatency
+                - controller-worker
                 type: string
-              type: array
-          type: object
-  version: v1
+              powerOn:
+                description: PowerOn defines the initial power state of the node if
+                  static provisioning is being used.
+                type: boolean
+              processors:
+                description: Processors defines the core allocations for each function
+                  across all NUMA sockets/nodes.
+                items:
+                  properties:
+                    functions:
+                      description: Functions defines a list of function specific allocations
+                        for the given NUMA socket/node.
+                      items:
+                        properties:
+                          count:
+                            description: Count defines the number of cores to allocate
+                              to a specific function.
+                            format: int64
+                            maximum: 64
+                            minimum: 0
+                            type: integer
+                          function:
+                            description: Function defines the function for which to
+                              allocate a number of cores.
+                            enum:
+                            - platform
+                            - shared
+                            - vswitch
+                            - application-isolated
+                            - application
+                            type: string
+                        required:
+                        - function
+                        - count
+                        type: object
+                      type: array
+                    node:
+                      description: Node defines the NUMA node number for which to
+                        allocate a number of functions.
+                      format: int64
+                      maximum: 7
+                      minimum: 0
+                      type: integer
+                  required:
+                  - node
+                  - functions
+                  type: object
+                type: array
+              provisioningMode:
+                description: ProvisioningMode defines whether a host is provisioned
+                  dynamically when it appears in system host inventory or whether
+                  it is provisioned statically and powered up explicitly.  Statically
+                  provisioned hosts require that the user supply a boot MAC address,
+                  board management IP address, and a management IP address if the
+                  management network is configured for static address assignment.
+                enum:
+                - static
+                - dynamic
+                type: string
+              ptpInstances:
+                description: PtpInstances defines the list of ptp instance to be configured
+                  against this interface.
+                items:
+                  maxLength: 255
+                  pattern: ^[a-zA-Z0-9\-_]+$
+                  type: string
+                maxLength: 255
+                pattern: ^[a-zA-Z0-9\-_]+$
+                type: array
+              rootDevice:
+                description: RootDevice defines the absolute device path of the device
+                  to be used as the root file system.
+                maxLength: 4095
+                pattern: ^/dev/.+$
+                type: string
+              routes:
+                description: Routes defines the list of routes to be configured against
+                  this host. Routes require that the target interface be configured
+                  with a suitable address (e.g., one that allows reachability to next
+                  hop device(s)) therefore the host must be configured with valid
+                  addresses or configured to for automatic address assignment from
+                  a platform network.
+                items:
+                  properties:
+                    gateway:
+                      description: Gateway defines the next hop gateway IP address.
+                      type: string
+                    interface:
+                      description: Interface is a reference to the interface name
+                        against which to configure the route.
+                      maxLength: 255
+                      pattern: ^[a-zA-Z0-9\-_\.]+$
+                      type: string
+                    metric:
+                      description: Metric defines the route preference metric for
+                        this route.
+                      format: int64
+                      maximum: 255
+                      minimum: 1
+                      type: integer
+                    prefix:
+                      description: Prefix defines the destination network address
+                        prefix length.
+                      format: int64
+                      maximum: 128
+                      minimum: 0
+                      type: integer
+                    subnet:
+                      description: Subnet defines the destination network address
+                        subnet.
+                      type: string
+                  required:
+                  - interface
+                  - subnet
+                  - prefix
+                  - gateway
+                  type: object
+                type: array
+              storage:
+                description: Storage defines the storage attributes for the host
+                properties:
+                  filesystems:
+                    description: FileSystems defines the list of file systems to be
+                      defined on the host.
+                    items:
+                      properties:
+                        name:
+                          description: Name defines the system defined name of the
+                            filesystem resource.  Each filesystem name may only be
+                            applicable to a subset of host personalities. Refer to
+                            StarlingX documentation for more information.
+                          enum:
+                          - backup
+                          - docker
+                          - scratch
+                          - kubelet
+                          type: string
+                        size:
+                          format: int64
+                          minimum: 1
+                          type: integer
+                      required:
+                      - name
+                      - size
+                      type: object
+                    type: array
+                  monitor:
+                    description: Monitor defines whether a Ceph storage monitor should
+                      be enabled on a node.
+                    properties:
+                      size:
+                        description: Size represents the storage allocated to the
+                          monitor in gibibytes
+                        format: int64
+                        maximum: 40
+                        minimum: 20
+                        type: integer
+                    type: object
+                  osds:
+                    description: OSDs defines the list of OSD devices to be created
+                      on the host.  This is only applicable to storage related nodes.
+                    items:
+                      properties:
+                        cluster:
+                          description: ClusterName defines the storage cluster to
+                            which the OSD device should be assigned.  By default this
+                            is the "ceph_cluster".
+                          maxLength: 255
+                          type: string
+                        function:
+                          description: Function defines the function to be assigned
+                            to the OSD device.
+                          enum:
+                          - osd
+                          - journal
+                          type: string
+                        journal:
+                          description: Journal defines another OSD device to be used
+                            as the journal for this OSD device.
+                          properties:
+                            location:
+                              description: "Location defines\tthe OSD device path\
+                                \ to be used as the Journal OSD for this logical device."
+                              maxLength: 255
+                              type: string
+                            size:
+                              description: Size defines the size of the OSD journal
+                                in gibibytes.
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                          - location
+                          - size
+                          type: object
+                        path:
+                          description: Path defines the disk device path to use as
+                            backing for the OSD device.
+                          maxLength: 4095
+                          pattern: ^/dev/.+$
+                          type: string
+                      required:
+                      - function
+                      - path
+                      type: object
+                    type: array
+                  volumeGroups:
+                    description: VolumeGroups defines the list of volume groups to
+                      be created on the host.
+                    items:
+                      properties:
+                        concurrentDiskOperations:
+                          description: ConcurrentDiskOperations defines the number
+                            of concurrent disk operations permitted.
+                          format: int64
+                          minimum: 1
+                          type: integer
+                        lvmType:
+                          description: LVMType defines the provisioning type for volumes
+                            defines with 'Type' set to 'lvm'.
+                          enum:
+                          - thin
+                          - thick
+                          type: string
+                        name:
+                          description: SystemName defines the name of the logical
+                            volume group
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_]+$
+                          type: string
+                        physicalVolumes:
+                          description: PhysicalVolumes defines the list of volumes
+                            to be created on the host.
+                          items:
+                            properties:
+                              path:
+                                description: Path defines the device path backing
+                                  the physical volume.  If 'Type' is set as disk then
+                                  this attribute refers to the absolute path of a
+                                  disk device.  If 'Type' is set as partition then
+                                  it refers to the device path of the disk onto which
+                                  this partition will be created.
+                                maxLength: 255
+                                type: string
+                              size:
+                                description: Size defines the size of the disk partition
+                                  in gibibytes.  This should be omitted if the path
+                                  refers to a disk.
+                                format: int64
+                                minimum: 1
+                                type: integer
+                              type:
+                                description: Type defines the type of physical volume.
+                                enum:
+                                - disk
+                                - partition
+                                type: string
+                            required:
+                            - type
+                            - path
+                            type: object
+                          type: array
+                      required:
+                      - name
+                      - physicalVolumes
+                      type: object
+                    type: array
+                type: object
+              subfunctions:
+                description: SubFunctionList defines the set of subfunctions to be
+                  provisioned on the node at time of initial provisioning.
+                items:
+                  enum:
+                  - controller
+                  - worker
+                  - storage
+                  - lowlatency
+                  type: string
+                type: array
+            type: object
+    served: true
+    storage: true
 status:
   acceptedNames:
-    kind: ""
-    plural: ""
+    kind: ''
+    plural: ''
   conditions: []
   storedVersions: []

--- a/config/crds/starlingx_v1_platformnetwork.yaml
+++ b/config/crds/starlingx_v1_platformnetwork.yaml
@@ -1,156 +1,162 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    controller-tools.k8s.io: "1.0"
+    controller-tools.k8s.io: '1.0'
   name: platformnetworks.starlingx.windriver.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.type
-    description: The platform network type.
-    name: type
-    type: string
-  - JSONPath: .spec.subnet
-    description: The platform network address subnet.
-    name: subnet
-    type: string
-  - JSONPath: .spec.prefix
-    description: The platform network address prefix.
-    name: prefix
-    type: string
-  - JSONPath: .status.inSync
-    description: The current synchronization state.
-    name: insync
-    type: boolean
-  - JSONPath: .status.reconciled
-    description: The current reconciliation state.
-    name: reconciled
-    type: boolean
   group: starlingx.windriver.com
   names:
     kind: PlatformNetwork
     plural: platformnetworks
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            allocation:
-              description: Allocation defines the allocation scheme details for the
-                network
-              properties:
-                order:
-                  description: Order defines whether host address are allocation randomly
-                    or sequential from the available pool or addresses.
-                  enum:
-                  - sequential
-                  - random
-                  type: string
-                ranges:
-                  description: Ranges defines the pools from which host addresses
-                    are allocated.   If omitted addresses the entire network address
-                    space is considered available.
-                  items:
-                    properties:
-                      end:
-                        description: End defines the end of the address range (inclusively)
-                        type: string
-                      start:
-                        description: Start defines the beginning of the address range
-                          (inclusively)
-                        type: string
-                    required:
-                    - start
-                    - end
-                    type: object
-                  type: array
-                type:
-                  description: Type defines whether network addresses are allocated
-                    dynamically or statically.
-                  enum:
-                  - static
-                  - dynamic
-                  type: string
-              required:
-              - type
-              type: object
-            gateway:
-              description: Gateway defines the nexthop gateway IP address if applicable
-              type: string
-            prefix:
-              format: int64
-              maximum: 128
-              minimum: 1
-              type: integer
-            subnet:
-              description: Subnet defines the IPv4 or IPv6 network address for the
-                network
-              type: string
-            type:
-              description: Type defines the intended usage of the network
-              enum:
-              - mgmt
-              - pxeboot
-              - infra
-              - oam
-              - multicast
-              - system-controller
-              - cluster-host
-              - cluster-pod
-              - cluster-service
-              - storage
-              - other
-              type: string
-          required:
-          - type
-          - subnet
-          - prefix
-          - allocation
-          type: object
-        status:
-          properties:
-            id:
-              description: ID defines the system assigned unique identifier.  This
-                will only exist once this resource has been provisioned into the system.
-              type: string
-            inSync:
-              description: Defines whether the resource has been provisioned on the
-                target system.
-              type: boolean
-            poolUUID:
-              description: PoolUUID defines the system assigned unique identifier
-                that is represents the networks underlying address pool resource.  This
-                will only exist once this resource has been provisioned into the system.
-              type: string
-            reconciled:
-              description: Reconciled defines whether the network has been successfully
-                reconciled at least once.  If further changes are made they will be
-                ignored by the reconciler.
-              type: boolean
-          required:
-          - reconciled
-          - inSync
-          type: object
-  version: v1
+  versions:
+  - additionalPrinterColumns:
+    - description: The platform network type.
+      jsonPath: .spec.type
+      name: type
+      type: string
+    - description: The platform network address subnet.
+      jsonPath: .spec.subnet
+      name: subnet
+      type: string
+    - description: The platform network address prefix.
+      jsonPath: .spec.prefix
+      name: prefix
+      type: string
+    - description: The current synchronization state.
+      jsonPath: .status.inSync
+      name: insync
+      type: boolean
+    - description: The current reconciliation state.
+      jsonPath: .status.reconciled
+      name: reconciled
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              allocation:
+                description: Allocation defines the allocation scheme details for
+                  the network
+                properties:
+                  order:
+                    description: Order defines whether host address are allocation
+                      randomly or sequential from the available pool or addresses.
+                    enum:
+                    - sequential
+                    - random
+                    type: string
+                  ranges:
+                    description: Ranges defines the pools from which host addresses
+                      are allocated.   If omitted addresses the entire network address
+                      space is considered available.
+                    items:
+                      properties:
+                        end:
+                          description: End defines the end of the address range (inclusively)
+                          type: string
+                        start:
+                          description: Start defines the beginning of the address
+                            range (inclusively)
+                          type: string
+                      required:
+                      - start
+                      - end
+                      type: object
+                    type: array
+                  type:
+                    description: Type defines whether network addresses are allocated
+                      dynamically or statically.
+                    enum:
+                    - static
+                    - dynamic
+                    type: string
+                required:
+                - type
+                type: object
+              gateway:
+                description: Gateway defines the nexthop gateway IP address if applicable
+                type: string
+              prefix:
+                format: int64
+                maximum: 128
+                minimum: 1
+                type: integer
+              subnet:
+                description: Subnet defines the IPv4 or IPv6 network address for the
+                  network
+                type: string
+              type:
+                description: Type defines the intended usage of the network
+                enum:
+                - mgmt
+                - pxeboot
+                - infra
+                - oam
+                - multicast
+                - system-controller
+                - cluster-host
+                - cluster-pod
+                - cluster-service
+                - storage
+                - other
+                type: string
+            required:
+            - type
+            - subnet
+            - prefix
+            - allocation
+            type: object
+          status:
+            properties:
+              id:
+                description: ID defines the system assigned unique identifier.  This
+                  will only exist once this resource has been provisioned into the
+                  system.
+                type: string
+              inSync:
+                description: Defines whether the resource has been provisioned on
+                  the target system.
+                type: boolean
+              poolUUID:
+                description: PoolUUID defines the system assigned unique identifier
+                  that is represents the networks underlying address pool resource.  This
+                  will only exist once this resource has been provisioned into the
+                  system.
+                type: string
+              reconciled:
+                description: Reconciled defines whether the network has been successfully
+                  reconciled at least once.  If further changes are made they will
+                  be ignored by the reconciler.
+                type: boolean
+            required:
+            - reconciled
+            - inSync
+            type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
-    kind: ""
-    plural: ""
+    kind: ''
+    plural: ''
   conditions: []
   storedVersions: []

--- a/config/crds/starlingx_v1_ptpinstance.yaml
+++ b/config/crds/starlingx_v1_ptpinstance.yaml
@@ -1,83 +1,88 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    controller-tools.k8s.io: "1.0"
+    controller-tools.k8s.io: '1.0'
   name: ptpinstances.starlingx.windriver.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.inSync
-    description: The current synchronization state.
-    name: insync
-    type: boolean
-  - JSONPath: .status.reconciled
-    description: The current reconciliation state.
-    name: reconciled
-    type: boolean
   group: starlingx.windriver.com
   names:
     kind: PtpInstance
     plural: ptpinstances
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            parameters:
-              description: Parameters contains a list of parameters assigned to the
-                ptp instance
-              items:
+  versions:
+  - additionalPrinterColumns:
+    - description: The current synchronization state.
+      jsonPath: .status.inSync
+      name: insync
+      type: boolean
+    - description: The current reconciliation state.
+      jsonPath: .status.reconciled
+      name: reconciled
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              parameters:
+                description: Parameters contains a list of parameters assigned to
+                  the ptp instance
+                items:
+                  type: string
+                type: array
+              service:
+                description: Serivce defines the service type of the ptp instance
+                enum:
+                - ptp4l
+                - phc2sys
+                - ts2phc
                 type: string
-              type: array
-            service:
-              description: Serivce defines the service type of the ptp instance
-              enum:
-              - ptp4l
-              - phc2sys
-              - ts2phc
-              type: string
-          required:
-          - service
-          type: object
-        status:
-          properties:
-            id:
-              description: ID defines the system assigned unique identifier.  This
-                will only exist once this resource has been provisioned into the system.
-              type: string
-            inSync:
-              description: Defines whether the resource has been provisioned on the
-                target system.
-              type: boolean
-            reconciled:
-              description: Reconciled defines whether the host has been successfully
-                reconciled at least once.  If further changes are made they will be
-                ignored by the reconciler.
-              type: boolean
-          required:
-          - reconciled
-          - inSync
-          type: object
-  version: v1
+            required:
+            - service
+            type: object
+          status:
+            properties:
+              id:
+                description: ID defines the system assigned unique identifier.  This
+                  will only exist once this resource has been provisioned into the
+                  system.
+                type: string
+              inSync:
+                description: Defines whether the resource has been provisioned on
+                  the target system.
+                type: boolean
+              reconciled:
+                description: Reconciled defines whether the host has been successfully
+                  reconciled at least once.  If further changes are made they will
+                  be ignored by the reconciler.
+                type: boolean
+            required:
+            - reconciled
+            - inSync
+            type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
-    kind: ""
-    plural: ""
+    kind: ''
+    plural: ''
   conditions: []
   storedVersions: []

--- a/config/crds/starlingx_v1_ptpinterface.yaml
+++ b/config/crds/starlingx_v1_ptpinterface.yaml
@@ -1,82 +1,87 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    controller-tools.k8s.io: "1.0"
+    controller-tools.k8s.io: '1.0'
   name: ptpinterfaces.starlingx.windriver.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.inSync
-    description: The current synchronization state.
-    name: insync
-    type: boolean
-  - JSONPath: .status.reconciled
-    description: The current reconciliation state.
-    name: reconciled
-    type: boolean
   group: starlingx.windriver.com
   names:
     kind: PtpInterface
     plural: ptpinterfaces
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            parameters:
-              description: InterfaceParameters contains a list of parameters assigned
-                to the ptp interface
-              items:
+  versions:
+  - additionalPrinterColumns:
+    - description: The current synchronization state.
+      jsonPath: .status.inSync
+      name: insync
+      type: boolean
+    - description: The current reconciliation state.
+      jsonPath: .status.reconciled
+      name: reconciled
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              parameters:
+                description: InterfaceParameters contains a list of parameters assigned
+                  to the ptp interface
+                items:
+                  type: string
+                type: array
+              ptpinstance:
+                description: ptpinstance defines the ptp instance assigned to the
+                  ptp interface
+                maxLength: 255
+                pattern: ^[a-zA-Z0-9\-_]+$
                 type: string
-              type: array
-            ptpinstance:
-              description: ptpinstance defines the ptp instance assigned to the ptp
-                interface
-              maxLength: 255
-              pattern: ^[a-zA-Z0-9\-_]+$
-              type: string
-          required:
-          - ptpinstance
-          type: object
-        status:
-          properties:
-            id:
-              description: ID defines the system assigned unique identifier.  This
-                will only exist once this resource has been provisioned into the system.
-              type: string
-            inSync:
-              description: Defines whether the resource has been provisioned on the
-                target system.
-              type: boolean
-            reconciled:
-              description: Reconciled defines whether the host has been successfully
-                reconciled at least once.  If further changes are made they will be
-                ignored by the reconciler.
-              type: boolean
-          required:
-          - reconciled
-          - inSync
-          type: object
-  version: v1
+            required:
+            - ptpinstance
+            type: object
+          status:
+            properties:
+              id:
+                description: ID defines the system assigned unique identifier.  This
+                  will only exist once this resource has been provisioned into the
+                  system.
+                type: string
+              inSync:
+                description: Defines whether the resource has been provisioned on
+                  the target system.
+                type: boolean
+              reconciled:
+                description: Reconciled defines whether the host has been successfully
+                  reconciled at least once.  If further changes are made they will
+                  be ignored by the reconciler.
+                type: boolean
+            required:
+            - reconciled
+            - inSync
+            type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
-    kind: ""
-    plural: ""
+    kind: ''
+    plural: ''
   conditions: []
   storedVersions: []

--- a/config/crds/starlingx_v1_system.yaml
+++ b/config/crds/starlingx_v1_system.yaml
@@ -1,354 +1,365 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    controller-tools.k8s.io: "1.0"
+    controller-tools.k8s.io: '1.0'
   name: systems.starlingx.windriver.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.systemMode
-    description: The configured system mode.
-    name: mode
-    type: string
-  - JSONPath: .status.systemType
-    description: The configured system type.
-    name: type
-    type: string
-  - JSONPath: .status.softwareVersion
-    description: The current software version
-    name: version
-    type: string
-  - JSONPath: .status.inSync
-    description: The current synchronization state.
-    name: insync
-    type: boolean
-  - JSONPath: .status.reconciled
-    description: The current reconciliation state.
-    name: reconciled
-    type: boolean
   group: starlingx.windriver.com
   names:
     kind: System
     plural: systems
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            certificates:
-              description: Certificates is a list of references to certificates that
-                must be installed.
-              items:
+  versions:
+  - additionalPrinterColumns:
+    - description: The configured system mode.
+      jsonPath: .status.systemMode
+      name: mode
+      type: string
+    - description: The configured system type.
+      jsonPath: .status.systemType
+      name: type
+      type: string
+    - description: The current software version
+      jsonPath: .status.softwareVersion
+      name: version
+      type: string
+    - description: The current synchronization state.
+      jsonPath: .status.inSync
+      name: insync
+      type: boolean
+    - description: The current reconciliation state.
+      jsonPath: .status.reconciled
+      name: reconciled
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              certificates:
+                description: Certificates is a list of references to certificates
+                  that must be installed.
+                items:
+                  properties:
+                    secret:
+                      description: Secret is the name of a TLS secret containing the
+                        public certificate and private key.  The secret must be of
+                        type kubernetes.io/tls and must contain specific data attributes.  Specifically,
+                        all secrets must, at a minimum contain the "tls.crt" key since
+                        all certificates will at least require public certificate
+                        PEM data.  The remaining two keys "tls.key" and "ca.crt" are
+                        optional depending on the certificate type. For the "platform",
+                        "openstack", "tpm", and "docker" certificate types both the
+                        "tls.crt" and "tls.key" certificates are needed while for
+                        the "*_ca" version of those same certificate types only the
+                        "tls.crt" attribute is required.  The "ca.crt" attribute is
+                        only required for the "platform" or "tpm" certificate types,
+                        and only if the supplied public certificate is signed by a
+                        non-standard root CA.
+                      type: string
+                    type:
+                      description: Type represents the intended usage of the certificate
+                      enum:
+                      - ssl
+                      - ssl_ca
+                      - openstack
+                      - openstack_ca
+                      - docker_registry
+                      - tpm_mode
+                      type: string
+                  required:
+                  - type
+                  - secret
+                  type: object
+                type: array
+              contact:
+                description: Contact is a method to reach the person responsible for
+                  the system.  For example it could be an email address, phone number,
+                  or physical address.
+                maxLength: 255
+                pattern: ^[a-zA-Z0-9@\-_\. ]+$
+                type: string
+              description:
+                description: Description is a free form string describing the intended
+                  purpose of the system.
+                type: string
+              dnsServers:
+                description: Nameservers is an array of Domain SystemName servers.  Each
+                  server can be specified as either an IPv4 or IPv6 address.
+                items:
+                  type: string
+                type: array
+              latitude:
+                description: Latitude is the latitude geolocation coordinate of the
+                  system's physical location.
+                maxLength: 30
+                pattern: ^[a-zA-Z0-9\-_\. ]+$
+                type: string
+              license:
+                description: License is a reference to a license file that must be
+                  installed.
                 properties:
                   secret:
                     description: Secret is the name of a TLS secret containing the
-                      public certificate and private key.  The secret must be of type
-                      kubernetes.io/tls and must contain specific data attributes.  Specifically,
-                      all secrets must, at a minimum contain the "tls.crt" key since
-                      all certificates will at least require public certificate PEM
-                      data.  The remaining two keys "tls.key" and "ca.crt" are optional
-                      depending on the certificate type. For the "platform", "openstack",
-                      "tpm", and "docker" certificate types both the "tls.crt" and
-                      "tls.key" certificates are needed while for the "*_ca" version
-                      of those same certificate types only the "tls.crt" attribute
-                      is required.  The "ca.crt" attribute is only required for the
-                      "platform" or "tpm" certificate types, and only if the supplied
-                      public certificate is signed by a non-standard root CA.
-                    type: string
-                  type:
-                    description: Type represents the intended usage of the certificate
-                    enum:
-                    - ssl
-                    - ssl_ca
-                    - openstack
-                    - openstack_ca
-                    - docker_registry
-                    - tpm_mode
+                      license file contents. It must refer to a Opaque Kubernetes
+                      Secret.
                     type: string
                 required:
-                - type
                 - secret
                 type: object
-              type: array
-            contact:
-              description: Contact is a method to reach the person responsible for
-                the system.  For example it could be an email address, phone number,
-                or physical address.
-              maxLength: 255
-              pattern: ^[a-zA-Z0-9@\-_\. ]+$
-              type: string
-            description:
-              description: Description is a free form string describing the intended
-                purpose of the system.
-              type: string
-            dnsServers:
-              description: Nameservers is an array of Domain SystemName servers.  Each
-                server can be specified as either an IPv4 or IPv6 address.
-              items:
+              location:
+                description: Location is a short description of the system's physical
+                  location.
+                maxLength: 255
+                pattern: ^[a-zA-Z0-9\-_\. ]+$
                 type: string
-              type: array
-            latitude:
-              description: Latitude is the latitude geolocation coordinate of the
-                system's physical location.
-              maxLength: 30
-              pattern: ^[a-zA-Z0-9\-_\. ]+$
-              type: string
-            license:
-              description: License is a reference to a license file that must be installed.
-              properties:
-                secret:
-                  description: Secret is the name of a TLS secret containing the license
-                    file contents. It must refer to a Opaque Kubernetes Secret.
-                  type: string
-              required:
-              - secret
-              type: object
-            location:
-              description: Location is a short description of the system's physical
-                location.
-              maxLength: 255
-              pattern: ^[a-zA-Z0-9\-_\. ]+$
-              type: string
-            longitude:
-              description: Longitude is the longitude geolocation coordinate of the
-                system's physical location.
-              maxLength: 30
-              pattern: ^[a-zA-Z0-9\-_\. ]+$
-              type: string
-            ntpServers:
-              description: NTPServers is an array of Network Time Protocol servers.  Each
-                server can be specified as either an IPv4 or IPv6 address, or a FQDN
-                hostname.
-              items:
+              longitude:
+                description: Longitude is the longitude geolocation coordinate of
+                  the system's physical location.
+                maxLength: 30
+                pattern: ^[a-zA-Z0-9\-_\. ]+$
                 type: string
-              type: array
-            ptp:
-              description: PTP defines the Precision Time Protocol configuration for
-                the system.
-              properties:
-                mechanism:
-                  description: Mechanism defines the high level messaging architecture
-                    used to implement the precision time procotol.
-                  enum:
-                  - p2p
-                  - e2e
+              ntpServers:
+                description: NTPServers is an array of Network Time Protocol servers.  Each
+                  server can be specified as either an IPv4 or IPv6 address, or a
+                  FQDN hostname.
+                items:
                   type: string
-                mode:
-                  description: Mode defines the precision time protocol mode of the
-                    system.
-                  enum:
-                  - hardware
-                  - software
-                  - legacy
-                  type: string
-                transport:
-                  description: Transport defines the network transport protocol used
-                    to implement the precision time protocol.
-                  enum:
-                  - l2
-                  - udp
-                  type: string
-              type: object
-            serviceParameters:
-              description: ServiceParameters is a list of service parameters
-              items:
+                type: array
+              ptp:
+                description: PTP defines the Precision Time Protocol configuration
+                  for the system.
                 properties:
-                  paramname:
-                    description: ParamName identifies the name for this service parameter
-                    maxLength: 255
+                  mechanism:
+                    description: Mechanism defines the high level messaging architecture
+                      used to implement the precision time procotol.
+                    enum:
+                    - p2p
+                    - e2e
                     type: string
-                  paramvalue:
-                    description: ParamValue identifies the value for this service
-                      parameter
-                    maxLength: 4096
+                  mode:
+                    description: Mode defines the precision time protocol mode of
+                      the system.
+                    enum:
+                    - hardware
+                    - software
+                    - legacy
                     type: string
-                  personality:
-                    description: Personality identifies the personality for this service
-                      parameter
-                    maxLength: 255
+                  transport:
+                    description: Transport defines the network transport protocol
+                      used to implement the precision time protocol.
+                    enum:
+                    - l2
+                    - udp
                     type: string
-                  resource:
-                    description: Resource identifies the resource for this service
-                      parameter
-                    maxLength: 255
-                    type: string
-                  section:
-                    description: Section identifies the section for this service parameter
-                    maxLength: 128
-                    pattern: ^[a-zA-Z0-9\-_]+$
-                    type: string
-                  service:
-                    description: Service identifies the service for this service parameter
-                    maxLength: 16
-                    pattern: ^[a-zA-Z0-9\-_]+$
-                    type: string
-                required:
-                - service
-                - section
-                - paramname
-                - paramvalue
                 type: object
-              type: array
-            storage:
-              description: Storage is a set of storage specific attributes to be configured
-                for the system.
-              properties:
-                backends:
-                  description: Backends is a set of backend storage methods to be
-                    configured.  Only
-                  items:
+              serviceParameters:
+                description: ServiceParameters is a list of service parameters
+                items:
+                  properties:
+                    paramname:
+                      description: ParamName identifies the name for this service
+                        parameter
+                      maxLength: 255
+                      type: string
+                    paramvalue:
+                      description: ParamValue identifies the value for this service
+                        parameter
+                      maxLength: 4096
+                      type: string
+                    personality:
+                      description: Personality identifies the personality for this
+                        service parameter
+                      maxLength: 255
+                      type: string
+                    resource:
+                      description: Resource identifies the resource for this service
+                        parameter
+                      maxLength: 255
+                      type: string
+                    section:
+                      description: Section identifies the section for this service
+                        parameter
+                      maxLength: 128
+                      pattern: ^[a-zA-Z0-9\-_]+$
+                      type: string
+                    service:
+                      description: Service identifies the service for this service
+                        parameter
+                      maxLength: 16
+                      pattern: ^[a-zA-Z0-9\-_]+$
+                      type: string
+                  required:
+                  - service
+                  - section
+                  - paramname
+                  - paramvalue
+                  type: object
+                type: array
+              storage:
+                description: Storage is a set of storage specific attributes to be
+                  configured for the system.
+                properties:
+                  backends:
+                    description: Backends is a set of backend storage methods to be
+                      configured.  Only
+                    items:
+                      properties:
+                        name:
+                          description: SystemName uniquely identifies the storage
+                            backend instance.
+                          maxLength: 255
+                          pattern: ^[a-zA-Z0-9\-_]+$
+                          type: string
+                        network:
+                          description: Network is the network type associated with
+                            this backend. At the momemnt it is used only for ceph
+                            backend.
+                          enum:
+                          - mgmt
+                          - cluster-host
+                          type: string
+                        partitionSize:
+                          description: PartitionSize is the controller disk partition
+                            size to be allocated for the Ceph monitor - in gigabytes.
+                            This attribute is only applicable for Ceph storage backends.
+                          format: int64
+                          minimum: 20
+                          type: integer
+                        replicationFactor:
+                          description: ReplicationFactor is the number of storage
+                            hosts required in each replication group for storage redundancy.
+                            This attribute is only applicable for Ceph storage backends.
+                          format: int64
+                          maximum: 3
+                          minimum: 1
+                          type: integer
+                        services:
+                          description: Services is a list of services to enable for
+                            this backend instance.  Each backend type supports a limited
+                            set of services.  Refer to customer documentation for
+                            more information.
+                          items:
+                            enum:
+                            - cinder
+                            - glance
+                            - nova
+                            - swift
+                            - rbd-provisioner
+                            type: string
+                          type: array
+                        type:
+                          description: Type specifies the storage backend type.
+                          enum:
+                          - file
+                          - lvm
+                          - ceph
+                          type: string
+                      required:
+                      - name
+                      - type
+                      type: object
+                    type: array
+                  drbd:
+                    description: DRBD defines the set of DRBD configuration attributes
+                      for the system.
                     properties:
-                      name:
-                        description: SystemName uniquely identifies the storage backend
-                          instance.
-                        maxLength: 255
-                        pattern: ^[a-zA-Z0-9\-_]+$
-                        type: string
-                      network:
-                        description: Network is the network type associated with this
-                          backend. At the momemnt it is used only for ceph backend.
-                        enum:
-                        - mgmt
-                        - cluster-host
-                        type: string
-                      partitionSize:
-                        description: PartitionSize is the controller disk partition
-                          size to be allocated for the Ceph monitor - in gigabytes.
-                          This attribute is only applicable for Ceph storage backends.
+                      linkUtilization:
+                        description: LinkUtilization defines the maximum link utilisation
+                          percentage during sync activities.
                         format: int64
+                        maximum: 100
                         minimum: 20
                         type: integer
-                      replicationFactor:
-                        description: ReplicationFactor is the number of storage hosts
-                          required in each replication group for storage redundancy.
-                          This attribute is only applicable for Ceph storage backends.
-                        format: int64
-                        maximum: 3
-                        minimum: 1
-                        type: integer
-                      services:
-                        description: Services is a list of services to enable for
-                          this backend instance.  Each backend type supports a limited
-                          set of services.  Refer to customer documentation for more
-                          information.
-                        items:
-                          enum:
-                          - cinder
-                          - glance
-                          - nova
-                          - swift
-                          - rbd-provisioner
+                    required:
+                    - linkUtilization
+                    type: object
+                  filesystems:
+                    description: Filesystems defines the set of controller file system
+                      definitions.
+                    items:
+                      properties:
+                        name:
+                          description: Name defines the system defined name of the
+                            filesystem resource.
                           type: string
-                        type: array
-                      type:
-                        description: Type specifies the storage backend type.
-                        enum:
-                        - file
-                        - lvm
-                        - ceph
-                        type: string
-                    required:
-                    - name
-                    - type
-                    type: object
-                  type: array
-                drbd:
-                  description: DRBD defines the set of DRBD configuration attributes
-                    for the system.
-                  properties:
-                    linkUtilization:
-                      description: LinkUtilization defines the maximum link utilisation
-                        percentage during sync activities.
-                      format: int64
-                      maximum: 100
-                      minimum: 20
-                      type: integer
-                  required:
-                  - linkUtilization
-                  type: object
-                filesystems:
-                  description: Filesystems defines the set of controller file system
-                    definitions.
-                  items:
-                    properties:
-                      name:
-                        description: Name defines the system defined name of the filesystem
-                          resource.
-                        type: string
-                      size:
-                        format: int64
-                        minimum: 1
-                        type: integer
-                    required:
-                    - name
-                    - size
-                    type: object
-                  type: array
-              type: object
-            vswitchType:
-              description: VSwitchType is the desired vswitch implementation to be
-                configured. This is intentionally left unvalidated to avoid issues
-                with proprietary vswitch implementation.
-              type: string
-          type: object
-        status:
-          properties:
-            defaults:
-              description: Defaults defines the configuration attributed collected
-                before applying any user configuration values.
-              type: string
-            id:
-              description: ID defines the unique identifier assigned by the system.
-              type: string
-            inSync:
-              description: Defines whether the resource has been provisioned on the
-                target system.
-              type: boolean
-            reconciled:
-              description: Reconciled defines whether the System has been successfully
-                reconciled at least once.  If further changes are made they will be
-                ignored by the reconciler.
-              type: boolean
-            softwareVersion:
-              description: SoftwareVersion defines the current software version reported
-                by the system API.
-              type: string
-            systemMode:
-              description: SystemMode defines the current system mode reported by
-                the system API.
-              type: string
-            systemType:
-              description: SystemType defines the current system type reported by
-                the system API.
-              type: string
-          required:
-          - id
-          - systemType
-          - systemMode
-          - softwareVersion
-          - inSync
-          - reconciled
-          type: object
-  version: v1
+                        size:
+                          format: int64
+                          minimum: 1
+                          type: integer
+                      required:
+                      - name
+                      - size
+                      type: object
+                    type: array
+                type: object
+              vswitchType:
+                description: VSwitchType is the desired vswitch implementation to
+                  be configured. This is intentionally left unvalidated to avoid issues
+                  with proprietary vswitch implementation.
+                type: string
+            type: object
+          status:
+            properties:
+              defaults:
+                description: Defaults defines the configuration attributed collected
+                  before applying any user configuration values.
+                type: string
+              id:
+                description: ID defines the unique identifier assigned by the system.
+                type: string
+              inSync:
+                description: Defines whether the resource has been provisioned on
+                  the target system.
+                type: boolean
+              reconciled:
+                description: Reconciled defines whether the System has been successfully
+                  reconciled at least once.  If further changes are made they will
+                  be ignored by the reconciler.
+                type: boolean
+              softwareVersion:
+                description: SoftwareVersion defines the current software version
+                  reported by the system API.
+                type: string
+              systemMode:
+                description: SystemMode defines the current system mode reported by
+                  the system API.
+                type: string
+              systemType:
+                description: SystemType defines the current system type reported by
+                  the system API.
+                type: string
+            required:
+            - id
+            - systemType
+            - systemMode
+            - softwareVersion
+            - inSync
+            - reconciled
+            type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
-    kind: ""
-    plural: ""
+    kind: ''
+    plural: ''
   conditions: []
   storedVersions: []


### PR DESCRIPTION
This change migrates all the helm chart CRDs from
apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1.

The apiextensions.k8s.io/v1beta1 API version of CRD is not
supported from k8s version 1.22.5.
https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/

The manifests need to be updated to use apiextensions.k8s.io/v1

Manifests are updated according to following deprecation guide
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#migrate-to-non-deprecated-apis

Note:
According to https://www.pulumi.com/registry/packages/kubernetes/api-docs/apiextensions/v1/customresourcedefinition/
'served' and 'storage' are mandatory fields of
CustomResourceDefinitionVersion.
With 'served=true', this version can be served via REST
APIs. 'storage=true' signifies that this version should be
used to persist custom resources to the storage.

Test Plan:
PASS: helm chart deployment is successful.
FAIL: platform-deployment-manager pod is Running
      Reason: 'manager' container fails to start
      This change only includes CRD apiversion change.
      We will need to migrate Webhook resources similar
      to this.

Signed-off-by: Kaustubh Dhokte <kaustubh.dhokte@windriver.com>