### PR TITLE
Copy clockSynchronization by value

### DIFF
--- a/api/v1/constructors.go
+++ b/api/v1/constructors.go
@@ -810,7 +810,9 @@ func NewHostProfileSpec(host v1info.HostInfo) (*HostProfileSpec, error) {
 	spec.BootDevice = &bootDevice
 	rootDevice := fixDevicePath(host.RootDevice, host)
 	spec.RootDevice = &rootDevice
-	spec.ClockSynchronization = host.ClockSynchronization
+	clock := *host.ClockSynchronization
+	clockCopied := clock[0:] // Copy ClockSynchronization value
+	spec.ClockSynchronization = &clockCopied
 	ptpInstances := host.BuildPTPInstanceList()
 	ptpInstanceList := StringsToPtpInstanceItemList(ptpInstances)
 	spec.PtpInstances = ptpInstanceList


### PR DESCRIPTION
hostInfo is the current configuration obtained from host. At the beginning of host reconcile, "defaults" is created from hostInfo and clockSynchronization is copied as pointer. Later profile is created by merging defaults with user configuration. In this moment, clockSynchronization value is updated but all valuables which have the same pointer refers to this new value.

As a result, when clockSynchronization values in hostInfo and profile are compared to detect attribute update necessity, these two values are the same and it does not send to update clockSynchronization value.

This fix is to copy clockSynchronization value instead of copying pointer.

Test Plan:
PASS: Install with ptp;
      - Controller is unlocked-Enabled-available
      - Host INSYNC and RECONCILED are true
      - Host clock configuration is "ptp"
PASS: Install with ntp;
      - Controller is unlocked-Enabled-available
      - Host INSYNC and RECONCILED are true
      - Host clock configuration is "ntp"
PASS: Install with no ClockSynchronization specified;
      - Controller is unlocked-Enabled-available
      - Host INSYNC and RECONCILED are true
      - Host clock configuration is "ntp"
PASS: "make && DEBUG=yes make docker-build" finish successfully

Signed-off-by: Takamasa Takenaka <takamasa.takenaka@windriver.com>