### PR TITLE
Update documents

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -41,7 +41,7 @@ The logs from the currently running Pod can be queried using the following
 command.  The "-f" argument follows the log stream much like the Linux "tail" 
 command.
 ```
-kubectl -n platform-deployment-manager logs platform-deployment-manager-0 manager -f
+kubectl -n platform-deployment-manager logs platform-deployment-manager-[uid] -f
 ```
 
 ## Looking at logs of the previously running Pod
@@ -52,7 +52,7 @@ instantiations are lost unless the platform is configured with a more advance
 data collection mechanism.
  
 ```
-kubectl -n platform-deployment-manager logs platform-deployment-manager-0 manager -p
+kubectl -n platform-deployment-manager logs platform-deployment-manager-[uid] -p
 ```
 
 ## Viewing event history
@@ -150,7 +150,7 @@ The DM consumes a ConfigMap at runtime which can contain individual boolean
 values that control the state of each reconciler.  Any changes to the ConfigMap
 are immediately read into the DM's internal configuration and go into effect the
 next time the DM queries its internal state.   The set of supported values can
-be found in the ```pkg/config/config.go``` file within the DM repo.  The
+be found in the ```common/config.go``` file within the DM repo.  The
 following Helm chart override file provides an example of how to set ConfigMap
 values as an override to disable the Host Memory sub-reconciler.
 
@@ -232,7 +232,7 @@ statefulset to 0 to force its termination.  Reversing the change by setting the
 replica count back to the normal value of 1 should relaunch the DM.
 
 ```bash
-kubectl scale --replicas=0 -n platform-deployment-manager statefulset platform-deployment-manager
+kubectl scale --replicas=0 -n platform-deployment-manager deployment platform-deployment-manager
 ```
 
 ## Restarting the Deployment Manager
@@ -242,7 +242,7 @@ force the DM to re-evaluate the state of all hosts you can elect to restart the
 DM Pod.
 
 ```
-kubectl -n platform-deployment-manager delete pods platform-deployment-manager-0
+kubectl -n platform-deployment-manager delete pods platform-deployment-manager-[uid]
 ```
 
 ## Deleting the Deployment Manager
@@ -252,5 +252,5 @@ to the Deployment Manager.  If the DM was installed using the recommended Helm
 chart install method then it can be removed using a similar operation.
 
 ```bash
-helm delete --purge deployment-manager
+helm uninstall deployment-manager
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+
+# Uncomment if you place private fork like gophercloud like "external" directory
+# COPY external/ external/
+
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/Makefile
+++ b/Makefile
@@ -248,22 +248,22 @@ helm-package: helm-ver-check helm-lint
 
 # Generate some example deployment configurations
 .PHONY: examples
-examples:
-	kustomize build examples/standard/default > examples/standard.yaml
-	kustomize build examples/standard/vxlan > examples/standard-vxlan.yaml
-	kustomize build examples/standard/https > examples/standard-https.yaml
-	kustomize build examples/standard/https-with-cert-manager > examples/standard-https-with-cert-manager.yaml
-	kustomize build examples/standard/bond > examples/standard-bond.yaml
-	kustomize build examples/standard/per-instance-ptp > examples/standard-per-instance-ptp.yaml
-	kustomize build examples/storage/default > examples/storage.yaml
-	kustomize build examples/aio-sx/default > examples/aio-sx.yaml
-	kustomize build examples/aio-sx/vxlan > examples/aio-sx-vxlan.yaml
-	kustomize build examples/aio-sx/https > examples/aio-sx-https.yaml
-	kustomize build examples/aio-sx/https-with-cert-manager > examples/aio-sx-https-with-cert-manager.yaml
-	kustomize build examples/aio-sx/single-nic > examples/aio-sx-single-nic.yaml
-	kustomize build examples/aio-sx/vf-rate-limit > examples/aio-sx-vf-rate-limit.yaml
-	kustomize build examples/aio-sx/geo-location > examples/aio-sx-geo-location.yaml
-	kustomize build examples/aio-dx/default > examples/aio-dx.yaml
-	kustomize build examples/aio-dx/vxlan > examples/aio-dx-vxlan.yaml
-	kustomize build examples/aio-dx/https > examples/aio-dx-https.yaml
-	kustomize build examples/aio-dx/https-with-cert-manager > examples/aio-dx-https-with-cert-manager.yaml
+examples: kustomize
+	$(KUSTOMIZE) build examples/standard/default > examples/standard.yaml
+	$(KUSTOMIZE) build examples/standard/vxlan > examples/standard-vxlan.yaml
+	$(KUSTOMIZE) build examples/standard/https > examples/standard-https.yaml
+	$(KUSTOMIZE) build examples/standard/https-with-cert-manager > examples/standard-https-with-cert-manager.yaml
+	$(KUSTOMIZE) build examples/standard/bond > examples/standard-bond.yaml
+	$(KUSTOMIZE) build examples/standard/per-instance-ptp > examples/standard-per-instance-ptp.yaml
+	$(KUSTOMIZE) build examples/storage/default > examples/storage.yaml
+	$(KUSTOMIZE) build examples/aio-sx/default > examples/aio-sx.yaml
+	$(KUSTOMIZE) build examples/aio-sx/vxlan > examples/aio-sx-vxlan.yaml
+	$(KUSTOMIZE) build examples/aio-sx/https > examples/aio-sx-https.yaml
+	$(KUSTOMIZE) build examples/aio-sx/https-with-cert-manager > examples/aio-sx-https-with-cert-manager.yaml
+	$(KUSTOMIZE) build examples/aio-sx/single-nic > examples/aio-sx-single-nic.yaml
+	$(KUSTOMIZE) build examples/aio-sx/vf-rate-limit > examples/aio-sx-vf-rate-limit.yaml
+	$(KUSTOMIZE) build examples/aio-sx/geo-location > examples/aio-sx-geo-location.yaml
+	$(KUSTOMIZE) build examples/aio-dx/default > examples/aio-dx.yaml
+	$(KUSTOMIZE) build examples/aio-dx/vxlan > examples/aio-dx-vxlan.yaml
+	$(KUSTOMIZE) build examples/aio-dx/https > examples/aio-dx-https.yaml
+	$(KUSTOMIZE) build examples/aio-dx/https-with-cert-manager > examples/aio-dx-https-with-cert-manager.yaml

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ fail or not complete.
 The Deployment Manager depends on the System API to execute configuration
 changes on the target system.  Following the initial software installation the
 System API is not functional until the system has been bootstrapped.  The first
-controller can be bootstrapped using Ansible®. This method is described at the 
-following wiki.  
+controller can be bootstrapped using Ansible®. This method is described in
+"Installation guides" section at the following wiki.
  
-https://docs.starlingx.io/deploy_install_guides/index.html
+https://docs.starlingx.io/
 
 Following the bootstrapping of the system by the Ansible deployment method, the
 System API is enabled and the Deployment Manager can continue the system
@@ -96,7 +96,7 @@ documentation on each attribute along with validation rules that conform to the
 OpenAPI v3 schema validation specification.  The full schema definition is
 stored in this repo and can be found in the ```config/crds``` directory.  The
 CRD instances are automatically generated based on annotations added directly
-to the source code found under ```pkg/apis```.
+to the source code found under ```api/v1```.
 
 A full system deployment configuration is composed of several Kubernetes Custom
 Resource (CR) instances.  Each CR conforms to a CRD instance defined under the 
@@ -108,6 +108,8 @@ of several instances of each of the following CRD types.
  + Data Network
  + Host Profile
  + Host
+ + PTP Instances
+ + PTP Interfaces
  
 To streamline the process of defining many Host records it is possible to move
 common host attributes into a HostProfile definition and to re-use that 
@@ -160,19 +162,10 @@ found within the listed files.
  kustomize build examples/aio-dx/https > /tmp/wind-river-cloud-platform-deployment-manager/system/aio-dx-https.yaml
  ```
 
-***Note***: the output directory can be overridden by setting the ```EXAMPLES```
-environment variable to a suitable destination directory.  For example, running
-the following command generates the examples within a different output
-directory.
-
 ***Note***: the HTTPS examples must be edited to add X.509 certificates and
 keys that are appropriate for your environment.  Follow the instructions
 provided in the ```deploy``` tool section related to HTTPS and BMC.
 
-
-```bash
-$ EXAMPLES=/tmp/examples make examples
-```
 
 ***Note***: The examples provided assume a certain hardware configuration and
 may need to be modified to work in your environment.  For instance, it is
@@ -208,10 +201,6 @@ to the ```bin``` directory of this repo.
 
 ```bash
 $ make tools
-go generate ./pkg/... ./cmd/...
-go fmt ./pkg/... ./cmd/...
-go vet ./pkg/... ./cmd/...
-go build -gcflags """" -o bin/deploy github.com/wind-river/cloud-platform-deployment-manager/cmd/deploy
 ```
 
 ### Using The ```deploy``` Tool

--- a/examples/aio-dx-https-with-cert-manager.yaml
+++ b/examples/aio-dx-https-with-cert-manager.yaml
@@ -45,8 +45,8 @@ spec:
   - registry.central
   duration: 2160h
   ipAddresses:
-  - null
-  - null
+  - ""
+  - ""
   issuerRef:
     kind: ClusterIssuer
     name: system-local-ca
@@ -54,11 +54,11 @@ spec:
   secretName: system-registry-local-certificate
   subject:
     countries:
-    - null
+    - ""
     organizationalUnits:
     - WRCP-System
     provinces:
-    - null
+    - ""
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -68,10 +68,10 @@ metadata:
 spec:
   commonName: null
   dnsNames:
-  - null
+  - ""
   duration: 2160h
   ipAddresses:
-  - null
+  - ""
   issuerRef:
     kind: ClusterIssuer
     name: system-local-ca
@@ -79,11 +79,11 @@ spec:
   secretName: system-restapi-gui-certificate
   subject:
     countries:
-    - null
+    - ""
     organizationalUnits:
     - WRCP-System
     provinces:
-    - null
+    - ""
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -98,10 +98,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0b
+  name: group0-data0
   namespace: deployment
 spec:
-  description: group0 data networks for the shared internal networks.
+  description: group0 data networks for the tenant1 networks.
   mtu: 1500
   type: vlan
 ---
@@ -110,10 +110,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0
+  name: group0-data0b
   namespace: deployment
 spec:
-  description: group0 data networks for the tenant1 networks.
+  description: group0 data networks for the shared internal networks.
   mtu: 1500
   type: vlan
 ---

--- a/examples/aio-dx-https.yaml
+++ b/examples/aio-dx-https.yaml
@@ -39,10 +39,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0b
+  name: group0-data0
   namespace: deployment
 spec:
-  description: group0 data networks for the shared internal networks.
+  description: group0 data networks for the tenant1 networks.
   mtu: 1500
   type: vlan
 ---
@@ -51,10 +51,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0
+  name: group0-data0b
   namespace: deployment
 spec:
-  description: group0 data networks for the tenant1 networks.
+  description: group0 data networks for the shared internal networks.
   mtu: 1500
   type: vlan
 ---

--- a/examples/aio-dx-vxlan.yaml
+++ b/examples/aio-dx-vxlan.yaml
@@ -28,10 +28,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0b
+  name: group0-data0
   namespace: deployment
 spec:
-  description: group0 data networks for the shared internal networks.
+  description: group0 data networks for the tenant1 networks.
   mtu: 1500
   type: vlan
 ---
@@ -40,10 +40,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0
+  name: group0-data0b
   namespace: deployment
 spec:
-  description: group0 data networks for the tenant1 networks.
+  description: group0 data networks for the shared internal networks.
   mtu: 1500
   type: vlan
 ---
@@ -93,6 +93,22 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
+  name: group0-vxlan0
+  namespace: deployment
+spec:
+  description: group0 vxlan data networks for the tenant1 networks.
+  mtu: 1400
+  type: vxlan
+  vxlan:
+    endpointMode: static
+    ttl: 10
+    udpPortNumber: 4789
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
   name: group0-vxlan0b
   namespace: deployment
 spec:
@@ -102,22 +118,6 @@ spec:
   vxlan:
     endpointMode: dynamic
     multicastGroup: 239.0.1.10
-    ttl: 10
-    udpPortNumber: 4789
----
-apiVersion: starlingx.windriver.com/v1
-kind: DataNetwork
-metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
-  name: group0-vxlan0
-  namespace: deployment
-spec:
-  description: group0 vxlan data networks for the tenant1 networks.
-  mtu: 1400
-  type: vxlan
-  vxlan:
-    endpointMode: static
     ttl: 10
     udpPortNumber: 4789
 ---

--- a/examples/aio-dx.yaml
+++ b/examples/aio-dx.yaml
@@ -28,10 +28,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0b
+  name: group0-data0
   namespace: deployment
 spec:
-  description: group0 data networks for the shared internal networks.
+  description: group0 data networks for the tenant1 networks.
   mtu: 1500
   type: vlan
 ---
@@ -40,10 +40,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0
+  name: group0-data0b
   namespace: deployment
 spec:
-  description: group0 data networks for the tenant1 networks.
+  description: group0 data networks for the shared internal networks.
   mtu: 1500
   type: vlan
 ---

--- a/examples/aio-dx/https-with-cert-manager/platform_certificate_certmanager.yaml
+++ b/examples/aio-dx/https-with-cert-manager/platform_certificate_certmanager.yaml
@@ -33,15 +33,15 @@ spec:
   commonName: null # Common Name
   subject:
     countries:
-    - null # Country
+    - "" # Country
     provinces:
-    - null # State/Province
+    - "" # State/Province
     organizationalUnits:
     - WRCP-System
   ipAddresses:
-  -  null # OAM floating IP
+  -  "" # OAM floating IP
   dnsNames:
-  - null # OAM IP or FQDN 
+  - "" # OAM IP or FQDN 
 ---
 # StarlingX Docker Registry Certificate
 apiVersion: cert-manager.io/v1
@@ -58,14 +58,14 @@ spec:
   renewBefore: 360h  # 15d
   subject:
     countries:
-    - null # Country
+    - "" # Country
     provinces:
-    - null # State/Province
+    - "" # State/Province
     organizationalUnits:
     - WRCP-System
   ipAddresses:
-  - null # oam floating IP address
-  - null # oam mgmt IP address
+  - "" # oam floating IP address
+  - "" # oam mgmt IP address
   dnsNames:
   - registry.local
   - registry.central

--- a/examples/aio-sx-geo-location.yaml
+++ b/examples/aio-sx-geo-location.yaml
@@ -28,10 +28,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0b
+  name: group0-data0
   namespace: deployment
 spec:
-  description: group0 data networks for the shared internal networks.
+  description: group0 data networks for the tenant1 networks.
   mtu: 1500
   type: vlan
 ---
@@ -40,10 +40,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0
+  name: group0-data0b
   namespace: deployment
 spec:
-  description: group0 data networks for the tenant1 networks.
+  description: group0 data networks for the shared internal networks.
   mtu: 1500
   type: vlan
 ---

--- a/examples/aio-sx-https-with-cert-manager.yaml
+++ b/examples/aio-sx-https-with-cert-manager.yaml
@@ -45,8 +45,8 @@ spec:
   - registry.central
   duration: 2160h
   ipAddresses:
-  - null
-  - null
+  - ""
+  - ""
   issuerRef:
     kind: ClusterIssuer
     name: system-local-ca
@@ -54,11 +54,11 @@ spec:
   secretName: system-registry-local-certificate
   subject:
     countries:
-    - null
+    - ""
     organizationalUnits:
     - WRCP-System
     provinces:
-    - null
+    - ""
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -68,10 +68,10 @@ metadata:
 spec:
   commonName: null
   dnsNames:
-  - null
+  - ""
   duration: 2160h
   ipAddresses:
-  - null
+  - ""
   issuerRef:
     kind: ClusterIssuer
     name: system-local-ca
@@ -79,11 +79,11 @@ spec:
   secretName: system-restapi-gui-certificate
   subject:
     countries:
-    - null
+    - ""
     organizationalUnits:
     - WRCP-System
     provinces:
-    - null
+    - ""
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -98,10 +98,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0b
+  name: group0-data0
   namespace: deployment
 spec:
-  description: group0 data networks for the shared internal networks.
+  description: group0 data networks for the tenant1 networks.
   mtu: 1500
   type: vlan
 ---
@@ -110,10 +110,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0
+  name: group0-data0b
   namespace: deployment
 spec:
-  description: group0 data networks for the tenant1 networks.
+  description: group0 data networks for the shared internal networks.
   mtu: 1500
   type: vlan
 ---

--- a/examples/aio-sx-https.yaml
+++ b/examples/aio-sx-https.yaml
@@ -39,10 +39,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0b
+  name: group0-data0
   namespace: deployment
 spec:
-  description: group0 data networks for the shared internal networks.
+  description: group0 data networks for the tenant1 networks.
   mtu: 1500
   type: vlan
 ---
@@ -51,10 +51,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0
+  name: group0-data0b
   namespace: deployment
 spec:
-  description: group0 data networks for the tenant1 networks.
+  description: group0 data networks for the shared internal networks.
   mtu: 1500
   type: vlan
 ---

--- a/examples/aio-sx-single-nic.yaml
+++ b/examples/aio-sx-single-nic.yaml
@@ -28,10 +28,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0b
+  name: group0-data0
   namespace: deployment
 spec:
-  description: group0 data networks for the shared internal networks.
+  description: group0 data networks for the tenant1 networks.
   mtu: 1500
   type: vlan
 ---
@@ -40,10 +40,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0
+  name: group0-data0b
   namespace: deployment
 spec:
-  description: group0 data networks for the tenant1 networks.
+  description: group0 data networks for the shared internal networks.
   mtu: 1500
   type: vlan
 ---

--- a/examples/aio-sx-vf-rate-limit.yaml
+++ b/examples/aio-sx-vf-rate-limit.yaml
@@ -28,10 +28,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0b
+  name: group0-data0
   namespace: deployment
 spec:
-  description: group0 data networks for the shared internal networks.
+  description: group0 data networks for the tenant1 networks.
   mtu: 1500
   type: vlan
 ---
@@ -40,10 +40,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0
+  name: group0-data0b
   namespace: deployment
 spec:
-  description: group0 data networks for the tenant1 networks.
+  description: group0 data networks for the shared internal networks.
   mtu: 1500
   type: vlan
 ---

--- a/examples/aio-sx-vxlan.yaml
+++ b/examples/aio-sx-vxlan.yaml
@@ -28,10 +28,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0b
+  name: group0-data0
   namespace: deployment
 spec:
-  description: group0 data networks for the shared internal networks.
+  description: group0 data networks for the tenant1 networks.
   mtu: 1500
   type: vlan
 ---
@@ -40,10 +40,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0
+  name: group0-data0b
   namespace: deployment
 spec:
-  description: group0 data networks for the tenant1 networks.
+  description: group0 data networks for the shared internal networks.
   mtu: 1500
   type: vlan
 ---
@@ -93,6 +93,22 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
+  name: group0-vxlan0
+  namespace: deployment
+spec:
+  description: group0 vxlan data networks for the tenant1 networks.
+  mtu: 1400
+  type: vxlan
+  vxlan:
+    endpointMode: static
+    ttl: 10
+    udpPortNumber: 4789
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
   name: group0-vxlan0b
   namespace: deployment
 spec:
@@ -102,22 +118,6 @@ spec:
   vxlan:
     endpointMode: dynamic
     multicastGroup: 239.0.1.10
-    ttl: 10
-    udpPortNumber: 4789
----
-apiVersion: starlingx.windriver.com/v1
-kind: DataNetwork
-metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
-  name: group0-vxlan0
-  namespace: deployment
-spec:
-  description: group0 vxlan data networks for the tenant1 networks.
-  mtu: 1400
-  type: vxlan
-  vxlan:
-    endpointMode: static
     ttl: 10
     udpPortNumber: 4789
 ---

--- a/examples/aio-sx.yaml
+++ b/examples/aio-sx.yaml
@@ -28,10 +28,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0b
+  name: group0-data0
   namespace: deployment
 spec:
-  description: group0 data networks for the shared internal networks.
+  description: group0 data networks for the tenant1 networks.
   mtu: 1500
   type: vlan
 ---
@@ -40,10 +40,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0
+  name: group0-data0b
   namespace: deployment
 spec:
-  description: group0 data networks for the tenant1 networks.
+  description: group0 data networks for the shared internal networks.
   mtu: 1500
   type: vlan
 ---

--- a/examples/aio-sx/https-with-cert-manager/platform_certificate_certmanager.yaml
+++ b/examples/aio-sx/https-with-cert-manager/platform_certificate_certmanager.yaml
@@ -33,15 +33,15 @@ spec:
   commonName: null # Common Name
   subject:
     countries:
-    - null # Country
+    - "" # Country
     provinces:
-    - null # State/Province
+    - "" # State/Province
     organizationalUnits:
     - WRCP-System
   ipAddresses:
-  -  null # OAM floating IP
+  -  "" # OAM floating IP
   dnsNames:
-  - null # OAM IP or FQDN 
+  - "" # OAM IP or FQDN 
 ---
 # StarlingX Docker Registry Certificate
 apiVersion: cert-manager.io/v1
@@ -58,14 +58,14 @@ spec:
   renewBefore: 360h  # 15d
   subject:
     countries:
-    - null # Country
+    - "" # Country
     provinces:
-    - null # State/Province
+    - "" # State/Province
     organizationalUnits:
     - WRCP-System
   ipAddresses:
-  - null # oam floating IP address
-  - null # oam mgmt IP address
+  - "" # oam floating IP address
+  - "" # oam mgmt IP address
   dnsNames:
   - registry.local
   - registry.central

--- a/examples/standard-bond.yaml
+++ b/examples/standard-bond.yaml
@@ -26,10 +26,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0b
+  name: group0-data0
   namespace: deployment
 spec:
-  description: group0 data networks for the shared internal networks.
+  description: group0 data networks for the tenant1 networks.
   mtu: 1500
   type: vlan
 ---
@@ -38,10 +38,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0
+  name: group0-data0b
   namespace: deployment
 spec:
-  description: group0 data networks for the tenant1 networks.
+  description: group0 data networks for the shared internal networks.
   mtu: 1500
   type: vlan
 ---

--- a/examples/standard-https-with-cert-manager.yaml
+++ b/examples/standard-https-with-cert-manager.yaml
@@ -43,8 +43,8 @@ spec:
   - registry.central
   duration: 2160h
   ipAddresses:
-  - null
-  - null
+  - ""
+  - ""
   issuerRef:
     kind: ClusterIssuer
     name: system-local-ca
@@ -52,11 +52,11 @@ spec:
   secretName: system-registry-local-certificate
   subject:
     countries:
-    - null
+    - ""
     organizationalUnits:
     - WRCP-System
     provinces:
-    - null
+    - ""
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -66,10 +66,10 @@ metadata:
 spec:
   commonName: null
   dnsNames:
-  - null
+  - ""
   duration: 2160h
   ipAddresses:
-  - null
+  - ""
   issuerRef:
     kind: ClusterIssuer
     name: system-local-ca
@@ -77,11 +77,11 @@ spec:
   secretName: system-restapi-gui-certificate
   subject:
     countries:
-    - null
+    - ""
     organizationalUnits:
     - WRCP-System
     provinces:
-    - null
+    - ""
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -96,10 +96,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0b
+  name: group0-data0
   namespace: deployment
 spec:
-  description: group0 data networks for the shared internal networks.
+  description: group0 data networks for the tenant1 networks.
   mtu: 1500
   type: vlan
 ---
@@ -108,10 +108,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0
+  name: group0-data0b
   namespace: deployment
 spec:
-  description: group0 data networks for the tenant1 networks.
+  description: group0 data networks for the shared internal networks.
   mtu: 1500
   type: vlan
 ---

--- a/examples/standard-https.yaml
+++ b/examples/standard-https.yaml
@@ -37,10 +37,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0b
+  name: group0-data0
   namespace: deployment
 spec:
-  description: group0 data networks for the shared internal networks.
+  description: group0 data networks for the tenant1 networks.
   mtu: 1500
   type: vlan
 ---
@@ -49,10 +49,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0
+  name: group0-data0b
   namespace: deployment
 spec:
-  description: group0 data networks for the tenant1 networks.
+  description: group0 data networks for the shared internal networks.
   mtu: 1500
   type: vlan
 ---

--- a/examples/standard-per-instance-ptp.yaml
+++ b/examples/standard-per-instance-ptp.yaml
@@ -26,10 +26,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0b
+  name: group0-data0
   namespace: deployment
 spec:
-  description: group0 data networks for the shared internal networks.
+  description: group0 data networks for the tenant1 networks.
   mtu: 1500
   type: vlan
 ---
@@ -38,10 +38,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0
+  name: group0-data0b
   namespace: deployment
 spec:
-  description: group0 data networks for the tenant1 networks.
+  description: group0 data networks for the shared internal networks.
   mtu: 1500
   type: vlan
 ---

--- a/examples/standard-vxlan.yaml
+++ b/examples/standard-vxlan.yaml
@@ -26,10 +26,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0b
+  name: group0-data0
   namespace: deployment
 spec:
-  description: group0 data networks for the shared internal networks.
+  description: group0 data networks for the tenant1 networks.
   mtu: 1500
   type: vlan
 ---
@@ -38,10 +38,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0
+  name: group0-data0b
   namespace: deployment
 spec:
-  description: group0 data networks for the tenant1 networks.
+  description: group0 data networks for the shared internal networks.
   mtu: 1500
   type: vlan
 ---
@@ -91,6 +91,22 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
+  name: group0-vxlan0
+  namespace: deployment
+spec:
+  description: group0 vxlan data networks for the tenant1 networks.
+  mtu: 1400
+  type: vxlan
+  vxlan:
+    endpointMode: static
+    ttl: 10
+    udpPortNumber: 4789
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
   name: group0-vxlan0b
   namespace: deployment
 spec:
@@ -100,22 +116,6 @@ spec:
   vxlan:
     endpointMode: dynamic
     multicastGroup: 239.0.1.10
-    ttl: 10
-    udpPortNumber: 4789
----
-apiVersion: starlingx.windriver.com/v1
-kind: DataNetwork
-metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
-  name: group0-vxlan0
-  namespace: deployment
-spec:
-  description: group0 vxlan data networks for the tenant1 networks.
-  mtu: 1400
-  type: vxlan
-  vxlan:
-    endpointMode: static
     ttl: 10
     udpPortNumber: 4789
 ---

--- a/examples/standard.yaml
+++ b/examples/standard.yaml
@@ -26,10 +26,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0b
+  name: group0-data0
   namespace: deployment
 spec:
-  description: group0 data networks for the shared internal networks.
+  description: group0 data networks for the tenant1 networks.
   mtu: 1500
   type: vlan
 ---
@@ -38,10 +38,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0
+  name: group0-data0b
   namespace: deployment
 spec:
-  description: group0 data networks for the tenant1 networks.
+  description: group0 data networks for the shared internal networks.
   mtu: 1500
   type: vlan
 ---

--- a/examples/standard/https-with-cert-manager/platform_certificate_certmanager.yaml
+++ b/examples/standard/https-with-cert-manager/platform_certificate_certmanager.yaml
@@ -33,15 +33,15 @@ spec:
   commonName: null # Common Name
   subject:
     countries:
-    - null # Country
+    - "" # Country
     provinces:
-    - null # State/Province
+    - "" # State/Province
     organizationalUnits:
     - WRCP-System
   ipAddresses:
-  -  null # OAM floating IP
+  -  "" # OAM floating IP
   dnsNames:
-  - null # OAM IP or FQDN 
+  - "" # OAM IP or FQDN 
 ---
 # StarlingX Docker Registry Certificate
 apiVersion: cert-manager.io/v1
@@ -58,14 +58,14 @@ spec:
   renewBefore: 360h  # 15d
   subject:
     countries:
-    - null # Country
+    - "" # Country
     provinces:
-    - null # State/Province
+    - "" # State/Province
     organizationalUnits:
     - WRCP-System
   ipAddresses:
-  - null # oam floating IP address
-  - null # oam mgmt IP address
+  - "" # oam floating IP address
+  - "" # oam mgmt IP address
   dnsNames:
   - registry.local
   - registry.central

--- a/examples/storage.yaml
+++ b/examples/storage.yaml
@@ -26,10 +26,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0b
+  name: group0-data0
   namespace: deployment
 spec:
-  description: group0 data networks for the shared internal networks.
+  description: group0 data networks for the tenant1 networks.
   mtu: 1500
   type: vlan
 ---
@@ -38,10 +38,10 @@ kind: DataNetwork
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: group0-data0
+  name: group0-data0b
   namespace: deployment
 spec:
-  description: group0 data networks for the tenant1 networks.
+  description: group0 data networks for the shared internal networks.
   mtu: 1500
   type: vlan
 ---


### PR DESCRIPTION
Update the following documents:
- README.md
- DEBUGGING.md
- DEVELOPER.md

Update go version and remove unnecessary packages like dep. Add a small description how to include vender private fork. Directory structure for example stays as in legacy structure but mentions it is not limited under GOPATH/src.

And kustomize is installed automatically during the build process but kustomize at "make examples" still use the external kustomize command. It is changed to use downloaded kustomize but "null" is evaluated as null and it is not allowed with newer kustomize. It is changed to "".

Test Plas:
PASS: Run "make examples" finish successfully and examples are
      generated.

Signed-off-by: Takamasa Takenaka <takamasa.takenaka@windriver.com>