### PR TITLE
Switch to use new K8s control-plane label

### DIFF
--- a/helm/wind-river-cloud-platform-deployment-manager/templates/manifests.yaml
+++ b/helm/wind-river-cloud-platform-deployment-manager/templates/manifests.yaml
@@ -543,7 +543,7 @@ spec:
         runAsNonRoot: false
       serviceAccountName: {{ .Values.namespace }}
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       terminationGracePeriodSeconds: 10
 {{- with .Values.tolerations }}
       tolerations:

--- a/helm/wind-river-cloud-platform-deployment-manager/values.yaml
+++ b/helm/wind-river-cloud-platform-deployment-manager/values.yaml
@@ -44,6 +44,9 @@ tolerations:
   - key: "node-role.kubernetes.io/master"
     operator: "Exists"
     effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/control-plane"
+    operator: "Exists"
+    effect: "NoSchedule"
 
 resources: {}
 # NOTE(alegacy): disabled until required.


### PR DESCRIPTION
Deployment Manager need to be updated to use 'control-plane' with nodeSelector/Tolerations so we may upgrade from 'master'.

This updates pod nodeSelector to use
'node-role.kubernetes.io/control-plane' instead of 'node-role.kubernetes.io/master'.

This updates pod Tolerations to support both:
- 'node-role.kubernetes.io/master'
- 'node-role.kubernetes.io/control-plane'

Signed-off-by: Saba Touheed Mujawar <sabatouheed.mujawar@windriver.com>