### PR TITLE
Update DM playbook to accept random name of pod

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -169,11 +169,24 @@
       when: helmv2_dm_exists.rc != 0
 
     # Restart Deployment Manager if it was reinstalled
-    - name: Restart Deployment Manager if reinstalled
-      command: >-
-        kubectl -n platform-deployment-manager delete pods platform-deployment-manager-0
-      environment:
-        KUBECONFIG: "/etc/kubernetes/admin.conf"
+    - block:
+      - name: Search for the pod of the Deployment Manager
+        shell: |
+          kubectl -n platform-deployment-manager get pods | awk 'NR == 2 { print $1 }'
+        environment:
+          KUBECONFIG: "/etc/kubernetes/admin.conf"
+        register: deployment_manager_pod_name
+
+      - debug:
+          msg: "{{ deployment_manager_pod_name.stdout }}"
+
+      - name: Restart Deployment Manager if reinstalled
+        command: >-
+          kubectl -n platform-deployment-manager delete pods {{ deployment_manager_pod_name.stdout }}
+        environment:
+          KUBECONFIG: "/etc/kubernetes/admin.conf"
+        when: deployment_manager_pod_name.stdout
+
       when: helmv2_dm_exists.rc == 0 or helmv3_dm_exists.rc == 0
 
     - name: Wait for Deployment Manager to be ready


### PR DESCRIPTION
When we build DM with kubebuilder v3, the manager is deployed as
deployment compared with as statefulsets in kubebuilder v1. As a
result the name of the manager pod is attached with a random id. This
commit modifies the DM playbook to search for the pod name in the
namespace, and use that name to replace hard-coded pod name in the
playbook.

Tests passed:
1. Deploy the central cloud with this playbook
2. Deploy the subcloud with this playbook by dcmanager subcloud add
3. Reconfig the subcloud with this playbook by dcmanager subcloud
reconfig

Signed-off-by: Yuxing Jiang <yuxing.jiang@windriver.com>