### PR TITLE
Migrate golangci-lint

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -98,7 +98,10 @@ project now uses the GoLangCI-lint tool which is also in use by newer
 Kubebuilder versions.
 
 ```bash
-curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
+# We used this link to download the golangci-lint, but it is not valid any more
+#curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
+
+curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh  | sh -s -- -b $(go env GOPATH)/bin/ v1.13
 ```
 
 #### Docker

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -13,7 +13,7 @@ RUN wget https://github.com/kubernetes-sigs/kustomize/releases/download/v1.0.11/
 
 # Install our current version of golangci-lint.  We can probably upgrade to a
 # new version but this one has been tested and verified to work.
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh  | sh -s -- -b $(go env GOPATH)/bin/ v1.13
 
 # Install the latest version of Docker although we should probably try and
 # align the container version and the host version to ensure compatibility.

--- a/pkg/controller/system/system_controller.go
+++ b/pkg/controller/system/system_controller.go
@@ -819,7 +819,7 @@ func (r *ReconcileSystem) ReconcileCertificates(client *gophercloud.ServiceClien
 		// The system API reports the serial number prepended with the mode as
 		// a "signature" rather than the actual signature so replicate that here
 		// for the purpose of comparisons.
-		signature := fmt.Sprintf("%s_%d", c.Type, cert.SerialNumber)
+		signature := fmt.Sprintf("%s_%s", c.Type, cert.SerialNumber.String())
 
 		found := false
 		for _, certificate := range info.Certificates {
@@ -1234,7 +1234,7 @@ func (r *ReconcileSystem) GetCertificateSignatures(instance *starlingxv1.System)
 
 		// Determine the "signature" based on the certificate type and the
 		// serial number reported by the system API
-		signature := fmt.Sprintf("%s_%d", c.Type, cert.SerialNumber)
+		signature := fmt.Sprintf("%s_%s", c.Type, cert.SerialNumber.String())
 
 		certificate := starlingxv1.CertificateInfo{
 			Type:      c.Type,


### PR DESCRIPTION
https://install.goreleaser.com/github.com/golangci/golangci-lint.sh is not valid any more.
Need to update the DEVELOPER.md and Dockerfile.builder which refer it.
This commit opts https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh v1.13
for the stable/v2.0.8 branch. This commit also contains some change to fit for this golangci-lint.

Regarding the master branch, as we are using go v1.17, we'd better to choose a later version
of golangci-lint, and make changes to adapt the requirement of the new go version.

Test: Created new image with "make" and "make docker-build"

Signed-off-by: Yuxing Jiang <yuxing.jiang@windriver.com>