### PR TITLE
Fix make golangci error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ helm/wind-river-cloud-platform-deployment-manager/templates/rbac
 *.swp
 *.swo
 *~
+.vscode

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -88,19 +88,6 @@ sudo cp kustomize_1.0.11_linux_amd64 /usr/local/bin/kustomize
 sudo chmod 755 /usr/local/bin/kustomize
 ```
 
-
-#### GoLangCI
-
-The GoLangCI-lint tool is not a requirement of the Kubebuilder project 
-scaffolding, but the Deployment Manager Makefile has been extended since its
-initial creation.  Rather than relying on "go vet" for static analysis the
-project now uses the GoLangCI-lint tool which is also in use by newer
-Kubebuilder versions.
-
-```bash
-curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
-```
-
 #### Docker
 
 The Docker version that is shipped with most distributions is out of date

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -11,10 +11,6 @@ RUN wget https://get.helm.sh/helm-v2.16.10-linux-amd64.tar.gz -q -O - | tar zx -
 # version without significant effort.
 RUN curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH); chmod +x kubebuilder && mv kubebuilder /usr/local/bin/
 
-# Install our current version of golangci-lint.  We can probably upgrade to a
-# new version but this one has been tested and verified to work.
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
-
 # Install the latest version of Docker although we should probably try and
 # align the container version and the host version to ensure compatibility.
 RUN apt-get update && \

--- a/Makefile
+++ b/Makefile
@@ -90,12 +90,12 @@ generate: controller-gen deepequal-gen ## Generate code containing DeepCopy, Dee
 fmt: ## Run go fmt against code.
 	go fmt ./...
 
-golangci: ## Run the golangci-lint static analysis
-	golangci-lint run ./api/...
-	golangci-lint run ./controllers/...
+golangci: golangci-lint ## Run the golangci-lint static analysis
+	$(GOLANGCI_LINT) run ./api/...
+	$(GOLANGCI_LINT) run ./controllers/...
 
 .PHONY: vet
-vet: ## Run go vet against code.
+vet: golangci ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
@@ -164,12 +164,16 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 DEEPEQUAL_GEN ?= $(LOCALBIN)/deepequal-gen
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.8.0
+GOLANGCI_LINT_VERSION ?= v1.49.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
+GOLANGCI_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh"
+
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
@@ -191,6 +195,11 @@ $(ENVTEST): $(LOCALBIN)
 deepequal-gen: $(DEEPEQUAL_GEN) ## Download deepequal-gen locally if necessary.
 $(DEEPEQUAL_GEN): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install github.com/wind-river/deepequal-gen@latest
+
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
+$(GOLANGCI_LINT): $(LOCALBIN)
+	curl -sSfL $(GOLANGCI_INSTALL_SCRIPT) | sh -s -- -b $(LOCALBIN) $(GOLANGCI_LINT_VERSION)
 
 # Build the builder image
 builder-build:

--- a/api/v1/constructors.go
+++ b/api/v1/constructors.go
@@ -691,7 +691,7 @@ func parseStorageInfo(profile *HostProfileSpec, host v1info.HostInfo) error {
 // NOTE: for now we are only going to generate a single secret for all nodes.
 // If customization is required the user can manually clone what they need.
 func autoGenerateBMSecretName() string {
-	return fmt.Sprintf("bmc-secret")
+	return "bmc-secret"
 }
 
 // parseBoardManagementInfo is a utility which parses the board management data

--- a/api/v1/hostprofile_webhook.go
+++ b/api/v1/hostprofile_webhook.go
@@ -96,7 +96,7 @@ func validateProcessorInfo(obj *HostProfile) error {
 func validatePhysicalVolumeInfo(obj *PhysicalVolumeInfo) error {
 	if obj.Type == physicalvolumes.PVTypePartition {
 		if obj.Size == nil {
-			msg := fmt.Sprintf("partition specifications must include a 'size' attribute")
+			msg := "partition specifications must include a 'size' attribute"
 			return errors.New(msg)
 		}
 	}

--- a/api/v1/webhook_suite_test.go
+++ b/api/v1/webhook_suite_test.go
@@ -74,6 +74,7 @@ var _ = BeforeSuite(func() {
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred())
 
 	// start webhook server using Manager
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
@@ -85,6 +86,7 @@ var _ = BeforeSuite(func() {
 		LeaderElection:     false,
 		MetricsBindAddress: "0",
 	})
+	Expect(err).NotTo(HaveOccurred())
 
 	err = (&DataNetwork{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())

--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -378,7 +378,7 @@ func (r *HostReconciler) ReconcileAttributes(client *gophercloud.ServiceClient, 
 		if opts.BMPassword != nil && strings.HasPrefix(client.Endpoint, cloudManager.HTTPPrefix) {
 			if r.HTTPSRequired() {
 				// Do not send password information in the clear.
-				msg := fmt.Sprintf("it is unsafe to configure BM credentials thru a non HTTPS URL")
+				msg := "it is unsafe to configure BM credentials thru a non HTTPS URL"
 				return common.NewSystemDependency(msg)
 			} else {
 				logHost.Info("allowing BMC configuration over HTTP connection")
@@ -1004,7 +1004,7 @@ func (r *HostReconciler) ReconcileHostByState(client *gophercloud.ServiceClient,
 		}
 
 	} else {
-		msg := fmt.Sprintf("waiting for a stable state")
+		msg := "waiting for a stable state"
 		m := NewStableHostMonitor(instance, host.ID)
 		return r.CloudManager.StartMonitor(m, msg)
 	}
@@ -1192,7 +1192,7 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 	var current *starlingxv1.HostProfileSpec
 
 	if !host.Stable() {
-		msg := fmt.Sprintf("waiting for a stable state")
+		msg := "waiting for a stable state"
 		m := NewStableHostMonitor(instance, host.ID)
 		return r.CloudManager.StartMonitor(m, msg)
 	}
@@ -1330,7 +1330,7 @@ func (r *HostReconciler) ReconcileDeletedHost(client *gophercloud.ServiceClient,
 	}
 
 	if !host.Stable() {
-		msg := fmt.Sprintf("waiting for a stable state before deleting host")
+		msg := "waiting for a stable state before deleting host"
 		m := NewStableHostMonitor(instance, host.ID)
 		return r.CloudManager.StartMonitor(m, msg)
 	}

--- a/controllers/hostprofile_controller_test.go
+++ b/controllers/hostprofile_controller_test.go
@@ -4,7 +4,6 @@ package controllers
 
 import (
 	"context"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -14,11 +13,6 @@ import (
 )
 
 var _ = Describe("HostProfile controller", func() {
-
-	const (
-		timeout  = time.Second * 10
-		interval = time.Millisecond * 250
-	)
 
 	Context("HostProfile with data", func() {
 		It("Should created successfully", func() {

--- a/controllers/system/system_controller.go
+++ b/controllers/system/system_controller.go
@@ -685,7 +685,7 @@ func (r *SystemReconciler) PrivateKeyTranmissionAllowed(client *gophercloud.Serv
 	if r.HTTPSRequiredForCertificates() {
 		if !info.Capabilities.HTTPSEnabled {
 			// Do not send private key information in the clear.
-			msg := fmt.Sprintf("it is unsafe to install certificates while HTTPS is disabled")
+			msg := "it is unsafe to install certificates while HTTPS is disabled"
 			return common.NewSystemDependency(msg)
 		}
 
@@ -694,7 +694,7 @@ func (r *SystemReconciler) PrivateKeyTranmissionAllowed(client *gophercloud.Serv
 			// the endpoint hasn't been switched over yet, or the user is trying
 			// to do this through the internal URL so disallow, reset the client,
 			// and try again.
-			msg := fmt.Sprintf("it is unsafe to install certificates thru a non HTTPS URL")
+			msg := "it is unsafe to install certificates thru a non HTTPS URL"
 			return common.NewHTTPSClientRequired(msg)
 		}
 	} else {

--- a/controllers/system/system_controller_test.go
+++ b/controllers/system/system_controller_test.go
@@ -4,7 +4,6 @@ package system
 
 import (
 	"context"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -14,11 +13,6 @@ import (
 )
 
 var _ = Describe("System controller", func() {
-
-	const (
-		timeout  = time.Second * 10
-		interval = time.Millisecond * 250
-	)
 
 	Context("System with data", func() {
 		It("Should created successfully", func() {


### PR DESCRIPTION
It had error because golangci-lint version was old.
Now using the latest version of golangci-lint(v1.49.0)

Modify Makefile to download golangci-lint automatically,
so that user does not need to install golangci-lint
manually.
golangci-lint will be placed [local copy of repo]/bin
directory.

Fix some lint erros.

Test Plan:
PASS: "make golangci" finish successfully and no lint error
PASS: "make golangci-lint" downloaded the specified version of
      golangci-lint and placed into local bin directory
PASS: "make golangci-lint" does not download golangci-lint
      again, if golangci-lint exists in local bin directory
PASS: "make && DEBUG=yes make docker-build" finish successfully
PASS: Install SX successfully with designer DM

Signed-off-by: Takamasa Takenaka <takamasa.takenaka@windriver.com>