### PR TITLE
Recover deploy tool version info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,15 @@ HELM_CLIENT_VER := $(shell helm version --client --short 2>/dev/null | awk '{pri
 HELM_CLIENT_VER_REL := $(shell echo ${HELM_CLIENT_VER} | awk -F. '{print $$1}')
 HELM_CLIENT_VER_MAJ := $(shell echo ${HELM_CLIENT_VER} | awk -F. '{print $$2}')
 
-DEPLOY_LDFLAGS := -X cmd/deploy/cmd.GitLastTag=${GIT_LAST_TAG}
-DEPLOY_LDFLAGS += -X cmd/deploy/cmd.GitHead=${GIT_HEAD}
-DEPLOY_LDFLAGS += -X cmd/deploy/cmd.GitBranch=${GIT_BRANCH}
+# Parameters for deploy tool
+GIT_HEAD := $(shell git rev-list -1 HEAD)
+GIT_LAST_TAG := $(shell git describe --abbrev=0 --tags)
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+
+APP_MODULE := "github.com/wind-river/cloud-platform-deployment-manager"
+DEPLOY_LDFLAGS := -X ${APP_MODULE}/cmd/deploy/cmd.GitLastTag=${GIT_LAST_TAG}
+DEPLOY_LDFLAGS += -X ${APP_MODULE}/cmd/deploy/cmd.GitHead=${GIT_HEAD}
+DEPLOY_LDFLAGS += -X ${APP_MODULE}/cmd/deploy/cmd.GitBranch=${GIT_BRANCH}
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23


### PR DESCRIPTION
When deploy configuration is generated by deploy tool,
the head has lack of deploy tool version information in
the comment line:

V1 base tool has:
```
# Generated: Wed Aug  3 15:37:25 UTC 2022
# Tool version: v2.0.8 (stable/final_ver_kubebuilder_v1: 58b926012681ea655d59abeb94bcd08944a299a6)
```
But the current deploy is lacking this version information
```
# Generated: Wed Aug  3 15:37:53 UTC 2022
# Tool version:  (: )
```

This fix recovers this information.

Test Plan:
PASS: "make tools" finish successfully.
PASS: deploy tool generates configuration file
      with tool version in header.
      - deploy tool built under GOPATH
      - deploy tool built under non-GOPATH
PASS: "make && DEBUG=yes make docker-build" finish successfully.

Signed-off-by: Takamasa Takenaka <takamasa.takenaka@windriver.com>