### PR TITLE
Lowercase the bootMAC before compare

### DIFF
--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -1265,6 +1265,16 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 	}
 	defaults.BoardManagement = &bmInfo
 
+	// To compate the BootMAC's we need to lowercase the values
+	if defaults.BootMAC != nil {
+		lowerDefaultsBootMAC := strings.ToLower(*defaults.BootMAC)
+		defaults.BootMAC = &lowerDefaultsBootMAC
+	}
+	if profile.BootMAC != nil {
+		lowerProfileBootMAC := strings.ToLower(*profile.BootMAC)
+		profile.BootMAC = &lowerProfileBootMAC
+	}
+
 	// Create a new composite profile that is backed by the host's default
 	// configuration.  This will ensure that if a user deletes an optional
 	// attribute that we will know how to restore the original value.


### PR DESCRIPTION
This commit uses lowercase to the BootMAC to avoid inconsistency when comparing host and profile bootMACs.

Test Case:
1. In the DM configuration (except controller-0)
- Create a new host/hostprofile
- Modify host.spec.override.bootmac using uppercase
2. Apply the DM.

Signed-off-by: Hugo Brito <hugo.brito@windriver.com>