### PR TITLE
Add clock service type for PTP instances

### DIFF
--- a/api/v1/ptpinstance_types.go
+++ b/api/v1/ptpinstance_types.go
@@ -10,7 +10,7 @@ import (
 // PtpInstanceSpec defines the desired state of PtpInstance
 type PtpInstanceSpec struct {
 	// Serivce defines the service type of the ptp instance
-	// +kubebuilder:validation:Enum=ptp4l;phc2sys;ts2phc
+	// +kubebuilder:validation:Enum=ptp4l;phc2sys;ts2phc;clock
 	Service string `json:"service"`
 
 	// Parameters contains a list of parameters assigned to the ptp instance

--- a/config/crd/bases/starlingx.windriver.com_ptpinstances.yaml
+++ b/config/crd/bases/starlingx.windriver.com_ptpinstances.yaml
@@ -56,6 +56,7 @@ spec:
                 - ptp4l
                 - phc2sys
                 - ts2phc
+                - clock
                 type: string
             required:
             - service

--- a/helm/wind-river-cloud-platform-deployment-manager/templates/crds.yaml
+++ b/helm/wind-river-cloud-platform-deployment-manager/templates/crds.yaml
@@ -1864,6 +1864,7 @@ spec:
                 - ptp4l
                 - phc2sys
                 - ts2phc
+                - clock
                 type: string
             required:
             - service


### PR DESCRIPTION
PTP instances support 4 types of service
('ptp4l', 'phc2sys', 'ts2phc', 'clock'), but the DM
only accepts 3, this commit adds the 'clock' type
to reflect the sysinv configuration.

Test Plan:
1. Create DM configuration with PTP basic conf.
2. Set at least one PTP instance type to 'clock'
3. Apply the DM and verify the ptp instance
- Instance created with service type 'clock'

Signed-off-by: Hugo Brito <hugo.brito@windriver.com>