### PR TITLE
Fix error in make builder-run

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -30,7 +30,7 @@ apt-get -y install docker-ce
 ENV PATH="${PATH}:/usr/local/kubebuilder/bin:/bin"
 
 # Set the workdir into which we will will be working within this container
-WORKDIR /go/src/github.com/wind-river/cloud-platform-deployment-manager
+WORKDIR /go/src
 
 # Initialize helm within the container otherwise no helm commands will work.
 RUN helm init --stable-repo-url=https://charts.helm.sh/stable --client-only

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ builder-build:
 
 builder-run: builder-build
 	docker run -v /var/run/docker.sock:/var/run/docker.sock \
-		-v ${PWD}:/go/src/github.com/wind-river/cloud-platform-deployment-manager \
+		-v ${PWD}:/go/src \
 		--rm ${BUILDER_IMG}
 
 # Check minimum helm version


### PR DESCRIPTION
Running with builder-run and it failed:
-----
06:09:27 vet: github.com/wind-river/cloud-platform-
deployment-manager/api/v1/zz_generated.deepequal.go:12:11
: undeclared name: AddressInfo
-----
It happned by adding unnessessary directries to generate
deepequal if this command is running under go/src/github.com
directory.

This fix is to place source code directory not into
under git.com directory so that deepequal-gen generates
deepequal code in proper directory.

KNOWN ISSUE:
If your local DM repo is placed under
${HOME}/go/src/github.com/wind-river
Build will be failed.

WORKAROUND:
Place any directory except under ${HOME}/go/src
directory.

Test Plan:
PASS: "make && DEBUG=yes make docker-build" finishes successfully
PASS: "make builder-run" finishes successfully
      and build container is created and
      DM container (latest and debug) are created
PASS: Install with designer DM created by
      build-run finished successfully

Signed-off-by: Takamasa Takenaka <takamasa.takenaka@windriver.com>