### PR TITLE
Fix addresses creation for any interface class

### DIFF
--- a/controllers/host/networking.go
+++ b/controllers/host/networking.go
@@ -768,7 +768,7 @@ func interfaceUpdateRequired(info starlingxv1.CommonInterfaceInfo, iface *interf
 		result = true
 	}
 
-	if info.Class == interfaces.IFClassData {
+	if info.Class == interfaces.IFClassData || hasIPv4StaticAddresses(info, profile) || hasIPv6StaticAddresses(info, profile) {
 		// TODO(alegacy): We might need to remove this restriction and manage
 		//  these attributes for other interface classes, but for now limit our
 		//  handling of these for data interfaces only.


### PR DESCRIPTION
When the deployment-manager configures addresses for an
interface the DM only checks if the interface needs to
change mode to static only when it is of class data. This
commit verifies if exist static addresses bound to the interface
and change the mode to static.

Test Plan:
1. Use DM with an interface configured with class != data
2. Use DM with static addresses bound to the interface
3. Apply the DM and verify the interfaces and addresses of the host
- Interface must have the ipv4_mode/ipv6_mode set to static
- Addresses created normally

Signed-off-by: Hugo Brito <hugo.brito@windriver.com>