### PR TITLE
Test code migration

### DIFF
--- a/api/v1/constructors_test.go
+++ b/api/v1/constructors_test.go
@@ -1,0 +1,97 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+
+package v1
+
+import (
+	"reflect"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/disks"
+	"github.com/wind-river/cloud-platform-deployment-manager/platform"
+)
+
+var _ = Describe("Constructor utils for kind", func() {
+	Describe("stripPartitionNumber utility", func() {
+		Context("with partition and disk data", func() {
+			It("should removes the \"-partNNN\" successfully", func() {
+				type args struct {
+					path string
+				}
+				tests := []struct {
+					name string
+					args args
+					want string
+				}{
+					{
+						name: "partition",
+						args: args{"/dev/disk/by-path/pci-0000:00:0d.0-ata-1.0-part2"},
+						want: "/dev/disk/by-path/pci-0000:00:0d.0-ata-1.0",
+					},
+					{
+						name: "disk",
+						args: args{"/dev/disk/by-path/pci-0000:00:0d.0-ata-1.0"},
+						want: "/dev/disk/by-path/pci-0000:00:0d.0-ata-1.0",
+					},
+				}
+				for _, tt := range tests {
+					got := stripPartitionNumber(tt.args.path)
+					Expect(got).To(Equal(tt.want))
+				}
+			})
+		})
+	})
+
+	Describe("fixDevicePath utility", func() {
+		Context("with path data", func() {
+			It("should convert it to the newer format", func() {
+				type args struct {
+					path string
+					host platform.HostInfo
+				}
+				host1 := platform.HostInfo{
+					Disks: []disks.Disk{
+						{DeviceNode: "/dev/sdaa",
+							DevicePath: "/dev/disk/by-path/pci-0000:00:14.0-usb-0:1:1.0-scsi-0:0:0:0"},
+						{DeviceNode: "/dev/sda",
+							DevicePath: "/dev/disk/by-path/pci-0000:00:15.0-usb-0:1:1.0-scsi-0:0:0:0"},
+						{DeviceNode: "/dev/sdbb",
+							DevicePath: "/dev/disk/by-path/pci-0000:00:16.0-usb-0:1:1.0-scsi-0:0:0:0"},
+						{DeviceNode: "/dev/sdb",
+							DevicePath: "/dev/disk/by-path/pci-0000:00:17.0-usb-0:1:1.0-scsi-0:0:0:0"},
+					},
+				}
+				tests := []struct {
+					name string
+					args args
+					want string
+				}{
+					{name: "short-form-no-overlap",
+						args: args{path: "sda", host: host1},
+						want: "/dev/disk/by-path/pci-0000:00:15.0-usb-0:1:1.0-scsi-0:0:0:0"},
+					{name: "short-form",
+						args: args{path: "sdaa", host: host1},
+						want: "/dev/disk/by-path/pci-0000:00:14.0-usb-0:1:1.0-scsi-0:0:0:0"},
+					{name: "long-form-no-overlap",
+						args: args{path: "/dev/sdb", host: host1},
+						want: "/dev/disk/by-path/pci-0000:00:17.0-usb-0:1:1.0-scsi-0:0:0:0"},
+					{name: "long-form",
+						args: args{path: "/dev/sdbb", host: host1},
+						want: "/dev/disk/by-path/pci-0000:00:16.0-usb-0:1:1.0-scsi-0:0:0:0"},
+					{name: "already-in-new-format",
+						args: args{path: "/dev/disk/by-path/pci-0000:00:16.0-usb-0:1:1.0-scsi-0:0:0:0", host: host1},
+						want: "/dev/disk/by-path/pci-0000:00:16.0-usb-0:1:1.0-scsi-0:0:0:0"},
+					{name: "not-found",
+						args: args{path: "/dev/sdc", host: host1},
+						want: "/dev/sdc"},
+				}
+				for _, tt := range tests {
+					got := fixDevicePath(tt.args.path, tt.args.host)
+					Expect(reflect.DeepEqual(got, tt.want)).To(BeTrue())
+				}
+			})
+		})
+	})
+})

--- a/api/v1/datanetwork_type_test.go
+++ b/api/v1/datanetwork_type_test.go
@@ -1,0 +1,69 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+package v1
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Datanetwork controller", func() {
+
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+	ctx := context.Background()
+	Context("DataNetwork with data", func() {
+		It("Should created successfully", func() {
+			key := types.NamespacedName{
+				Name:      "foo",
+				Namespace: "default",
+			}
+			mtu := 1500
+			description := "This is a sample description"
+
+			created := &DataNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+				Spec: DataNetworkSpec{
+					Type:        "flat",
+					Description: &description,
+					MTU:         &mtu,
+				}}
+			Expect(k8sClient.Create(ctx, created)).To(Succeed())
+
+			fetched := &DataNetwork{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(fetched).To(Equal(created))
+
+			updated := fetched.DeepCopy()
+
+			updated.Labels = map[string]string{"hello": "world"}
+			Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(fetched).To(Equal(updated))
+
+			Expect(k8sClient.Delete(ctx, fetched)).To(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeFalse())
+		})
+	})
+})

--- a/api/v1/host_type_test.go
+++ b/api/v1/host_type_test.go
@@ -1,0 +1,80 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+package v1
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Datanetwork controller", func() {
+
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	Context("Host with data", func() {
+		It("Should created successfully", func() {
+			ctx := context.Background()
+			key := types.NamespacedName{
+				Name:      "foo",
+				Namespace: "default",
+			}
+			bootMac := "01:02:03:04:05:06"
+			bmAddress := "192.168.9.9"
+			match := MatchInfo{
+				BootMAC: &bootMac,
+			}
+			bmType := "bmc"
+			created := &Host{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+				Spec: HostSpec{
+					Profile: "some-profile",
+					Match:   &match,
+					Overrides: &HostProfileSpec{
+						Addresses: []AddressInfo{
+							{Interface: "enp0s3", Address: "1.2.3.10", Prefix: 24},
+						},
+						BoardManagement: &BMInfo{
+							Type:    &bmType,
+							Address: &bmAddress,
+						},
+					},
+				}}
+			Expect(k8sClient.Create(ctx, created)).To(Succeed())
+
+			fetched := &Host{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(fetched).To(Equal(created))
+
+			updated := fetched.DeepCopy()
+			updated.Labels = map[string]string{"hello": "world"}
+			Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(fetched).To(Equal(updated))
+
+			Expect(k8sClient.Delete(ctx, fetched)).To(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeFalse())
+		})
+	})
+})

--- a/api/v1/hostprofile_type_test.go
+++ b/api/v1/hostprofile_type_test.go
@@ -1,0 +1,168 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+package v1
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("HostProfile controller", func() {
+
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	Context("HostProfile with data", func() {
+		It("Should created successfully", func() {
+			ctx := context.Background()
+			key := types.NamespacedName{
+				Name:      "foo",
+				Namespace: "default",
+			}
+			created := &HostProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				}}
+			Expect(k8sClient.Create(ctx, created)).Should(Succeed())
+
+			fetched := &HostProfile{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(fetched).To(Equal(created))
+
+			updated := fetched.DeepCopy()
+			updated.Labels = map[string]string{"hello": "world"}
+			Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(fetched).To(Equal(updated))
+
+			Expect(k8sClient.Delete(ctx, fetched)).To(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeFalse())
+		})
+		It("Should created successfully", func() {
+			ctx := context.Background()
+			type args struct {
+				console string
+			}
+
+			key := types.NamespacedName{
+				Name:      "foo",
+				Namespace: "default",
+			}
+			tests := []struct {
+				name    string
+				args    args
+				wantErr bool
+			}{
+				{name: "empty",
+					args:    args{console: ""},
+					wantErr: false},
+				{name: "serial-simple",
+					args:    args{console: "ttyS0"},
+					wantErr: false},
+				{name: "serial-simple-double-digit",
+					args:    args{console: "ttyS0"},
+					wantErr: false},
+				{name: "serial-missing-baud",
+					args:    args{console: "ttyS0"},
+					wantErr: true},
+				{name: "serial-with-baud",
+					args:    args{console: "ttyS0,115200"},
+					wantErr: false},
+				{name: "serial-with-baud-and-parity",
+					args:    args{console: "ttyS0,115200n8"},
+					wantErr: false},
+				{name: "serial-double-digit-with-baud",
+					args:    args{console: "ttyS01,115200"},
+					wantErr: false},
+				{name: "serial-double-digit-with-baud-and-parity",
+					args:    args{console: "ttyS01,115200n8"},
+					wantErr: false},
+				{name: "serial-invalid",
+					args:    args{console: "tty"},
+					wantErr: true},
+				{name: "serial-invalid-numbers",
+					args:    args{console: "1111"},
+					wantErr: true},
+				{name: "graphical-simple",
+					args:    args{console: "tty0"},
+					wantErr: false},
+				{name: "graphical-double-digit",
+					args:    args{console: "tty01"},
+					wantErr: false},
+				{name: "parallel-simple",
+					args:    args{console: "lp0"},
+					wantErr: false},
+				{name: "parallel-double-digit",
+					args:    args{console: "lp01"},
+					wantErr: false},
+				{name: "usb-simple",
+					args:    args{console: "ttyUSB0"},
+					wantErr: false},
+				{name: "usb-simple-double-digit",
+					args:    args{console: "ttyUSB0"},
+					wantErr: false},
+				{name: "usb-missing-baud",
+					args:    args{console: "ttyUSB0,"},
+					wantErr: true},
+				{name: "usb-with-baud",
+					args:    args{console: "ttyUSB0,115200"},
+					wantErr: false},
+				{name: "usb-with-baud-and-parity",
+					args:    args{console: "ttyUSB0,115200n8"},
+					wantErr: false},
+				{name: "usb-double-digit-with-baud",
+					args:    args{console: "ttyUSB01,115200"},
+					wantErr: false},
+				{name: "usb-double-digit-with-baud-and-parity",
+					args:    args{console: "ttyUSB01,115200n8"},
+					wantErr: false},
+				{name: "usb-invalid",
+					args:    args{console: "usb0"},
+					wantErr: true},
+			}
+			for _, tt := range tests {
+				created := &HostProfile{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tt.name,
+						Namespace: "default",
+					},
+					Spec: HostProfileSpec{
+						ProfileBaseAttributes: ProfileBaseAttributes{
+							Console: &tt.args.console,
+						},
+					}}
+				fetched := &HostProfile{}
+				if tt.wantErr {
+					Expect(k8sClient.Create(ctx, created)).Error()
+				} else {
+					Expect(k8sClient.Create(ctx, created)).To(Succeed())
+					key.Name = tt.name
+					Eventually(func() bool {
+						err := k8sClient.Get(ctx, key, fetched)
+						return err == nil
+					}, timeout, interval).Should(BeTrue())
+					Expect(fetched.Spec.Console).To(Equal(created.Spec.Console))
+				}
+			}
+		})
+	})
+})

--- a/api/v1/platformnetwork_type_test.go
+++ b/api/v1/platformnetwork_type_test.go
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+package v1
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Platformnetwork controller", func() {
+
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	Context("PlatformNetwork with data", func() {
+		It("Should created successfully", func() {
+			ctx := context.Background()
+			key := types.NamespacedName{
+				Name:      "foo",
+				Namespace: "default",
+			}
+			order := "sequential"
+			created := &PlatformNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+				Spec: PlatformNetworkSpec{
+					Type:   "mgmt",
+					Subnet: "1.2.3.0",
+					Prefix: 24,
+					Allocation: AllocationInfo{
+						Type:  "static",
+						Order: &order,
+						Ranges: []AllocationRange{
+							{Start: "1.2.3.10", End: "1.2.3.49"},
+							{Start: "1.2.3.129", End: "1.2.3.139"}},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, created)).Should(Succeed())
+
+			fetched := &PlatformNetwork{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(fetched).To(Equal(created))
+
+			updated := fetched.DeepCopy()
+			updated.Labels = map[string]string{"hello": "world"}
+			Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(fetched).To(Equal(updated))
+
+			Expect(k8sClient.Delete(ctx, fetched)).To(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeFalse())
+		})
+	})
+})

--- a/api/v1/ptpinstance_type_test.go
+++ b/api/v1/ptpinstance_type_test.go
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+package v1
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Datanetwork controller", func() {
+
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	Context("PtpInstance with data", func() {
+		It("Should created successfully", func() {
+			ctx := context.Background()
+			key := types.NamespacedName{
+				Name:      "foo",
+				Namespace: "default",
+			}
+			created := &PtpInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+				Spec: PtpInstanceSpec{
+					Service:            "ptp4l",
+					InstanceParameters: []string{"domainNumber=24", "clientOnly=0"},
+				}}
+			Expect(k8sClient.Create(ctx, created)).Should(Succeed())
+
+			fetched := &PtpInstance{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(fetched).To(Equal(created))
+
+			updated := fetched.DeepCopy()
+			updated.Labels = map[string]string{"hello": "world"}
+			Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(fetched).To(Equal(updated))
+
+			Expect(k8sClient.Delete(ctx, fetched)).To(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeFalse())
+		})
+	})
+})

--- a/api/v1/ptpinterface_type_test.go
+++ b/api/v1/ptpinterface_type_test.go
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+package v1
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Datanetwork controller", func() {
+
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	Context("PtpInstance with data", func() {
+		It("Should created successfully", func() {
+			ctx := context.Background()
+			key := types.NamespacedName{
+				Name:      "foo",
+				Namespace: "default",
+			}
+			created := &PtpInterface{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+				Spec: PtpInterfaceSpec{
+					PtpInstance:         "ptp1",
+					InterfaceParameters: []string{"foo1=bar1", "foo2=bar2"},
+				}}
+			Expect(k8sClient.Create(ctx, created)).Should(Succeed())
+
+			fetched := &PtpInterface{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(fetched).To(Equal(created))
+
+			updated := fetched.DeepCopy()
+			updated.Labels = map[string]string{"hello": "world"}
+			Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(fetched).To(Equal(updated))
+
+			Expect(k8sClient.Delete(ctx, fetched)).To(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeFalse())
+		})
+	})
+})

--- a/api/v1/system_type_test.go
+++ b/api/v1/system_type_test.go
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+package v1
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Datanetwork controller", func() {
+
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	Context("System with data", func() {
+		It("Should created successfully", func() {
+			type StringList []string
+			ctx := context.Background()
+			key := types.NamespacedName{
+				Name:      "foo",
+				Namespace: "default",
+			}
+			description := string("A sample description")
+			location := string("A sample location")
+			contact := string("A sample contact")
+			latitude := string("45.35189954974955")
+			longitude := string("-75.91866628453701")
+			// FIXME: After StringList workaround, fix this part
+			// dnsServers := StringList([]string{"8.8.8.8", "4.4.4.4"})
+			// ntpServers := StringList([]string{"time.ntp.org", "1.2.3.4"})
+			ptpMode := "hardware"
+			created := &System{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+				Spec: SystemSpec{
+					Description: &description,
+					Location:    &location,
+					Latitude:    &latitude,
+					Longitude:   &longitude,
+					Contact:     &contact,
+					// DNSServers:  &dnsServers,
+					// NTPServers:  &ntpServers,
+					PTP: &PTPInfo{
+						Mode: &ptpMode,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, created)).To(Succeed())
+
+			fetched := &System{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(fetched).To(Equal(created))
+
+			updated := fetched.DeepCopy()
+			updated.Labels = map[string]string{"hello": "world"}
+			Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(fetched).To(Equal(updated))
+
+			Expect(k8sClient.Delete(ctx, fetched)).To(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil
+			}, timeout, interval).Should(BeFalse())
+		})
+	})
+})

--- a/api/v1/webhook_suite_test.go
+++ b/api/v1/webhook_suite_test.go
@@ -22,6 +22,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -38,10 +39,9 @@ var cancel context.CancelFunc
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	// FIXME: We need to specify namespace ".Values.namespace".
-	// RunSpecsWithDefaultAndCustomReporters(t,
-	// 	"Webhook Suite",
-	// 	[]Reporter{printer.NewlineReporter{}})
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Webhook Suite",
+		[]Reporter{printer.NewlineReporter{}})
 }
 
 var _ = BeforeSuite(func() {
@@ -61,10 +61,8 @@ var _ = BeforeSuite(func() {
 	var err error
 	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()
-	// FIXME: We need to specify namespace ".Values.namespace".
-	// but this fails here
-	// Expect(err).NotTo(HaveOccurred())
-	// Expect(cfg).NotTo(BeNil())
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
 
 	scheme := runtime.NewScheme()
 	err = AddToScheme(scheme)
@@ -76,10 +74,6 @@ var _ = BeforeSuite(func() {
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
-	// FIXME: We need to specify namespace ".Values.namespace".
-	// but this fails here
-	// Expect(err).NotTo(HaveOccurred())
-	// Expect(k8sClient).NotTo(BeNil())
 
 	// start webhook server using Manager
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
@@ -91,8 +85,6 @@ var _ = BeforeSuite(func() {
 		LeaderElection:     false,
 		MetricsBindAddress: "0",
 	})
-	// FIXME: We need to specify namespace ".Values.namespace".
-	// Expect(err).NotTo(HaveOccurred())
 
 	err = (&DataNetwork{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())

--- a/common/common_suite_test.go
+++ b/common/common_suite_test.go
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2022 Wind River Systems, Inc. */
+package common
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommon(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Common Suite")
+}

--- a/common/utilities_test.go
+++ b/common/utilities_test.go
@@ -1,348 +1,352 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
 
 package common
 
 import (
 	"reflect"
-	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
-func TestIsIPv4(t *testing.T) {
-	type args struct {
-		address string
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{name: "any",
-			args: args{address: "0.0.0.0"},
-			want: true},
-		{name: "normal",
-			args: args{address: "1.2.3.4"},
-			want: true},
-		{name: "ipv6-to-ipv4-mapped",
-			args: args{address: "::ffff:1.2.3.4"},
-			want: true},
-		{name: "invalid-fqdn",
-			args: args{address: "a.b.c.d"},
-			want: false},
-		{name: "invalid-too-many-octets",
-			args: args{address: "1.2.3.4.5"},
-			want: false},
-		{name: "invalid-ipv6",
-			args: args{address: "fd00::1"},
-			want: false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := IsIPv4(tt.args.address); got != tt.want {
-				t.Errorf("IsIPv4() = %v, want %v", got, tt.want)
-			}
+var _ = Describe("Common utils", func() {
+	Describe("IsIPv4 utility", func() {
+		Context("with address data", func() {
+			It("should determin IPv4 address", func() {
+				type args struct {
+					address string
+				}
+				tests := []struct {
+					name string
+					args args
+					want bool
+				}{
+					{name: "any",
+						args: args{address: "0.0.0.0"},
+						want: true},
+					{name: "normal",
+						args: args{address: "1.2.3.4"},
+						want: true},
+					{name: "ipv6-to-ipv4-mapped",
+						args: args{address: "::ffff:1.2.3.4"},
+						want: true},
+					{name: "invalid-fqdn",
+						args: args{address: "a.b.c.d"},
+						want: false},
+					{name: "invalid-too-many-octets",
+						args: args{address: "1.2.3.4.5"},
+						want: false},
+					{name: "invalid-ipv6",
+						args: args{address: "fd00::1"},
+						want: false},
+				}
+				for _, tt := range tests {
+					got := IsIPv4(tt.args.address)
+					Expect(got).To(Equal(tt.want))
+				}
+			})
 		})
-	}
-}
+	})
 
-func TestIsIPv6(t *testing.T) {
-	type args struct {
-		address string
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{name: "any",
-			args: args{address: "::"},
-			want: true},
-		{name: "normal",
-			args: args{address: "fd00::1:2:3:4"},
-			want: true},
-		{name: "ipv6-to-ipv4-mapped",
-			args: args{address: "::ffff:1.2.3.4"},
-			want: false},
-		{name: "invalid-fqdn",
-			args: args{address: "a.b.c.d"},
-			want: false},
-		{name: "invalid-too-many-octets",
-			args: args{address: "a:b:c:d:e:f:g:h:i"},
-			want: false},
-		{name: "invalid-too-many-expansions",
-			args: args{address: "fd00::1::2"},
-			want: false},
-		{name: "invalid-ipv6",
-			args: args{address: "fd00::asdf"},
-			want: false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := IsIPv6(tt.args.address); got != tt.want {
-				t.Errorf("IsIPv6() = %v, want %v", got, tt.want)
-			}
+	Describe("IsIPv6 utility", func() {
+		Context("with address data", func() {
+			It("should determin IPv6 address", func() {
+				type args struct {
+					address string
+				}
+				tests := []struct {
+					name string
+					args args
+					want bool
+				}{
+					{name: "any",
+						args: args{address: "::"},
+						want: true},
+					{name: "normal",
+						args: args{address: "fd00::1:2:3:4"},
+						want: true},
+					{name: "ipv6-to-ipv4-mapped",
+						args: args{address: "::ffff:1.2.3.4"},
+						want: false},
+					{name: "invalid-fqdn",
+						args: args{address: "a.b.c.d"},
+						want: false},
+					{name: "invalid-too-many-octets",
+						args: args{address: "a:b:c:d:e:f:g:h:i"},
+						want: false},
+					{name: "invalid-too-many-expansions",
+						args: args{address: "fd00::1::2"},
+						want: false},
+					{name: "invalid-ipv6",
+						args: args{address: "fd00::asdf"},
+						want: false},
+				}
+				for _, tt := range tests {
+					got := IsIPv6(tt.args.address)
+					Expect(got).To(Equal(tt.want))
+				}
+			})
 		})
-	}
-}
+	})
 
-func Test_ListDelta(t *testing.T) {
-	empty := make([]string, 0)
-	type args struct {
-		a []string
-		b []string
-	}
-	tests := []struct {
-		name        string
-		args        args
-		wantAdded   []string
-		wantRemoved []string
-		wantSame    []string
-	}{
-		{name: "add_first",
-			args: args{a: []string{},
-				b: []string{"1"}},
-			wantAdded:   []string{"1"},
-			wantRemoved: empty,
-			wantSame:    empty},
-		{name: "add_second",
-			args: args{a: []string{"2"},
-				b: []string{"1", "2"}},
-			wantAdded:   []string{"1"},
-			wantRemoved: empty,
-			wantSame:    []string{"2"}},
-		{name: "add_multiple",
-			args: args{a: []string{"2"},
-				b: []string{"1", "2", "3", "4"}},
-			wantAdded:   []string{"1", "3", "4"},
-			wantRemoved: empty,
-			wantSame:    []string{"2"}},
-		{name: "remove_last",
-			args: args{a: []string{"1"},
-				b: []string{}},
-			wantAdded:   empty,
-			wantRemoved: []string{"1"},
-			wantSame:    empty},
-		{name: "remove_one",
-			args: args{a: []string{"1", "2"},
-				b: []string{"2"}},
-			wantAdded:   empty,
-			wantRemoved: []string{"1"},
-			wantSame:    []string{"2"}},
-		{name: "remove_multiple",
-			args: args{a: []string{"1", "2", "3", "4"},
-				b: []string{"2"}},
-			wantAdded:   empty,
-			wantRemoved: []string{"1", "3", "4"},
-			wantSame:    []string{"2"}},
-		{name: "identical",
-			args: args{a: []string{"1"},
-				b: []string{"1"}},
-			wantAdded:   empty,
-			wantRemoved: empty,
-			wantSame:    []string{"1"}},
-	}
+	Describe("ListDelta utility", func() {
+		Context("with two lists", func() {
+			It("should calculate the difference", func() {
+				empty := make([]string, 0)
+				type args struct {
+					a []string
+					b []string
+				}
+				tests := []struct {
+					name        string
+					args        args
+					wantAdded   []string
+					wantRemoved []string
+					wantSame    []string
+				}{
+					{name: "add_first",
+						args: args{a: []string{},
+							b: []string{"1"}},
+						wantAdded:   []string{"1"},
+						wantRemoved: empty,
+						wantSame:    empty},
+					{name: "add_second",
+						args: args{a: []string{"2"},
+							b: []string{"1", "2"}},
+						wantAdded:   []string{"1"},
+						wantRemoved: empty,
+						wantSame:    []string{"2"}},
+					{name: "add_multiple",
+						args: args{a: []string{"2"},
+							b: []string{"1", "2", "3", "4"}},
+						wantAdded:   []string{"1", "3", "4"},
+						wantRemoved: empty,
+						wantSame:    []string{"2"}},
+					{name: "remove_last",
+						args: args{a: []string{"1"},
+							b: []string{}},
+						wantAdded:   empty,
+						wantRemoved: []string{"1"},
+						wantSame:    empty},
+					{name: "remove_one",
+						args: args{a: []string{"1", "2"},
+							b: []string{"2"}},
+						wantAdded:   empty,
+						wantRemoved: []string{"1"},
+						wantSame:    []string{"2"}},
+					{name: "remove_multiple",
+						args: args{a: []string{"1", "2", "3", "4"},
+							b: []string{"2"}},
+						wantAdded:   empty,
+						wantRemoved: []string{"1", "3", "4"},
+						wantSame:    []string{"2"}},
+					{name: "identical",
+						args: args{a: []string{"1"},
+							b: []string{"1"}},
+						wantAdded:   empty,
+						wantRemoved: empty,
+						wantSame:    []string{"1"}},
+				}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotAdded, gotRemoved, gotSame := ListDelta(tt.args.a, tt.args.b)
-			if !reflect.DeepEqual(gotAdded, tt.wantAdded) {
-				t.Errorf("ListDelta() gotAdded = %v, want %v", gotAdded, tt.wantAdded)
-			}
-			if !reflect.DeepEqual(gotRemoved, tt.wantRemoved) {
-				t.Errorf("ListDelta() gotRemoved = %v, want %v", gotRemoved, tt.wantRemoved)
-			}
-			if !reflect.DeepEqual(gotSame, tt.wantSame) {
-				t.Errorf("ListDelta() gotSame = %v, want %v", gotSame, tt.wantSame)
-			}
+				for _, tt := range tests {
+					gotAdded, gotRemoved, gotSame := ListDelta(tt.args.a, tt.args.b)
+					Expect(reflect.DeepEqual(gotAdded, tt.wantAdded)).To(BeTrue())
+					Expect(reflect.DeepEqual(gotRemoved, tt.wantRemoved)).To(BeTrue())
+					Expect(reflect.DeepEqual(gotSame, tt.wantSame)).To(BeTrue())
+				}
+			})
 		})
-	}
-}
+	})
 
-func Test_ListChanged(t *testing.T) {
-	type args struct {
-		a []string
-		b []string
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{name: "compare_with_empty",
-			args: args{a: []string{},
-				b: []string{"1"}},
-			want: true},
-		{name: "compare_with_non_empty",
-			args: args{a: []string{"2"},
-				b: []string{"1", "2"}},
-			want: true},
-		{name: "compare_to_empty",
-			args: args{a: []string{"1"},
-				b: []string{}},
-			want: true},
-		{name: "compare_to_non_empty",
-			args: args{a: []string{"1", "2"},
-				b: []string{"2"}},
-			want: true},
-		{name: "identical",
-			args: args{a: []string{"1"},
-				b: []string{"1"}},
-			want: false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := ListChanged(tt.args.a, tt.args.b); got != tt.want {
-				t.Errorf("ListChanged() = %v, want %v", got, tt.want)
-			}
+	Describe("ListChanged utility", func() {
+		Context("with two string arrays", func() {
+			It("should identify changed", func() {
+				type args struct {
+					a []string
+					b []string
+				}
+				tests := []struct {
+					name string
+					args args
+					want bool
+				}{
+					{name: "compare_with_empty",
+						args: args{a: []string{},
+							b: []string{"1"}},
+						want: true},
+					{name: "compare_with_non_empty",
+						args: args{a: []string{"2"},
+							b: []string{"1", "2"}},
+						want: true},
+					{name: "compare_to_empty",
+						args: args{a: []string{"1"},
+							b: []string{}},
+						want: true},
+					{name: "compare_to_non_empty",
+						args: args{a: []string{"1", "2"},
+							b: []string{"2"}},
+						want: true},
+					{name: "identical",
+						args: args{a: []string{"1"},
+							b: []string{"1"}},
+						want: false},
+				}
+				for _, tt := range tests {
+					got := ListChanged(tt.args.a, tt.args.b)
+					Expect(got).To(Equal(tt.want))
+				}
+			})
 		})
-	}
-}
+	})
 
-func TestListIntersect(t *testing.T) {
-	type args struct {
-		a []string
-		b []string
-	}
-	tests := []struct {
-		name  string
-		args  args
-		want  []string
-		want1 bool
-	}{
-		{name: "same",
-			args: args{a: []string{"a", "b"},
-				b: []string{"b", "a"}},
-			want:  []string{"a", "b"},
-			want1: true},
-		{name: "empty",
-			args: args{a: []string{},
-				b: []string{}},
-			want:  []string{},
-			want1: false},
-		{name: "intersect",
-			args: args{a: []string{"a", "b"},
-				b: []string{"b", "c"}},
-			want:  []string{"b"},
-			want1: true},
-		{name: "no-intersect",
-			args: args{a: []string{"a", "b"},
-				b: []string{"c", "d"}},
-			want:  []string{},
-			want1: false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, got1 := ListIntersect(tt.args.a, tt.args.b)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ListIntersect() got = %v, want %v", got, tt.want)
-			}
-			if got1 != tt.want1 {
-				t.Errorf("ListIntersect() got1 = %v, want %v", got1, tt.want1)
-			}
+	Describe("ListIntersect utility", func() {
+		Context("with two string arrays", func() {
+			It("should identify commonality", func() {
+				type args struct {
+					a []string
+					b []string
+				}
+				tests := []struct {
+					name  string
+					args  args
+					want  []string
+					want1 bool
+				}{
+					{name: "same",
+						args: args{a: []string{"a", "b"},
+							b: []string{"b", "a"}},
+						want:  []string{"a", "b"},
+						want1: true},
+					{name: "empty",
+						args: args{a: []string{},
+							b: []string{}},
+						want:  []string{},
+						want1: false},
+					{name: "intersect",
+						args: args{a: []string{"a", "b"},
+							b: []string{"b", "c"}},
+						want:  []string{"b"},
+						want1: true},
+					{name: "no-intersect",
+						args: args{a: []string{"a", "b"},
+							b: []string{"c", "d"}},
+						want:  []string{},
+						want1: false},
+				}
+				for _, tt := range tests {
+					got, got1 := ListIntersect(tt.args.a, tt.args.b)
+					Expect(reflect.DeepEqual(got, tt.want)).To(BeTrue())
+					Expect(got1).To(Equal(tt.want1))
+				}
+			})
 		})
-	}
-}
+	})
 
-func TestComparePartitionPaths(t *testing.T) {
-	type args struct {
-		a string
-		b string
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{name: "same-disks",
-			args: args{a: "/dev/disk/by-path/pci-0000:00:1f.2-ata-5.0",
-				b: "/dev/disk/by-path/pci-0000:00:1f.2-ata-5.0"},
-			want: true},
-		{name: "different-disks",
-			args: args{a: "/dev/disk/by-path/pci-0000:00:1f.2-ata-5.0",
-				b: "/dev/disk/by-path/pci-0000:00:1f.3-ata-6.0"},
-			want: false},
-		{name: "same-disk-partitions",
-			args: args{a: "/dev/disk/by-path/pci-0000:00:1f.2-ata-5.0-part1",
-				b: "/dev/disk/by-path/pci-0000:00:1f.2-ata-5.0-part1"},
-			want: true},
-		{name: "different-disks-partitions",
-			args: args{a: "/dev/disk/by-path/pci-0000:00:1f.2-ata-5.0-part1",
-				b: "/dev/disk/by-path/pci-0000:00:1f.3-ata-6.0-part1"},
-			want: false},
-		{name: "different-partitions",
-			args: args{a: "/dev/disk/by-path/pci-0000:00:1f.2-ata-5.0-part1",
-				b: "/dev/disk/by-path/pci-0000:00:1f.2-ata-5.0-part2"},
-			want: true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := ComparePartitionPaths(tt.args.a, tt.args.b); got != tt.want {
-				t.Errorf("ComparePartitionPaths() = %v, want %v", got, tt.want)
-			}
+	Describe("ComparePartitionPaths utility", func() {
+		Context("with two string", func() {
+			It("should identify disk portion matched", func() {
+				type args struct {
+					a string
+					b string
+				}
+				tests := []struct {
+					name string
+					args args
+					want bool
+				}{
+					{name: "same-disks",
+						args: args{a: "/dev/disk/by-path/pci-0000:00:1f.2-ata-5.0",
+							b: "/dev/disk/by-path/pci-0000:00:1f.2-ata-5.0"},
+						want: true},
+					{name: "different-disks",
+						args: args{a: "/dev/disk/by-path/pci-0000:00:1f.2-ata-5.0",
+							b: "/dev/disk/by-path/pci-0000:00:1f.3-ata-6.0"},
+						want: false},
+					{name: "same-disk-partitions",
+						args: args{a: "/dev/disk/by-path/pci-0000:00:1f.2-ata-5.0-part1",
+							b: "/dev/disk/by-path/pci-0000:00:1f.2-ata-5.0-part1"},
+						want: true},
+					{name: "different-disks-partitions",
+						args: args{a: "/dev/disk/by-path/pci-0000:00:1f.2-ata-5.0-part1",
+							b: "/dev/disk/by-path/pci-0000:00:1f.3-ata-6.0-part1"},
+						want: false},
+					{name: "different-partitions",
+						args: args{a: "/dev/disk/by-path/pci-0000:00:1f.2-ata-5.0-part1",
+							b: "/dev/disk/by-path/pci-0000:00:1f.2-ata-5.0-part2"},
+						want: true},
+				}
+				for _, tt := range tests {
+					got := ComparePartitionPaths(tt.args.a, tt.args.b)
+					Expect(got).To(Equal(tt.want))
+				}
+			})
 		})
-	}
-}
+	})
 
-func TestContainsString(t *testing.T) {
-	type args struct {
-		slice []string
-		s     string
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{name: "included",
-			args: args{slice: []string{"abc", "def"},
-				s: "abc"},
-			want: true},
-		{name: "not-included",
-			args: args{slice: []string{"abc", "def"},
-				s: "xyz"},
-			want: false},
-		{name: "substring-not-included",
-			args: args{slice: []string{"abc", "def"},
-				s: "a"},
-			want: false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := ContainsString(tt.args.slice, tt.args.s); got != tt.want {
-				t.Errorf("ContainsString() = %v, want %v", got, tt.want)
-			}
+	Describe("ContainsString utility", func() {
+		Context("with two string", func() {
+			It("should identify contained", func() {
+				type args struct {
+					slice []string
+					s     string
+				}
+				tests := []struct {
+					name string
+					args args
+					want bool
+				}{
+					{name: "included",
+						args: args{slice: []string{"abc", "def"},
+							s: "abc"},
+						want: true},
+					{name: "not-included",
+						args: args{slice: []string{"abc", "def"},
+							s: "xyz"},
+						want: false},
+					{name: "substring-not-included",
+						args: args{slice: []string{"abc", "def"},
+							s: "a"},
+						want: false},
+				}
+				for _, tt := range tests {
+					got := ContainsString(tt.args.slice, tt.args.s)
+					Expect(got).To(Equal(tt.want))
+				}
+			})
 		})
-	}
-}
+	})
 
-func TestRemoveString(t *testing.T) {
-	type args struct {
-		slice []string
-		s     string
-	}
-	tests := []struct {
-		name       string
-		args       args
-		wantResult []string
-	}{
-		{name: "included",
-			args: args{slice: []string{"abc", "def"},
-				s: "abc"},
-			wantResult: []string{"def"}},
-		{name: "not-included",
-			args: args{slice: []string{"abc", "def"},
-				s: "xyz"},
-			wantResult: []string{"abc", "def"}},
-		{name: "substring-not-included",
-			args: args{slice: []string{"abc", "def"},
-				s: "a"},
-			wantResult: []string{"abc", "def"}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if gotResult := RemoveString(tt.args.slice, tt.args.s); !reflect.DeepEqual(gotResult, tt.wantResult) {
-				t.Errorf("RemoveString() = %v, want %v", gotResult, tt.wantResult)
-			}
+	Describe("RemoveString utility", func() {
+		Context("with string and list", func() {
+			It("should remove string from list", func() {
+				type args struct {
+					slice []string
+					s     string
+				}
+				tests := []struct {
+					name       string
+					args       args
+					wantResult []string
+				}{
+					{name: "included",
+						args: args{slice: []string{"abc", "def"},
+							s: "abc"},
+						wantResult: []string{"def"}},
+					{name: "not-included",
+						args: args{slice: []string{"abc", "def"},
+							s: "xyz"},
+						wantResult: []string{"abc", "def"}},
+					{name: "substring-not-included",
+						args: args{slice: []string{"abc", "def"},
+							s: "a"},
+						wantResult: []string{"abc", "def"}},
+				}
+				for _, tt := range tests {
+					gotResult := RemoveString(tt.args.slice, tt.args.s)
+					Expect(reflect.DeepEqual(gotResult, tt.wantResult)).To(BeTrue())
+				}
+			})
 		})
-	}
-}
+	})
+})

--- a/controllers/common/common_suite_test.go
+++ b/controllers/common/common_suite_test.go
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2022 Wind River Systems, Inc. */
+package common
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommon(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Common Suite")
+}

--- a/controllers/common/merge_test.go
+++ b/controllers/common/merge_test.go
@@ -1,0 +1,487 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+
+package common
+
+import (
+	"encoding/json"
+	"reflect"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/imdario/mergo"
+	v1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
+)
+
+var _ = Describe("MergeTransformer utils", func() {
+	Describe("merge", func() {
+		Context("with profile spec data", func() {
+			It("should merge successfully", func() {
+				type args struct {
+					dst *v1.HostProfileSpec
+					src *v1.HostProfileSpec
+				}
+				base1 := "base1"
+				base2 := "base2"
+				tests := []struct {
+					name       string
+					args       args
+					wantErr    bool
+					wantStruct v1.HostProfileSpec
+				}{
+					{name: "string-overwrite-nil-pointer",
+						args: args{
+							dst: &v1.HostProfileSpec{
+								Base: nil,
+							},
+							src: &v1.HostProfileSpec{
+								Base: &base1,
+							},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							Base: &base1,
+						},
+					},
+					{name: "string-no-overwrite-from-nil-pointer",
+						args: args{
+							dst: &v1.HostProfileSpec{
+								Base: &base1,
+							},
+							src: &v1.HostProfileSpec{
+								Base: nil,
+							},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							Base: &base1,
+						},
+					},
+					{name: "string-overwrite",
+						args: args{
+							dst: &v1.HostProfileSpec{
+								Base: &base1,
+							},
+							src: &v1.HostProfileSpec{
+								Base: &base2,
+							},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							Base: &base2,
+						},
+					},
+					{name: "struct-overwrite-nil",
+						args: args{
+							dst: &v1.HostProfileSpec{
+								Storage: nil,
+							},
+							src: &v1.HostProfileSpec{
+								Storage: &v1.ProfileStorageInfo{
+									FileSystems: &v1.FileSystemList{
+										v1.FileSystemInfo{Name: "backup"},
+									},
+								},
+							},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							Storage: &v1.ProfileStorageInfo{
+								FileSystems: &v1.FileSystemList{
+									v1.FileSystemInfo{Name: "backup"},
+								},
+							},
+						},
+					},
+					{name: "struct-no-overwrite-from-nil",
+						args: args{
+							dst: &v1.HostProfileSpec{
+								Storage: &v1.ProfileStorageInfo{
+									FileSystems: &v1.FileSystemList{
+										v1.FileSystemInfo{Name: "backup"},
+									},
+								},
+							},
+							src: &v1.HostProfileSpec{
+								Storage: nil,
+							},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							Storage: &v1.ProfileStorageInfo{
+								FileSystems: &v1.FileSystemList{
+									v1.FileSystemInfo{Name: "backup"},
+								},
+							},
+						},
+					},
+					{name: "slice-pointer-overwrite-nil",
+						args: args{
+							dst: &v1.HostProfileSpec{
+								Storage: &v1.ProfileStorageInfo{},
+							},
+							src: &v1.HostProfileSpec{
+								Storage: &v1.ProfileStorageInfo{
+									FileSystems: &v1.FileSystemList{
+										v1.FileSystemInfo{Name: "backup"},
+									},
+								},
+							},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							Storage: &v1.ProfileStorageInfo{
+								FileSystems: &v1.FileSystemList{
+									v1.FileSystemInfo{Name: "backup"},
+								},
+							},
+						},
+					},
+					{name: "slice-pointer-no-overwrite-from-nil",
+						args: args{
+							dst: &v1.HostProfileSpec{
+								Storage: &v1.ProfileStorageInfo{
+									FileSystems: &v1.FileSystemList{
+										v1.FileSystemInfo{Name: "backup"},
+									},
+								},
+							},
+							src: &v1.HostProfileSpec{
+								Storage: &v1.ProfileStorageInfo{},
+							},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							Storage: &v1.ProfileStorageInfo{
+								FileSystems: &v1.FileSystemList{
+									v1.FileSystemInfo{Name: "backup"},
+								},
+							},
+						},
+					},
+					{name: "slice-pointer-with-key-merge",
+						args: args{
+							dst: &v1.HostProfileSpec{
+								Storage: &v1.ProfileStorageInfo{
+									FileSystems: &v1.FileSystemList{
+										v1.FileSystemInfo{Name: "backup", Size: 10},
+									},
+								},
+							},
+							src: &v1.HostProfileSpec{
+								Storage: &v1.ProfileStorageInfo{
+									FileSystems: &v1.FileSystemList{
+										v1.FileSystemInfo{Name: "backup", Size: 20},
+									},
+								},
+							},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							Storage: &v1.ProfileStorageInfo{
+								FileSystems: &v1.FileSystemList{
+									v1.FileSystemInfo{Name: "backup", Size: 20},
+								},
+							},
+						},
+					},
+					{name: "slice-pointer-with-key-append",
+						args: args{
+							dst: &v1.HostProfileSpec{
+								Storage: &v1.ProfileStorageInfo{
+									FileSystems: &v1.FileSystemList{
+										v1.FileSystemInfo{Name: "backup"},
+									},
+								},
+							},
+							src: &v1.HostProfileSpec{
+								Storage: &v1.ProfileStorageInfo{
+									FileSystems: &v1.FileSystemList{
+										v1.FileSystemInfo{Name: "docker"},
+									},
+								},
+							},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							Storage: &v1.ProfileStorageInfo{
+								FileSystems: &v1.FileSystemList{
+									v1.FileSystemInfo{Name: "backup"},
+									v1.FileSystemInfo{Name: "docker"},
+								},
+							},
+						},
+					},
+					{name: "slice-without-key",
+						args: args{
+							dst: &v1.HostProfileSpec{
+								ProfileBaseAttributes: v1.ProfileBaseAttributes{
+									SubFunctions: []v1.SubFunction{"sub1", "sub2"},
+								},
+							},
+							src: &v1.HostProfileSpec{},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							ProfileBaseAttributes: v1.ProfileBaseAttributes{
+								SubFunctions: []v1.SubFunction{"sub1", "sub2"},
+							},
+						},
+					},
+					{name: "slice-without-key-replace",
+						args: args{
+							dst: &v1.HostProfileSpec{
+								ProfileBaseAttributes: v1.ProfileBaseAttributes{
+									SubFunctions: []v1.SubFunction{"sub1", "sub2"},
+								},
+							},
+							src: &v1.HostProfileSpec{
+								ProfileBaseAttributes: v1.ProfileBaseAttributes{
+									SubFunctions: []v1.SubFunction{"sub10", "sub20"},
+								},
+							},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							ProfileBaseAttributes: v1.ProfileBaseAttributes{
+								SubFunctions: []v1.SubFunction{"sub10", "sub20"},
+							},
+						},
+					},
+					{name: "slice-without-key-reset-to-empty",
+						args: args{
+							dst: &v1.HostProfileSpec{
+								ProfileBaseAttributes: v1.ProfileBaseAttributes{
+									SubFunctions: []v1.SubFunction{"sub1", "sub2"},
+								},
+							},
+							src: &v1.HostProfileSpec{
+								ProfileBaseAttributes: v1.ProfileBaseAttributes{
+									SubFunctions: []v1.SubFunction{},
+								},
+							},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							ProfileBaseAttributes: v1.ProfileBaseAttributes{
+								SubFunctions: []v1.SubFunction{},
+							},
+						},
+					},
+					{name: "slice-without-key-overwrite-empty",
+						args: args{
+							dst: &v1.HostProfileSpec{
+								ProfileBaseAttributes: v1.ProfileBaseAttributes{
+									SubFunctions: []v1.SubFunction{},
+								},
+							},
+							src: &v1.HostProfileSpec{
+								ProfileBaseAttributes: v1.ProfileBaseAttributes{
+									SubFunctions: []v1.SubFunction{"sub1", "sub2"},
+								},
+							},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							ProfileBaseAttributes: v1.ProfileBaseAttributes{
+								SubFunctions: []v1.SubFunction{"sub1", "sub2"},
+							},
+						},
+					},
+					{name: "slice-with-key-no-overwrite-from-nil",
+						args: args{
+							dst: &v1.HostProfileSpec{
+								Interfaces: &v1.InterfaceInfo{
+									Ethernet: v1.EthernetList{
+										v1.EthernetInfo{
+											CommonInterfaceInfo: v1.CommonInterfaceInfo{Name: "eth0"},
+											Port:                v1.EthernetPortInfo{Name: "eth0"},
+										},
+									}}},
+							src: &v1.HostProfileSpec{},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							Interfaces: &v1.InterfaceInfo{
+								Ethernet: v1.EthernetList{
+									v1.EthernetInfo{
+										CommonInterfaceInfo: v1.CommonInterfaceInfo{Name: "eth0"},
+										Port:                v1.EthernetPortInfo{Name: "eth0"},
+									},
+								},
+							},
+						},
+					},
+					{name: "slice-with-key-overwrite-nil",
+						args: args{
+							dst: &v1.HostProfileSpec{},
+							src: &v1.HostProfileSpec{
+								Interfaces: &v1.InterfaceInfo{
+									Ethernet: v1.EthernetList{
+										v1.EthernetInfo{
+											CommonInterfaceInfo: v1.CommonInterfaceInfo{Name: "eth0"},
+											Port:                v1.EthernetPortInfo{Name: "eth0"},
+										},
+									},
+								},
+							},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							Interfaces: &v1.InterfaceInfo{
+								Ethernet: v1.EthernetList{
+									v1.EthernetInfo{
+										CommonInterfaceInfo: v1.CommonInterfaceInfo{Name: "eth0"},
+										Port:                v1.EthernetPortInfo{Name: "eth0"},
+									},
+								},
+							},
+						},
+					},
+					{name: "slice-with-key-overwrite-empty",
+						args: args{
+							dst: &v1.HostProfileSpec{
+								Interfaces: &v1.InterfaceInfo{
+									Ethernet: v1.EthernetList{}},
+							},
+							src: &v1.HostProfileSpec{
+								Interfaces: &v1.InterfaceInfo{
+									Ethernet: v1.EthernetList{
+										v1.EthernetInfo{
+											CommonInterfaceInfo: v1.CommonInterfaceInfo{Name: "eth0"},
+											Port:                v1.EthernetPortInfo{Name: "eth0"},
+										},
+									},
+								},
+							},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							Interfaces: &v1.InterfaceInfo{
+								Ethernet: v1.EthernetList{
+									v1.EthernetInfo{
+										CommonInterfaceInfo: v1.CommonInterfaceInfo{Name: "eth0"},
+										Port:                v1.EthernetPortInfo{Name: "eth0"},
+									},
+								},
+							},
+						},
+					},
+					{name: "slice-with-key-overwrite-with-empty",
+						args: args{
+							dst: &v1.HostProfileSpec{
+								Interfaces: &v1.InterfaceInfo{
+									Ethernet: v1.EthernetList{
+										v1.EthernetInfo{
+											CommonInterfaceInfo: v1.CommonInterfaceInfo{Name: "eth0"},
+											Port:                v1.EthernetPortInfo{Name: "eth0"},
+										},
+									},
+								},
+							},
+							src: &v1.HostProfileSpec{
+								Interfaces: &v1.InterfaceInfo{
+									Ethernet: v1.EthernetList{}},
+							},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							Interfaces: &v1.InterfaceInfo{
+								Ethernet: v1.EthernetList{},
+							},
+						},
+					},
+					{name: "slice-with-key-merge-elements",
+						args: args{
+							dst: &v1.HostProfileSpec{
+								Interfaces: &v1.InterfaceInfo{
+									Ethernet: v1.EthernetList{
+										v1.EthernetInfo{
+											CommonInterfaceInfo: v1.CommonInterfaceInfo{Name: "eth0"},
+											Port:                v1.EthernetPortInfo{Name: "eth0"},
+										},
+									},
+								},
+							},
+							src: &v1.HostProfileSpec{
+								Interfaces: &v1.InterfaceInfo{
+									Ethernet: v1.EthernetList{
+										v1.EthernetInfo{
+											CommonInterfaceInfo: v1.CommonInterfaceInfo{Name: "mgmt0"},
+											Port:                v1.EthernetPortInfo{Name: "eth0"},
+										},
+									},
+								},
+							},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							Interfaces: &v1.InterfaceInfo{
+								Ethernet: v1.EthernetList{
+									v1.EthernetInfo{
+										CommonInterfaceInfo: v1.CommonInterfaceInfo{Name: "mgmt0"},
+										Port:                v1.EthernetPortInfo{Name: "eth0"},
+									},
+								},
+							},
+						},
+					},
+					{name: "slice-with-key-append-elements",
+						args: args{
+							dst: &v1.HostProfileSpec{
+								Interfaces: &v1.InterfaceInfo{
+									Ethernet: v1.EthernetList{
+										v1.EthernetInfo{
+											CommonInterfaceInfo: v1.CommonInterfaceInfo{Name: "eth0"},
+											Port:                v1.EthernetPortInfo{Name: "eth0"},
+										},
+									},
+								},
+							},
+							src: &v1.HostProfileSpec{
+								Interfaces: &v1.InterfaceInfo{
+									Ethernet: v1.EthernetList{
+										v1.EthernetInfo{
+											CommonInterfaceInfo: v1.CommonInterfaceInfo{Name: "mgmt0"},
+											Port:                v1.EthernetPortInfo{Name: "eth0"},
+										},
+										v1.EthernetInfo{
+											CommonInterfaceInfo: v1.CommonInterfaceInfo{Name: "eth1"},
+											Port:                v1.EthernetPortInfo{Name: "eth1"},
+										},
+									},
+								},
+							},
+						},
+						wantErr: false,
+						wantStruct: v1.HostProfileSpec{
+							Interfaces: &v1.InterfaceInfo{
+								Ethernet: v1.EthernetList{
+									v1.EthernetInfo{
+										CommonInterfaceInfo: v1.CommonInterfaceInfo{Name: "mgmt0"},
+										Port:                v1.EthernetPortInfo{Name: "eth0"},
+									},
+									v1.EthernetInfo{
+										CommonInterfaceInfo: v1.CommonInterfaceInfo{Name: "eth1"},
+										Port:                v1.EthernetPortInfo{Name: "eth1"},
+									},
+								},
+							},
+						},
+					},
+				}
+				for _, tt := range tests {
+					err := mergo.Merge(tt.args.dst, tt.args.src, mergo.WithOverride, mergo.WithTransformers(DefaultMergeTransformer))
+					Expect(err != nil).To(Equal(tt.wantErr))
+					if !reflect.DeepEqual(*tt.args.dst, tt.wantStruct) {
+						dstBuf, err := json.Marshal(*tt.args.dst)
+						Expect(err != nil).To(BeNil())
+						wantBuf, _ := json.Marshal(tt.wantStruct)
+						Expect(dstBuf).To(Equal(wantBuf))
+					}
+				}
+			})
+		})
+	})
+})

--- a/controllers/datanetwork_controller_test.go
+++ b/controllers/datanetwork_controller_test.go
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2022 Wind River Systems, Inc. */
+package controllers
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
+	comm "github.com/wind-river/cloud-platform-deployment-manager/common"
+)
+
+var _ = Describe("Datanetwork controller", func() {
+
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	Context("DataNetwork with data", func() {
+		It("Should created successfully", func() {
+			ctx := context.Background()
+			key := types.NamespacedName{
+				Name:      "foo",
+				Namespace: "default",
+			}
+			mtu := 1500
+			description := "This is a sample description"
+
+			created := &starlingxv1.DataNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+				Spec: starlingxv1.DataNetworkSpec{
+					Type:        "flat",
+					Description: &description,
+					MTU:         &mtu,
+				}}
+			Expect(k8sClient.Create(ctx, created)).To(Succeed())
+
+			expected := created.DeepCopy()
+
+			fetched := &starlingxv1.DataNetwork{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil &&
+					fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion
+			}, timeout, interval).Should(BeTrue())
+			_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{DataNetworkFinalizerName})
+			Expect(found).To(BeTrue())
+		})
+	})
+})

--- a/controllers/host/host_controller_test.go
+++ b/controllers/host/host_controller_test.go
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+package host
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
+	comm "github.com/wind-river/cloud-platform-deployment-manager/common"
+)
+
+var _ = Describe("Host controller", func() {
+
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	Context("Host with data", func() {
+		It("Should created successfully", func() {
+			ctx := context.Background()
+			key := types.NamespacedName{
+				Name:      "foo",
+				Namespace: "default",
+			}
+			bootMac := "01:02:03:04:05:06"
+			bmAddress := "192.168.9.9"
+			match := starlingxv1.MatchInfo{
+				BootMAC: &bootMac,
+			}
+			bmType := "bmc"
+			created := &starlingxv1.Host{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+				Spec: starlingxv1.HostSpec{
+					Profile: "some-profile",
+					Match:   &match,
+					Overrides: &starlingxv1.HostProfileSpec{
+						Addresses: []starlingxv1.AddressInfo{
+							{Interface: "enp0s3", Address: "1.2.3.10", Prefix: 24},
+						},
+						BoardManagement: &starlingxv1.BMInfo{
+							Type:    &bmType,
+							Address: &bmAddress,
+						},
+					},
+				}}
+			Expect(k8sClient.Create(ctx, created)).To(Succeed())
+
+			expected := created.DeepCopy()
+
+			fetched := &starlingxv1.Host{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil &&
+					fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion
+			}, timeout, interval).Should(BeTrue())
+			_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{HostFinalizerName})
+			Expect(found).To(BeTrue())
+		})
+	})
+})

--- a/controllers/host/host_suite_test.go
+++ b/controllers/host/host_suite_test.go
@@ -1,13 +1,12 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* Copyright(c) 2019-2022 Wind River Systems, Inc. */
 
-package controllers
+package host
 
 import (
 	"context"
 	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -33,11 +32,6 @@ var testEnv *envtest.Environment
 var ctx context.Context
 var cancel context.CancelFunc
 
-const (
-	timeout  = time.Second * 60
-	interval = time.Second * 1
-)
-
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 
@@ -53,7 +47,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
+		CRDDirectoryPaths:     []string{filepath.Join("../..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 	}
 
@@ -79,36 +73,11 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	// Setup reconciler
-	// DataNetwork
-	err = (&DataNetworkReconciler{
+	// Host
+	err = (&HostReconciler{
 		Client: k8sManager.GetClient(),
 		Scheme: k8sManager.GetScheme(),
 	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-	// HostProfile
-	err = (&HostProfileReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-	// PlatformNetwork
-	err = (&PlatformNetworkReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-	// PtpInstance
-	err = (&PtpInstanceReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-	// PtpInterface
-	err = (&PtpInterfaceReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
 
 	go func() {
 		defer GinkgoRecover()
@@ -120,8 +89,6 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	cancel()
 	By("tearing down the test environment")
-	Eventually(func() bool {
-		err := testEnv.Stop()
-		return err == nil
-	}, timeout, interval).Should(BeTrue())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })

--- a/controllers/host/networking_test.go
+++ b/controllers/host/networking_test.go
@@ -1,0 +1,790 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+package host
+
+import (
+	"reflect"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/addresses"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/ports"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/routes"
+
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/interfaces"
+	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
+	v1info "github.com/wind-river/cloud-platform-deployment-manager/platform"
+)
+
+var _ = Describe("Networking utils", func() {
+	Describe("findConfiguredInterface utility", func() {
+		Context("with interface data", func() {
+			It("should find in the list", func() {
+
+				vid10 := 10
+				vid20 := 20
+				vfcount1 := 1
+				vfdriver1 := "netdevice"
+				vfdriver2 := "vfio"
+				sample := starlingxv1.HostProfileSpec{
+					Interfaces: &starlingxv1.InterfaceInfo{
+						Ethernet: starlingxv1.EthernetList{
+							starlingxv1.EthernetInfo{
+								CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{
+									Name: "lo",
+								},
+								Port: starlingxv1.EthernetPortInfo{
+									Name: "lo",
+								},
+							},
+							starlingxv1.EthernetInfo{
+								CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{
+									Name: "mgmt0",
+								},
+								Port: starlingxv1.EthernetPortInfo{
+									Name: "eth0",
+								},
+							},
+							starlingxv1.EthernetInfo{
+								CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{
+									Name: "eth1",
+								},
+								Port: starlingxv1.EthernetPortInfo{
+									Name: "eth1",
+								},
+							},
+							starlingxv1.EthernetInfo{
+								CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{
+									Name: "eth2",
+								},
+								Port: starlingxv1.EthernetPortInfo{
+									Name: "eth2",
+								},
+							},
+							starlingxv1.EthernetInfo{
+								CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{
+									Name: "member3",
+								},
+								Port: starlingxv1.EthernetPortInfo{
+									Name: "eth3",
+								},
+							},
+							starlingxv1.EthernetInfo{
+								CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{
+									Name: "member4",
+								},
+								Port: starlingxv1.EthernetPortInfo{
+									Name: "eth4",
+								},
+							},
+							starlingxv1.EthernetInfo{
+								CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{
+									Name: "sriov0",
+								},
+								Port: starlingxv1.EthernetPortInfo{
+									Name: "eth5",
+								},
+							},
+						},
+						VLAN: starlingxv1.VLANList{
+							starlingxv1.VLANInfo{
+								CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{
+									Name: "cluster0",
+								},
+								Lower: "mgmt0",
+								VID:   10,
+							},
+							starlingxv1.VLANInfo{
+								CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{
+									Name: "cluster0",
+								},
+								Lower: "bond0",
+								VID:   20,
+							},
+						},
+						Bond: starlingxv1.BondList{
+							starlingxv1.BondInfo{
+								CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{
+									Name: "infra0",
+								},
+								Members: starlingxv1.StringList{"eth1", "eth2"},
+							},
+							starlingxv1.BondInfo{
+								CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{
+									Name: "bond0",
+								},
+								Members: starlingxv1.StringList{"member3", "member4"},
+							},
+						},
+						VF: starlingxv1.VFList{
+							starlingxv1.VFInfo{
+								CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{
+									Name: "sriov1",
+								},
+								Lower:    "sriov0",
+								VFCount:  2,
+								VFDriver: &vfdriver2,
+							},
+							starlingxv1.VFInfo{
+								CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{
+									Name: "sriov2",
+								},
+								Lower:    "sriov0",
+								VFCount:  1,
+								VFDriver: &vfdriver1,
+							},
+						},
+					},
+				}
+				info := v1info.HostInfo{
+					Ports: []ports.Port{
+						{Name: "eth0",
+							InterfaceID: "uuid-eth0",
+						},
+						{Name: "eth1",
+							InterfaceID: "uuid-eth1",
+						},
+						{Name: "eth2",
+							InterfaceID: "uuid-eth2",
+						},
+						{Name: "eth3",
+							InterfaceID: "uuid-eth3",
+						},
+						{Name: "eth4",
+							InterfaceID: "uuid-eth4",
+						},
+						{Name: "eth5",
+							InterfaceID: "uuid-eth5",
+						},
+					},
+					Interfaces: []interfaces.Interface{
+						{Name: "lo",
+							Type: interfaces.IFTypeVirtual,
+						},
+						{Name: "eth0",
+							ID:   "uuid-eth0",
+							Type: interfaces.IFTypeEthernet,
+						},
+						{Name: "eth1",
+							ID:   "uuid-eth1",
+							Type: interfaces.IFTypeEthernet,
+						},
+						{Name: "eth2",
+							ID:   "uuid-eth2",
+							Type: interfaces.IFTypeEthernet,
+						},
+						{Name: "eth3",
+							ID:   "uuid-eth3",
+							Type: interfaces.IFTypeEthernet,
+						},
+						{Name: "eth4",
+							ID:   "uuid-eth4",
+							Type: interfaces.IFTypeEthernet,
+						},
+						{Name: "sriov0",
+							ID:   "uuid-eth5",
+							Type: interfaces.IFTypeEthernet,
+						},
+						{Name: "cluster0",
+							ID:   "uuid-cluster0",
+							Type: interfaces.IFTypeVLAN,
+							Uses: []string{"eth0"},
+						},
+						{Name: "vid20",
+							ID:   "uuid-vid20",
+							Type: interfaces.IFTypeVLAN,
+							Uses: []string{"infra0"},
+						},
+						{Name: "infra0",
+							ID:   "uuid-infra0",
+							Type: interfaces.IFTypeAE,
+							Uses: []string{"eth1", "eth2"},
+						},
+						{Name: "bond0",
+							ID:   "uuid-bond0",
+							Type: interfaces.IFTypeAE,
+							Uses: []string{"eth3", "eth4"},
+						},
+						{Name: "sriov1",
+							ID:   "uuid-sriov1",
+							Type: interfaces.IFTypeVF,
+							Uses: []string{"sriov0"},
+						},
+						{Name: "sriov2",
+							ID:   "uuid-sriov2",
+							Type: interfaces.IFTypeVF,
+							Uses: []string{"sriov1"},
+						},
+					},
+				}
+				type args struct {
+					profile *starlingxv1.HostProfileSpec
+					iface   *interfaces.Interface
+					host    *v1info.HostInfo
+				}
+				tests := []struct {
+					name  string
+					args  args
+					want  *starlingxv1.CommonInterfaceInfo
+					want1 bool
+				}{
+					{name: "find-loopback",
+						args: args{
+							profile: &sample,
+							iface: &interfaces.Interface{
+								ID:   "uuid-lo",
+								Name: "lo",
+								Type: interfaces.IFTypeVirtual,
+							},
+							host: &info,
+						},
+						want:  &sample.Interfaces.Ethernet[0].CommonInterfaceInfo,
+						want1: true,
+					},
+					{name: "find-loopback-not-configured",
+						args: args{
+							profile: &sample,
+							iface: &interfaces.Interface{
+								ID:   "uuid-lo1",
+								Name: "lo1",
+								Type: interfaces.IFTypeVirtual,
+							},
+							host: &info,
+						},
+						want:  nil,
+						want1: false,
+					},
+					{name: "find-ethernet",
+						args: args{
+							profile: &sample,
+							iface: &interfaces.Interface{
+								ID:   "uuid-eth1",
+								Name: "eth1",
+								Type: interfaces.IFTypeEthernet,
+							},
+							host: &info,
+						},
+						want:  &sample.Interfaces.Ethernet[2].CommonInterfaceInfo,
+						want1: true,
+					},
+					{name: "find-ethernet-renamed-interface",
+						args: args{
+							profile: &sample,
+							iface: &interfaces.Interface{
+								ID:   "uuid-eth0",
+								Name: "eth0",
+								Type: interfaces.IFTypeEthernet,
+							},
+							host: &info,
+						},
+						want:  &sample.Interfaces.Ethernet[1].CommonInterfaceInfo,
+						want1: true,
+					},
+					{name: "find-ethernet-not-configured",
+						args: args{
+							profile: &sample,
+							iface: &interfaces.Interface{
+								ID:   "uuid-eth9",
+								Name: "eth9",
+								Type: interfaces.IFTypeEthernet,
+							},
+							host: &info,
+						},
+						want:  nil,
+						want1: false,
+					},
+					{name: "find-vlan",
+						args: args{
+							profile: &sample,
+							iface: &interfaces.Interface{
+								ID:   "uuid-cluster0",
+								Name: "cluster0",
+								Type: interfaces.IFTypeVLAN,
+								VID:  &vid10,
+								Uses: []string{"eth0"},
+							},
+							host: &info,
+						},
+						want:  &sample.Interfaces.VLAN[0].CommonInterfaceInfo,
+						want1: true,
+					},
+					{name: "find-vlan-different-lower",
+						args: args{
+							profile: &sample,
+							iface: &interfaces.Interface{
+								ID:   "uuid-vid20",
+								Name: "vid20",
+								Type: interfaces.IFTypeVLAN,
+								VID:  &vid20,
+								Uses: []string{"infra0"},
+							},
+							host: &info,
+						},
+						want:  nil,
+						want1: false,
+					},
+					{name: "find-bond",
+						args: args{
+							profile: &sample,
+							iface: &interfaces.Interface{
+								ID:   "uuid-infra0",
+								Name: "infra0",
+								Type: interfaces.IFTypeAE,
+								Uses: []string{"eth1", "eth2"},
+							},
+							host: &info,
+						},
+						want:  &sample.Interfaces.Bond[0].CommonInterfaceInfo,
+						want1: true,
+					},
+					{name: "find-bond-renamed-members",
+						args: args{
+							profile: &sample,
+							iface: &interfaces.Interface{
+								ID:   "uuid-bond0",
+								Name: "bond0",
+								Type: interfaces.IFTypeAE,
+								Uses: []string{"eth3", "eth4"},
+							},
+							host: &info,
+						},
+						want:  &sample.Interfaces.Bond[1].CommonInterfaceInfo,
+						want1: true,
+					},
+					{name: "find-bond-renamed-members",
+						args: args{
+							profile: &sample,
+							iface: &interfaces.Interface{
+								ID:   "uuid-bond0",
+								Name: "bond0",
+								Type: interfaces.IFTypeAE,
+								Uses: []string{"eth3", "eth4"},
+							},
+							host: &info,
+						},
+						want:  &sample.Interfaces.Bond[1].CommonInterfaceInfo,
+						want1: true,
+					},
+					{name: "find-bond-not-configured",
+						args: args{
+							profile: &sample,
+							iface: &interfaces.Interface{
+								ID:   "uuid-bond10",
+								Name: "bond10",
+								Type: interfaces.IFTypeAE,
+								Uses: []string{"eth9", "eth10"},
+							},
+							host: &info,
+						},
+						want:  nil,
+						want1: false,
+					},
+					{name: "find-vf",
+						args: args{
+							profile: &sample,
+							iface: &interfaces.Interface{
+								ID:      "uuid-sriov1",
+								Name:    "sriov1",
+								Type:    interfaces.IFTypeVF,
+								VFCount: &vfcount1,
+								Uses:    []string{"sriov0"},
+							},
+							host: &info,
+						},
+						want:  &sample.Interfaces.VF[0].CommonInterfaceInfo,
+						want1: true,
+					},
+					{name: "find-vf-different-lower",
+						args: args{
+							profile: &sample,
+							iface: &interfaces.Interface{
+								ID:      "uuid-sriov2",
+								Name:    "sriov2",
+								Type:    interfaces.IFTypeVF,
+								VFCount: &vfcount1,
+								Uses:    []string{"sriov1"},
+							},
+							host: &info,
+						},
+						want:  nil,
+						want1: false,
+					},
+				}
+
+				for _, tt := range tests {
+					got, got1 := findConfiguredInterface(tt.args.iface, tt.args.profile, tt.args.host)
+					Expect(reflect.DeepEqual(got, tt.want)).To(BeTrue())
+					Expect(got1).To(Equal(tt.want1))
+				}
+			})
+		})
+	})
+
+	Describe("findConfiguredRoute utility", func() {
+		Context("with route data", func() {
+			It("should find in the list", func() {
+
+				metric1 := 1
+				metric2 := 2
+				sample := starlingxv1.HostProfileSpec{
+					Routes: starlingxv1.RouteList{
+						starlingxv1.RouteInfo{
+							Interface: "eth0",
+							Network:   "10.10.10.0",
+							Prefix:    24,
+							Gateway:   "10.10.10.1",
+							Metric:    nil,
+						},
+						starlingxv1.RouteInfo{
+							Interface: "eth0",
+							Network:   "fd00:1::",
+							Prefix:    64,
+							Gateway:   "fd00:1::1",
+							Metric:    nil,
+						},
+						starlingxv1.RouteInfo{
+							Interface: "eth0",
+							Network:   "11.11.11.0",
+							Prefix:    24,
+							Gateway:   "11.11.11.1",
+							Metric:    &metric1,
+						},
+						starlingxv1.RouteInfo{
+							Interface: "eth0",
+							Network:   "fd00:11::",
+							Prefix:    64,
+							Gateway:   "fd00:11::1",
+							Metric:    &metric2,
+						},
+					},
+				}
+
+				type args struct {
+					route   routes.Route
+					profile *starlingxv1.HostProfileSpec
+				}
+				tests := []struct {
+					name  string
+					args  args
+					want  *starlingxv1.RouteInfo
+					want1 bool
+				}{
+					{name: "find-ipv4",
+						args: args{
+							route: routes.Route{
+								ID:            "uuid0",
+								Network:       "10.10.10.0",
+								Prefix:        24,
+								Gateway:       "10.10.10.1",
+								Metric:        1,
+								InterfaceName: "eth0",
+							},
+							profile: &sample,
+						},
+						want:  &sample.Routes[0],
+						want1: true,
+					},
+					{name: "find-ipv4-with-metric",
+						args: args{
+							route: routes.Route{
+								ID:            "uuid2",
+								Network:       "11.11.11.0",
+								Prefix:        24,
+								Gateway:       "11.11.11.1",
+								Metric:        1,
+								InterfaceName: "eth0",
+							},
+							profile: &sample,
+						},
+						want:  &sample.Routes[2],
+						want1: true,
+					},
+					{name: "find-ipv4-with-wrong-metric",
+						args: args{
+							route: routes.Route{
+								ID:            "uuid10",
+								Network:       "11.11.11.0",
+								Prefix:        24,
+								Gateway:       "11.11.11.1",
+								Metric:        10,
+								InterfaceName: "eth0",
+							},
+							profile: &sample,
+						},
+						want:  nil,
+						want1: false,
+					},
+					{name: "find-ipv4-with-wrong-gateway",
+						args: args{
+							route: routes.Route{
+								ID:            "uuid10",
+								Network:       "11.11.11.0",
+								Prefix:        24,
+								Gateway:       "11.11.11.254",
+								Metric:        1,
+								InterfaceName: "eth0",
+							},
+							profile: &sample,
+						},
+						want:  nil,
+						want1: false,
+					},
+					{name: "find-ipv4-with-wrong-prefix",
+						args: args{
+							route: routes.Route{
+								ID:            "uuid10",
+								Network:       "11.11.11.0",
+								Prefix:        32,
+								Gateway:       "11.11.11.1",
+								Metric:        1,
+								InterfaceName: "eth0",
+							},
+							profile: &sample,
+						},
+						want:  nil,
+						want1: false,
+					},
+					{name: "find-ipv4-with-wrong-interface",
+						args: args{
+							route: routes.Route{
+								ID:            "uuid10",
+								Network:       "11.11.11.0",
+								Prefix:        24,
+								Gateway:       "11.11.11.1",
+								Metric:        1,
+								InterfaceName: "eth10",
+							},
+							profile: &sample,
+						},
+						want:  nil,
+						want1: false,
+					},
+					{name: "find-ipv6",
+						args: args{
+							route: routes.Route{
+								ID:            "uuid1",
+								Network:       "fd00:1::",
+								Prefix:        64,
+								Gateway:       "fd00:1::1",
+								Metric:        1,
+								InterfaceName: "eth0",
+							},
+							profile: &sample,
+						},
+						want:  &sample.Routes[1],
+						want1: true,
+					},
+					{name: "find-ipv6-with-metric",
+						args: args{
+							route: routes.Route{
+								ID:            "uuid0",
+								Network:       "fd00:11::",
+								Prefix:        64,
+								Gateway:       "fd00:11::1",
+								Metric:        2,
+								InterfaceName: "eth0",
+							},
+							profile: &sample,
+						},
+						want:  &sample.Routes[3],
+						want1: true,
+					},
+					{name: "find-ipv6-with-case-insensitive",
+						args: args{
+							route: routes.Route{
+								ID:            "uuid0",
+								Network:       "FD00:11::",
+								Prefix:        64,
+								Gateway:       "FD00:11::1",
+								Metric:        2,
+								InterfaceName: "eth0",
+							},
+							profile: &sample,
+						},
+						want:  &sample.Routes[3],
+						want1: true,
+					},
+					{name: "find-ipv6-with-wrong-metric",
+						args: args{
+							route: routes.Route{
+								ID:            "uuid0",
+								Network:       "fd00:11::",
+								Prefix:        64,
+								Gateway:       "fd00:11::1",
+								Metric:        20,
+								InterfaceName: "eth0",
+							},
+							profile: &sample,
+						},
+						want:  nil,
+						want1: false,
+					},
+					{name: "find-ipv6-with-wrong-gateway",
+						args: args{
+							route: routes.Route{
+								ID:            "uuid0",
+								Network:       "fd00:11::",
+								Prefix:        64,
+								Gateway:       "fd00:11::1111",
+								Metric:        2,
+								InterfaceName: "eth0",
+							},
+							profile: &sample,
+						},
+						want:  nil,
+						want1: false,
+					},
+					{name: "find-ipv6-with-wrong-prefix",
+						args: args{
+							route: routes.Route{
+								ID:            "uuid0",
+								Network:       "fd00:11::",
+								Prefix:        128,
+								Gateway:       "fd00:11::1",
+								Metric:        2,
+								InterfaceName: "eth0",
+							},
+							profile: &sample,
+						},
+						want:  nil,
+						want1: false,
+					},
+					{name: "find-ipv6-with-wrong-interface",
+						args: args{
+							route: routes.Route{
+								ID:            "uuid0",
+								Network:       "fd00:11::",
+								Prefix:        64,
+								Gateway:       "fd00:11::1",
+								Metric:        2,
+								InterfaceName: "eth10",
+							},
+							profile: &sample,
+						},
+						want:  nil,
+						want1: false,
+					},
+				}
+				for _, tt := range tests {
+					got, got1 := findConfiguredRoute(tt.args.route, tt.args.profile)
+					Expect(reflect.DeepEqual(got, tt.want)).To(BeTrue())
+					Expect(got1).To(Equal(tt.want1))
+				}
+			})
+		})
+	})
+
+	Describe("findConfiguredAddress utility", func() {
+		Context("with address data", func() {
+			It("should find in the list", func() {
+				sample := starlingxv1.HostProfileSpec{
+					Addresses: starlingxv1.AddressList{
+						starlingxv1.AddressInfo{
+							Interface: "eth0",
+							Address:   "10.10.10.10",
+							Prefix:    24,
+						},
+						starlingxv1.AddressInfo{
+							Interface: "eth0",
+							Address:   "fd00:1::10",
+							Prefix:    64,
+						},
+						starlingxv1.AddressInfo{
+							Interface: "eth0",
+							Address:   "11.11.11.10",
+							Prefix:    24,
+						},
+						starlingxv1.AddressInfo{
+							Interface: "eth0",
+							Address:   "fd00:11::10",
+							Prefix:    64,
+						},
+					},
+				}
+
+				type args struct {
+					Address addresses.Address
+					profile *starlingxv1.HostProfileSpec
+				}
+				tests := []struct {
+					name  string
+					args  args
+					want  *starlingxv1.AddressInfo
+					want1 bool
+				}{
+					{name: "find-ipv4",
+						args: args{
+							Address: addresses.Address{
+								ID:            "uuid0",
+								Address:       "10.10.10.10",
+								Prefix:        24,
+								InterfaceName: "eth0",
+							},
+							profile: &sample,
+						},
+						want:  &sample.Addresses[0],
+						want1: true,
+					},
+					{name: "find-ipv4-wrong-prefix",
+						args: args{
+							Address: addresses.Address{
+								ID:            "uuid2",
+								Address:       "11.11.11.11",
+								Prefix:        32,
+								InterfaceName: "eth0",
+							},
+							profile: &sample,
+						},
+						want:  nil,
+						want1: false,
+					},
+					{name: "find-ipv6",
+						args: args{
+							Address: addresses.Address{
+								ID:            "uuid1",
+								Address:       "fd00:1::10",
+								Prefix:        64,
+								InterfaceName: "eth0",
+							},
+							profile: &sample,
+						},
+						want:  &sample.Addresses[1],
+						want1: true,
+					},
+					{name: "find-ipv6-with-case-insensitive",
+						args: args{
+							Address: addresses.Address{
+								ID:            "uuid0",
+								Address:       "FD00:11::10",
+								Prefix:        64,
+								InterfaceName: "eth0",
+							},
+							profile: &sample,
+						},
+						want:  &sample.Addresses[3],
+						want1: true,
+					},
+					{name: "find-ipv6-with-wrong-prefix",
+						args: args{
+							Address: addresses.Address{
+								ID:            "uuid0",
+								Address:       "fd00:11::10",
+								Prefix:        128,
+								InterfaceName: "eth0",
+							},
+							profile: &sample,
+						},
+						want:  nil,
+						want1: false,
+					},
+				}
+				for _, tt := range tests {
+					got, got1 := findConfiguredAddress(tt.args.Address, tt.args.profile)
+					Expect(reflect.DeepEqual(got, tt.want)).To(BeTrue())
+					Expect(got1).To(Equal(tt.want1))
+				}
+			})
+		})
+	})
+})

--- a/controllers/host/profile_utils_test.go
+++ b/controllers/host/profile_utils_test.go
@@ -1,0 +1,457 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+
+package host
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"reflect"
+
+	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
+)
+
+var _ = Describe("Profile utils", func() {
+	Describe("MergeProfiles utility", func() {
+		Context("with profile spec data", func() {
+			It("should merge successfully", func() {
+
+				admin1 := "locked"
+				location1 := "vbox"
+				bmType1 := "bmc"
+				bm1 := starlingxv1.BMInfo{
+					Type: &bmType1,
+				}
+				personality2 := "controller"
+				admin2 := "unlocked"
+				type args struct {
+					a *starlingxv1.HostProfileSpec
+					b *starlingxv1.HostProfileSpec
+				}
+				size1 := 1
+				osds1 := starlingxv1.OSDList{
+					starlingxv1.OSDInfo{
+						Function: "osd",
+						Path:     "/dev/sda",
+					},
+				}
+				vgs1 := starlingxv1.VolumeGroupList{
+					starlingxv1.VolumeGroupInfo{
+						Name: "nova-local",
+						PhysicalVolumes: starlingxv1.PhysicalVolumeList{
+							starlingxv1.PhysicalVolumeInfo{
+								Type: "disk",
+								Path: "/dev/sdb",
+							},
+						},
+					},
+				}
+				fs1 := starlingxv1.FileSystemList{
+					starlingxv1.FileSystemInfo{
+						Name: "backup",
+						Size: 10,
+					},
+				}
+				osds2 := starlingxv1.OSDList{
+					starlingxv1.OSDInfo{
+						Function: "osd",
+						Path:     "/dev/sda",
+						Journal:  &starlingxv1.JournalInfo{Size: 10},
+					},
+					starlingxv1.OSDInfo{
+						Function: "osd",
+						Path:     "/dev/sdc",
+					},
+				}
+				vgs2 := starlingxv1.VolumeGroupList{
+					starlingxv1.VolumeGroupInfo{
+						Name: "nova-local",
+						PhysicalVolumes: starlingxv1.PhysicalVolumeList{
+							starlingxv1.PhysicalVolumeInfo{
+								Type: "disk",
+								Path: "/dev/sdd",
+							},
+							starlingxv1.PhysicalVolumeInfo{
+								Type: "partition",
+								Path: "/dev/sde",
+								Size: &size1,
+							},
+						},
+					},
+					starlingxv1.VolumeGroupInfo{
+						Name: "spare",
+						PhysicalVolumes: starlingxv1.PhysicalVolumeList{
+							starlingxv1.PhysicalVolumeInfo{
+								Type: "disk",
+								Path: "/dev/sdb",
+							},
+						},
+					},
+				}
+				fs2 := starlingxv1.FileSystemList{
+					starlingxv1.FileSystemInfo{
+						Name: "backup",
+						Size: 20,
+					},
+					starlingxv1.FileSystemInfo{
+						Name: "docker",
+						Size: 5,
+					},
+				}
+				vfcount1 := 1
+				vfcount2 := 2
+				vfcount3 := 3
+				tests := []struct {
+					name    string
+					args    args
+					want    *starlingxv1.HostProfileSpec
+					wantErr bool
+				}{
+					{name: "basic",
+						args: args{
+							a: &starlingxv1.HostProfileSpec{
+								ProfileBaseAttributes: starlingxv1.ProfileBaseAttributes{
+									AdministrativeState: &admin1,
+									Location:            &location1,
+								},
+								BoardManagement: &bm1,
+							},
+							b: &starlingxv1.HostProfileSpec{
+								ProfileBaseAttributes: starlingxv1.ProfileBaseAttributes{
+									AdministrativeState: &admin2,
+									Personality:         &personality2,
+								},
+							},
+						},
+						want: &starlingxv1.HostProfileSpec{
+							ProfileBaseAttributes: starlingxv1.ProfileBaseAttributes{
+								AdministrativeState: &admin2,
+								Personality:         &personality2,
+								Location:            &location1,
+							},
+							BoardManagement: &bm1,
+						},
+						wantErr: false},
+					{name: "interface-merge",
+						args: args{a: &starlingxv1.HostProfileSpec{
+							Interfaces: &starlingxv1.InterfaceInfo{
+								Ethernet: []starlingxv1.EthernetInfo{
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "eth0"}, Port: starlingxv1.EthernetPortInfo{Name: "eth0"}},
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "eth1"}, Port: starlingxv1.EthernetPortInfo{Name: "eth1"}},
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "sriov0"}, VFCount: &vfcount2, Port: starlingxv1.EthernetPortInfo{Name: "eth4"}}},
+								VLAN: []starlingxv1.VLANInfo{
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "vlan1"}, Lower: "eth0", VID: 1},
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "vlan2"}, Lower: "eth1", VID: 2}},
+								Bond: []starlingxv1.BondInfo{
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "bond0"}, Mode: "balanced", Members: []string{"eth0", "eth1"}},
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "bond1"}, Mode: "balanced", Members: []string{"eth2", "eth3"}}},
+								VF: []starlingxv1.VFInfo{
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "sriov1"}, VFCount: vfcount1, Lower: "sriov0"}},
+							}},
+							b: &starlingxv1.HostProfileSpec{
+								Interfaces: &starlingxv1.InterfaceInfo{
+									Ethernet: []starlingxv1.EthernetInfo{
+										{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "mgmt0"}, Port: starlingxv1.EthernetPortInfo{Name: "eth0"}},
+										{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "cluster0"}, Port: starlingxv1.EthernetPortInfo{Name: "eth2"}},
+										{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "sriov0"}, VFCount: &vfcount3, Port: starlingxv1.EthernetPortInfo{Name: "eth4"}}},
+									VLAN: []starlingxv1.VLANInfo{
+										{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "vlan1"}, Lower: "mgmt0", VID: 1},
+										{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "vlan3"}, Lower: "cluster0", VID: 3}},
+									Bond: []starlingxv1.BondInfo{
+										{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "bond0"}, Mode: "802.3ad", Members: []string{"eth10", "eth11"}},
+										{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "bond2"}, Mode: "802.3ad", Members: []string{"eth12", "eth13"}}},
+									VF: []starlingxv1.VFInfo{
+										{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "sriov2"}, VFCount: vfcount1, Lower: "sriov0"}},
+								},
+							},
+						},
+						wantErr: false,
+						want: &starlingxv1.HostProfileSpec{
+							Interfaces: &starlingxv1.InterfaceInfo{
+								Ethernet: []starlingxv1.EthernetInfo{
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "mgmt0"}, Port: starlingxv1.EthernetPortInfo{Name: "eth0"}},
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "eth1"}, Port: starlingxv1.EthernetPortInfo{Name: "eth1"}},
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "sriov0"}, VFCount: &vfcount3, Port: starlingxv1.EthernetPortInfo{Name: "eth4"}},
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "cluster0"}, Port: starlingxv1.EthernetPortInfo{Name: "eth2"}}},
+								VLAN: []starlingxv1.VLANInfo{
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "vlan1"}, Lower: "mgmt0", VID: 1},
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "vlan2"}, Lower: "eth1", VID: 2},
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "vlan3"}, Lower: "cluster0", VID: 3}},
+								Bond: []starlingxv1.BondInfo{
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "bond0"}, Mode: "802.3ad", Members: []string{"eth10", "eth11"}},
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "bond1"}, Mode: "balanced", Members: []string{"eth2", "eth3"}},
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "bond2"}, Mode: "802.3ad", Members: []string{"eth12", "eth13"}}},
+								VF: []starlingxv1.VFInfo{
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "sriov1"}, VFCount: vfcount1, Lower: "sriov0"},
+									{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "sriov2"}, VFCount: vfcount1, Lower: "sriov0"}},
+							},
+						},
+					},
+					{name: "storage-merge",
+						args: args{
+							a: &starlingxv1.HostProfileSpec{
+								Storage: &starlingxv1.ProfileStorageInfo{
+									Monitor:      &starlingxv1.MonitorInfo{Size: &size1},
+									OSDs:         &osds1,
+									VolumeGroups: &vgs1,
+									FileSystems:  &fs1,
+								},
+							},
+							b: &starlingxv1.HostProfileSpec{
+								Storage: &starlingxv1.ProfileStorageInfo{
+									Monitor:      &starlingxv1.MonitorInfo{Size: &size1},
+									OSDs:         &osds2,
+									VolumeGroups: &vgs2,
+									FileSystems:  &fs2,
+								},
+							},
+						},
+						wantErr: false,
+						want: &starlingxv1.HostProfileSpec{
+							Storage: &starlingxv1.ProfileStorageInfo{
+								Monitor:      &starlingxv1.MonitorInfo{Size: &size1},
+								OSDs:         &osds2,
+								VolumeGroups: &vgs2,
+								FileSystems:  &fs2,
+							},
+						},
+					},
+
+					{name: "processor-merge",
+						args: args{
+							a: &starlingxv1.HostProfileSpec{
+								Processors: starlingxv1.ProcessorNodeList{
+									starlingxv1.ProcessorInfo{
+										Node: 0,
+										Functions: starlingxv1.ProcessorFunctionList{
+											starlingxv1.ProcessorFunctionInfo{
+												Function: "vswitch",
+												Count:    1,
+											},
+										},
+									},
+								},
+							},
+							b: &starlingxv1.HostProfileSpec{
+								Processors: starlingxv1.ProcessorNodeList{
+									starlingxv1.ProcessorInfo{
+										Node: 0,
+										Functions: starlingxv1.ProcessorFunctionList{
+											starlingxv1.ProcessorFunctionInfo{
+												Function: "vswitch",
+												Count:    2,
+											},
+											starlingxv1.ProcessorFunctionInfo{
+												Function: "platform",
+												Count:    1,
+											},
+										},
+									},
+									starlingxv1.ProcessorInfo{
+										Node: 1,
+										Functions: starlingxv1.ProcessorFunctionList{
+											starlingxv1.ProcessorFunctionInfo{
+												Function: "vswitch",
+												Count:    4,
+											},
+											starlingxv1.ProcessorFunctionInfo{
+												Function: "platform",
+												Count:    2,
+											},
+										},
+									},
+								},
+							},
+						},
+						wantErr: false,
+						want: &starlingxv1.HostProfileSpec{
+							Processors: starlingxv1.ProcessorNodeList{
+								starlingxv1.ProcessorInfo{
+									Node: 0,
+									Functions: starlingxv1.ProcessorFunctionList{
+										starlingxv1.ProcessorFunctionInfo{
+											Function: "vswitch",
+											Count:    2,
+										},
+										starlingxv1.ProcessorFunctionInfo{
+											Function: "platform",
+											Count:    1,
+										},
+									},
+								},
+								starlingxv1.ProcessorInfo{
+									Node: 1,
+									Functions: starlingxv1.ProcessorFunctionList{
+										starlingxv1.ProcessorFunctionInfo{
+											Function: "vswitch",
+											Count:    4,
+										},
+										starlingxv1.ProcessorFunctionInfo{
+											Function: "platform",
+											Count:    2,
+										},
+									},
+								},
+							},
+						},
+					},
+					{name: "memory-merge",
+						args: args{
+							a: &starlingxv1.HostProfileSpec{
+								Memory: starlingxv1.MemoryNodeList{
+									starlingxv1.MemoryNodeInfo{
+										Node: 0,
+										Functions: starlingxv1.MemoryFunctionList{
+											starlingxv1.MemoryFunctionInfo{
+												Function:  "vswitch",
+												PageSize:  "2MB",
+												PageCount: 16,
+											},
+											starlingxv1.MemoryFunctionInfo{
+												Function:  "vswitch",
+												PageSize:  "1GB",
+												PageCount: 1,
+											},
+										},
+									},
+								},
+							},
+							b: &starlingxv1.HostProfileSpec{
+								Memory: starlingxv1.MemoryNodeList{
+									starlingxv1.MemoryNodeInfo{
+										Node: 0,
+										Functions: starlingxv1.MemoryFunctionList{
+											starlingxv1.MemoryFunctionInfo{
+												Function:  "vswitch",
+												PageSize:  "2MB",
+												PageCount: 128,
+											},
+											starlingxv1.MemoryFunctionInfo{
+												Function:  "platform",
+												PageSize:  "2MB",
+												PageCount: 32,
+											},
+										},
+									},
+									starlingxv1.MemoryNodeInfo{
+										Node: 1,
+										Functions: starlingxv1.MemoryFunctionList{
+											starlingxv1.MemoryFunctionInfo{
+												Function:  "vswitch",
+												PageSize:  "2MB",
+												PageCount: 128,
+											},
+											starlingxv1.MemoryFunctionInfo{
+												Function:  "platform",
+												PageSize:  "2MB",
+												PageCount: 32,
+											},
+										},
+									},
+								},
+							},
+						},
+						wantErr: false,
+						want: &starlingxv1.HostProfileSpec{
+							Memory: starlingxv1.MemoryNodeList{
+								starlingxv1.MemoryNodeInfo{
+									Node: 0,
+									Functions: starlingxv1.MemoryFunctionList{
+										starlingxv1.MemoryFunctionInfo{
+											Function:  "vswitch",
+											PageSize:  "2MB",
+											PageCount: 128,
+										},
+										starlingxv1.MemoryFunctionInfo{
+											Function:  "vswitch",
+											PageSize:  "1GB",
+											PageCount: 1,
+										},
+										starlingxv1.MemoryFunctionInfo{
+											Function:  "platform",
+											PageSize:  "2MB",
+											PageCount: 32,
+										},
+									},
+								},
+								starlingxv1.MemoryNodeInfo{
+									Node: 1,
+									Functions: starlingxv1.MemoryFunctionList{
+										starlingxv1.MemoryFunctionInfo{
+											Function:  "vswitch",
+											PageSize:  "2MB",
+											PageCount: 128,
+										},
+										starlingxv1.MemoryFunctionInfo{
+											Function:  "platform",
+											PageSize:  "2MB",
+											PageCount: 32,
+										},
+									},
+								},
+							},
+						},
+					},
+					{name: "addresses-merge",
+						args: args{
+							a: &starlingxv1.HostProfileSpec{
+								Addresses: starlingxv1.AddressList{
+									{Address: "1.2.3.4", Prefix: 24, Interface: "eth0"},
+									{Address: "10.20.30.40", Prefix: 24, Interface: "eth1"},
+								},
+							},
+							b: &starlingxv1.HostProfileSpec{
+								Addresses: starlingxv1.AddressList{
+									{Address: "10.20.30.40", Prefix: 32, Interface: "eth2"},
+									{Address: "fd00::40", Prefix: 64, Interface: "eth1"},
+								},
+							},
+						},
+						wantErr: false,
+						want: &starlingxv1.HostProfileSpec{
+							Addresses: starlingxv1.AddressList{
+								{Address: "1.2.3.4", Prefix: 24, Interface: "eth0"},
+								{Address: "10.20.30.40", Prefix: 32, Interface: "eth2"},
+								{Address: "fd00::40", Prefix: 64, Interface: "eth1"},
+							},
+						},
+					},
+					{name: "routes-merge",
+						args: args{
+							a: &starlingxv1.HostProfileSpec{
+								Routes: starlingxv1.RouteList{
+									{Network: "10.10.10.0", Prefix: 24, Gateway: "10.10.10.1", Interface: "eth0"},
+									{Network: "172.16.0.0", Prefix: 16, Gateway: "172.16.0.1", Interface: "eth1"},
+								},
+							},
+							b: &starlingxv1.HostProfileSpec{
+								Routes: starlingxv1.RouteList{
+									{Network: "10.10.10.0", Prefix: 24, Gateway: "10.10.10.2", Interface: "eth0"},
+									{Network: "172.16.0.0", Prefix: 24, Gateway: "172.16.0.1", Interface: "eth2"},
+									{Network: "fd00:1::", Prefix: 64, Gateway: "fd00:1::1", Interface: "eth1"},
+								},
+							},
+						},
+						wantErr: false,
+						want: &starlingxv1.HostProfileSpec{
+							Routes: starlingxv1.RouteList{
+								{Network: "10.10.10.0", Prefix: 24, Gateway: "10.10.10.2", Interface: "eth0"},
+								{Network: "172.16.0.0", Prefix: 16, Gateway: "172.16.0.1", Interface: "eth1"},
+								{Network: "172.16.0.0", Prefix: 24, Gateway: "172.16.0.1", Interface: "eth2"},
+								{Network: "fd00:1::", Prefix: 64, Gateway: "fd00:1::1", Interface: "eth1"},
+							},
+						},
+					},
+				}
+				for _, tt := range tests {
+					got, err := MergeProfiles(tt.args.a, tt.args.b)
+					Expect(err).To(BeNil())
+					Expect(reflect.DeepEqual(got, tt.want)).To(BeTrue())
+					Expect(got).NotTo(BeNil())
+					Expect(got.DeepEqual(tt.want)).To(BeTrue())
+				}
+			})
+		})
+	})
+})

--- a/controllers/hostprofile_controller_test.go
+++ b/controllers/hostprofile_controller_test.go
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2022 Wind River Systems, Inc. */
+package controllers
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
+)
+
+var _ = Describe("HostProfile controller", func() {
+
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	Context("HostProfile with data", func() {
+		It("Should created successfully", func() {
+			ctx := context.Background()
+			created := &starlingxv1.HostProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				}}
+			Expect(k8sClient.Create(ctx, created)).To(Succeed())
+
+			// Mock is needed for the further testing
+			// Currently there is no update in HostProfile instance
+			// So we test only for create
+		})
+	})
+})

--- a/controllers/manager/manager_suite_test.go
+++ b/controllers/manager/manager_suite_test.go
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 022 Wind River Systems, Inc. */
+package manager
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Manager Suite")
+}

--- a/controllers/manager/manager_test.go
+++ b/controllers/manager/manager_test.go
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+
+package manager
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Manager utils", func() {
+	Describe("getNextCount utility", func() {
+		Context("with a count value", func() {
+			It("should return the next value", func() {
+				type args struct {
+					value string
+				}
+				tests := []struct {
+					name string
+					args args
+					want string
+				}{
+					{name: "empty value",
+						args: args{value: ""},
+						want: "1",
+					},
+					{name: "integer value",
+						args: args{value: "1"},
+						want: "2"},
+					{name: "alphanumeric value",
+						args: args{value: "foobar"},
+						want: "1"},
+				}
+				for _, tt := range tests {
+					got := getNextCount(tt.args.value)
+					Expect(got).To(Equal(tt.want))
+				}
+			})
+		})
+	})
+})

--- a/controllers/platformnetwork_controller_test.go
+++ b/controllers/platformnetwork_controller_test.go
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2022 Wind River Systems, Inc. */
+package controllers
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
+	comm "github.com/wind-river/cloud-platform-deployment-manager/common"
+)
+
+var _ = Describe("Platformnetwork controller", func() {
+
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	Context("PlatformNetwork with data", func() {
+		It("Should created successfully", func() {
+			ctx := context.Background()
+			key := types.NamespacedName{
+				Name:      "foo",
+				Namespace: "default",
+			}
+			order := "sequential"
+			created := &starlingxv1.PlatformNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+				Spec: starlingxv1.PlatformNetworkSpec{
+					Type:   "mgmt",
+					Subnet: "1.2.3.0",
+					Prefix: 24,
+					Allocation: starlingxv1.AllocationInfo{
+						Type:  "static",
+						Order: &order,
+						Ranges: []starlingxv1.AllocationRange{
+							{Start: "1.2.3.10", End: "1.2.3.49"},
+							{Start: "1.2.3.129", End: "1.2.3.139"}},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, created)).To(Succeed())
+
+			expected := created.DeepCopy()
+
+			fetched := &starlingxv1.PlatformNetwork{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil &&
+					fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion
+			}, timeout, interval).Should(BeTrue())
+			_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PlatformNetworkFinalizerName})
+			Expect(found).To(BeTrue())
+		})
+	})
+})

--- a/controllers/ptpinstance_controller_test.go
+++ b/controllers/ptpinstance_controller_test.go
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2022 Wind River Systems, Inc. */
+package controllers
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
+	comm "github.com/wind-river/cloud-platform-deployment-manager/common"
+)
+
+var _ = Describe("PtpInstance controller", func() {
+
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	Context("PtpInstance with data", func() {
+		It("Should created successfully", func() {
+			ctx := context.Background()
+			key := types.NamespacedName{
+				Name:      "foo",
+				Namespace: "default",
+			}
+			created := &starlingxv1.PtpInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+				Spec: starlingxv1.PtpInstanceSpec{
+					Service:            "ptp4l",
+					InstanceParameters: []string{"domainNumber=24", "clientOnly=0"},
+				}}
+			Expect(k8sClient.Create(ctx, created)).To(Succeed())
+
+			expected := created.DeepCopy()
+
+			fetched := &starlingxv1.PtpInstance{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil &&
+					fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion
+			}, timeout, interval).Should(BeTrue())
+			_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PtpInstanceFinalizerName})
+			Expect(found).To(BeTrue())
+		})
+	})
+})

--- a/controllers/ptpinterface_controller_test.go
+++ b/controllers/ptpinterface_controller_test.go
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2022 Wind River Systems, Inc. */
+package controllers
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
+	comm "github.com/wind-river/cloud-platform-deployment-manager/common"
+)
+
+var _ = Describe("PtpInterface controller", func() {
+
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	Context("PtpInstance with data", func() {
+		It("Should created successfully", func() {
+			ctx := context.Background()
+			key := types.NamespacedName{
+				Name:      "foo",
+				Namespace: "default",
+			}
+			created := &starlingxv1.PtpInterface{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+				Spec: starlingxv1.PtpInterfaceSpec{
+					PtpInstance:         "ptp1",
+					InterfaceParameters: []string{"foo1=bar1", "foo2=bar2"},
+				}}
+			Expect(k8sClient.Create(ctx, created)).To(Succeed())
+
+			expected := created.DeepCopy()
+
+			fetched := &starlingxv1.PtpInterface{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil &&
+					fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion
+			}, timeout, interval).Should(BeTrue())
+			_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PtpInterfaceFinalizerName})
+			Expect(found).To(BeTrue())
+		})
+	})
+})

--- a/controllers/system/system_controller_test.go
+++ b/controllers/system/system_controller_test.go
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2022 Wind River Systems, Inc. */
+package system
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
+)
+
+var _ = Describe("System controller", func() {
+
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	Context("System with data", func() {
+		It("Should created successfully", func() {
+			type StringList []string
+			ctx := context.Background()
+			description := string("A sample description")
+			location := string("A sample location")
+			contact := string("A sample contact")
+			latitude := string("45.35189954974955")
+			longitude := string("-75.91866628453701")
+			// FIXME: After StringList workaround, fix this part
+			// dnsServers := StringList([]string{"8.8.8.8", "4.4.4.4"})
+			// ntpServers := StringList([]string{"time.ntp.org", "1.2.3.4"})
+			ptpMode := "hardware"
+			created := &starlingxv1.System{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+				Spec: starlingxv1.SystemSpec{
+					Description: &description,
+					Location:    &location,
+					Latitude:    &latitude,
+					Longitude:   &longitude,
+					Contact:     &contact,
+					// DNSServers:  &dnsServers,
+					// NTPServers:  &ntpServers,
+					PTP: &starlingxv1.PTPInfo{
+						Mode: &ptpMode,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, created)).To(Succeed())
+
+			// Mock is needed for the further testing
+			// Currently there is no update in System instance
+			// So we test only for create
+		})
+	})
+})

--- a/controllers/system/system_suite_test.go
+++ b/controllers/system/system_suite_test.go
@@ -1,13 +1,12 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* Copyright(c) 2019-2022 Wind River Systems, Inc. */
 
-package controllers
+package system
 
 import (
 	"context"
 	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -33,11 +32,6 @@ var testEnv *envtest.Environment
 var ctx context.Context
 var cancel context.CancelFunc
 
-const (
-	timeout  = time.Second * 60
-	interval = time.Second * 1
-)
-
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 
@@ -53,7 +47,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
+		CRDDirectoryPaths:     []string{filepath.Join("../..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 	}
 
@@ -79,32 +73,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	// Setup reconciler
-	// DataNetwork
-	err = (&DataNetworkReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-	// HostProfile
-	err = (&HostProfileReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-	// PlatformNetwork
-	err = (&PlatformNetworkReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-	// PtpInstance
-	err = (&PtpInstanceReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-	// PtpInterface
-	err = (&PtpInterfaceReconciler{
+	// System
+	err = (&SystemReconciler{
 		Client: k8sManager.GetClient(),
 		Scheme: k8sManager.GetScheme(),
 	}).SetupWithManager(k8sManager)
@@ -120,8 +90,6 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	cancel()
 	By("tearing down the test environment")
-	Eventually(func() bool {
-		err := testEnv.Stop()
-		return err == nil
-	}, timeout, interval).Should(BeTrue())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })


### PR DESCRIPTION
When we migrated DM from v1 to v3, we left test code migration
because of the limited time.
This is test code migration from the kubebuilder v1 base to v3 base.

kubebuilder v3 created the test template with ginkgo and gomega.
So that the existing test code is modified to adapt to this environment
but no new testing scenario is added in this patch

Test Plan:
PASS: Run "make test" and finished successfully
PASS: Run "make && DEBUG=yes make docker-build" and finished successfully
PASS: Confirm test coverage is similar as before migration

Signed-off-by: Takamasa Takenaka <takamasa.takenaka@windriver.com>