### PR TITLE
Fix error in make builder-run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ generate: controller-gen deepequal-gen ## Generate code containing DeepCopy, Dee
 	sed -i 's#\[\]ServiceParameterInfo#ServiceParameterList#g' $(DEEPCOPY_GEN_FILE)
 	sed -i 's#\[\]StorageBackend#StorageBackendList#g' $(DEEPCOPY_GEN_FILE)
 	sed -i 's#\[\]ControllerFileSystemInfo#ControllerFileSystemList#g' $(DEEPCOPY_GEN_FILE)
-	$(DEEPEQUAL_GEN) -v 1 -o ${PWD} -O zz_generated.deepequal -i ./api/v1 -h ./hack/boilerplate.go.txt
+	$(DEEPEQUAL_GEN) -v 1 -o ${PWD} -O zz_generated.deepequal -i ./api/v1 -h ./hack/boilerplate.go.txt  --gen-package-path ./api/v1
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.


### PR DESCRIPTION
Running with builder-run and it failed:

06:09:27 vet: github.com/wind-river/cloud-platform-
deployment-manager/api/v1/zz_generated.deepequal.go:12:11
: undeclared name: AddressInfo

This is caused that deepequal-gen created the generated file
with package directory (github.com/wind-river/cloud-platform-
deployment-manager).

deepequal is updated to take a new parameter
"--gen-package-path" to specify the package path.

This fix is to update Makefile with this new parameter
so that deepequal is generated in the expected directory.

Test Plan:
PASS: "make && DEBUG=yes make docker-build" finishes successfully
PASS: "make && DEBUG=yes make docker-build" finishes successfully
      (under ${HOME}/go/src/github.com/wind-river)
PASS: make generate creates ./api/v1/zz_generated.deepequal.go
      (not depends on the repo directory)
PASS: "make builder-run" finishes successfully
      and build container is created and
      DM container (latest and debug) are created
PASS: Install with designer DM created by
      build-run finished successfully

Signed-off-by: Takamasa Takenaka <takamasa.takenaka@windriver.com>