### PR TITLE
Update CephPrimaryGroup when node is deleted

### DIFF
--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -1419,6 +1419,13 @@ func (r *HostReconciler) ReconcileResource(client *gophercloud.ServiceClient, in
 			}
 		}
 
+		// Remove deleted host from CephPrimaryGroup
+		host_uid := string(instance.UID)
+		if utils.ContainsString(CephPrimaryGroup, host_uid) {
+			CephPrimaryGroup = utils.RemoveString(CephPrimaryGroup, host_uid)
+			logHost.Info("host is no longer present as a ceph primary group")
+		}
+
 		return nil
 	}
 
@@ -1515,11 +1522,13 @@ func IsCephPrimaryGroup(host_uid string, rep int) (pg bool, err error) {
 	if len(host_uid) > 0 {
 		for _, c := range CephPrimaryGroup {
 			if c == host_uid {
+				logHost.V(2).Info("Host already in CephPrimaryGroup", "id", host_uid)
 				return true, nil
 			}
 		}
 		if len(CephPrimaryGroup) < rep {
 			CephPrimaryGroup = append(CephPrimaryGroup, host_uid)
+			logHost.V(2).Info("Host added in CephPrimaryGroup", "id", host_uid)
 			return true, nil
 		}
 	}


### PR DESCRIPTION
To support more than 2 storage nodes, we created a list to keep track of the Ceph Primary Group, but
when one of the hosts in this group is deleted the list is not updated resulting in DM get stucked
waiting the the deleted host to be unlock/available

Test Plan:
1. With configuration 2+2+2
- Lock one storage node system host-lock storage-1
- Delete 1 storage node system host-delete storage-1
- Delete host deployment (host is removed from group) kubectl -n deployment delete host storage-1
- Delete hostprofile deployment kubectl -n deployment delete hostprofile storage-1-profile
2. Modify the DM chaging the OSDs disk to another one
3. Apply the modified DM config
4. Reboot the server to boot via pxe

Signed-off-by: Hugo Brito <hugo.brito@windriver.com>