### PR TITLE
Support for host configurable MaxCPUMhzConfigured

### DIFF
--- a/api/v1/constructors.go
+++ b/api/v1/constructors.go
@@ -801,7 +801,7 @@ func NewHostProfileSpec(host v1info.HostInfo) (*HostProfileSpec, error) {
 	}
 	spec.Console = &host.Console
 	spec.InstallOutput = &host.InstallOutput
-	spec.MaxCPUFrequency = &host.MaxCPUFrequency
+	spec.MaxCPUMhzConfigured = &host.MaxCPUMhzConfigured
 	if host.Location.Name != nil && *host.Location.Name != "" {
 		spec.Location = host.Location.Name
 	}

--- a/api/v1/hostprofile_types.go
+++ b/api/v1/hostprofile_types.go
@@ -846,10 +846,10 @@ type ProfileBaseAttributes struct {
 	// +optional
 	ClockSynchronization *string `json:"clockSynchronization,omitempty"`
 
-	// MaxCPUFrequency defines the maximum limit of the CPU frequency set on the host.
+	// MaxCPUMhzConfigured defines the maximum limit of the CPU mhz configured on the host.
 	// +kubebuilder:validation:Pattern=^[1-9][0-9]*$
 	// +optional
-	MaxCPUFrequency *string `json:"maxCPUFrequency,omitempty"`
+	MaxCPUMhzConfigured *string `json:"maxCPUMhzConfigured,omitempty"`
 }
 
 // HostProfileSpec defines the desired state of HostProfile

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1499,8 +1499,8 @@ func (in *ProfileBaseAttributes) DeepCopyInto(out *ProfileBaseAttributes) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.MaxCPUFrequency != nil {
-		in, out := &in.MaxCPUFrequency, &out.MaxCPUFrequency
+	if in.MaxCPUMhzConfigured != nil {
+		in, out := &in.MaxCPUMhzConfigured, &out.MaxCPUMhzConfigured
 		*out = new(string)
 		**out = **in
 	}

--- a/api/v1/zz_generated.deepequal.go
+++ b/api/v1/zz_generated.deepequal.go
@@ -1697,11 +1697,11 @@ func (in *ProfileBaseAttributes) DeepEqual(other *ProfileBaseAttributes) bool {
 		}
 	}
 
-	if in.MaxCPUFrequency != nil {
-		if (in.MaxCPUFrequency == nil) != (other.MaxCPUFrequency == nil) {
+	if in.MaxCPUMhzConfigured != nil {
+		if (in.MaxCPUMhzConfigured == nil) != (other.MaxCPUMhzConfigured == nil) {
 			return false
-		} else if in.MaxCPUFrequency != nil {
-			if *in.MaxCPUFrequency != *other.MaxCPUFrequency {
+		} else if in.MaxCPUMhzConfigured != nil {
+			if *in.MaxCPUMhzConfigured != *other.MaxCPUMhzConfigured {
 				return false
 			}
 		}

--- a/config/crd/bases/starlingx.windriver.com_hostprofiles.yaml
+++ b/config/crd/bases/starlingx.windriver.com_hostprofiles.yaml
@@ -580,9 +580,9 @@ spec:
                 description: Location defines the physical location of the host in
                   the data centre.
                 type: string
-              maxCPUFrequency:
-                description: MaxCPUFrequency defines the maximum limit of the CPU
-                  frequency set on the host.
+              maxCPUMhzConfigured:
+                description: MaxCPUMhzConfigured defines the maximum limit of the
+                  CPU mhz configured on the host.
                 pattern: ^[1-9][0-9]*$
                 type: string
               memory:

--- a/config/crd/bases/starlingx.windriver.com_hosts.yaml
+++ b/config/crd/bases/starlingx.windriver.com_hosts.yaml
@@ -659,9 +659,9 @@ spec:
                     description: Location defines the physical location of the host
                       in the data centre.
                     type: string
-                  maxCPUFrequency:
-                    description: MaxCPUFrequency defines the maximum limit of the
-                      CPU frequency set on the host.
+                  maxCPUMhzConfigured:
+                    description: MaxCPUMhzConfigured defines the maximum limit of
+                      the CPU mhz configured on the host.
                     pattern: ^[1-9][0-9]*$
                     type: string
                   memory:

--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -268,9 +268,9 @@ func (r *HostReconciler) UpdateRequired(instance *starlingxv1.Host, profile *sta
 		opts.InstallOutput = profile.InstallOutput
 	}
 
-	if profile.MaxCPUFrequency != nil && *profile.MaxCPUFrequency != h.MaxCPUFrequency {
+	if profile.MaxCPUMhzConfigured != nil && *profile.MaxCPUMhzConfigured != h.MaxCPUMhzConfigured {
 		result = true
-		opts.MaxCPUFrequency = profile.MaxCPUFrequency
+		opts.MaxCPUMhzConfigured = profile.MaxCPUMhzConfigured
 	}
 
 	if profile.RootDevice != nil && *profile.RootDevice != h.RootDevice {

--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -14,7 +14,28 @@
     
     - set_fact:
         deploy_config: "{{ deployment_config }}"
+        wait_for_dm_unlock: " {{ wait_for_dm_unlock| default(5) }}"
       when: deployment_config is defined
+
+    - block:
+      # Information to be used at final DM checks.
+        - name: Get host name
+          shell: |
+            source /etc/platform/openrc; hostname
+          register: get_host_name 
+
+        # In order to determine if the host is a subcloud's node
+        - name: Get distributed_cloud_role
+          shell: >-
+            source /etc/platform/openrc; system show |
+            awk '$2 ~ /^distributed_cloud_role/ {print $4}'
+          register: get_distributed_cloud_role
+
+        - name: Show dc_role and hostname
+          debug:
+            msg:
+            - "hostname: {{get_host_name.stdout}}"
+            - "dc_role: {{ get_distributed_cloud_role.stdout }}"
 
     - block:
       # Copy required files up to the target host if this playbook is being
@@ -284,3 +305,83 @@
       environment:
         KUBECONFIG: "/etc/kubernetes/admin.conf"
       when: get_dm_default_registry_key.stdout == ""
+
+    - block:
+        - wait_for:
+            # Waiting task after apply config to avoid failures getting info
+            timeout: 5
+            msg: Waiting after apply DM config
+
+        # - If unlock task is triggered, is highly probable that the config applied is correct.
+        # - If the task fails (by achieving max retries without calling the unlock), the
+        #   playbook will fail but it will collect some information before exiting.
+        - name: Wait until unlock task triggered
+          shell: |
+            source /etc/platform/openrc;
+            system host-show "{{ get_host_name.stdout}}" | awk '$2 ~ /^task/ {print $4}'
+          register: get_show_task_status
+          until: ("Unlocking" in get_show_task_status.stdout)
+          retries: 60
+          delay: "{{wait_for_dm_unlock}}"
+          ignore_errors: yes
+
+        - name: Show waiting unlock
+          debug:
+            msg:
+            - "waiting: {{get_show_task_status.stdout}}"
+            - "waiting: {{get_show_task_status.stderr}}"
+
+        # Get a list of unreconciled resources at moment of failing
+        - name: Retrieve kubectl resources reconciled status
+          shell: >-
+            kubectl -n deployment get datanetworks,hostprofiles,hosts,platformnetworks,systems,ptpinstances,ptpinterfaces |
+            awk '$NF ~ /^false/ {print}'
+          environment:
+            KUBECONFIG: "/etc/kubernetes/admin.conf"
+          register: get_recon_status_pre_unlock
+
+        - name: Show unreconciled resources
+          debug:
+            msg:
+            - "recon: {{get_recon_status_pre_unlock.stdout}}"
+
+        # Get pod name to retrieve the logs
+        - name: Get dm pod name
+          shell: >-
+            kubectl -n platform-deployment-manager get pods |
+            awk '$1 ~ /^platform-deployment-manager/ {print $1}'
+          environment:
+            KUBECONFIG: "/etc/kubernetes/admin.conf"
+          register: get_dm_pod_name
+
+        # Get errors from pod logs. Searching for error lines into logs which:
+        # - Contain 'ERROR' key word.
+        # - Are not validation or waiting errors (which could be temporal).
+        # - Are not the same "Verb + value". Usually we see same error
+        #   multiple times in logs.
+        - name: Retrieve dm logs
+          shell: >-
+            kubectl -n platform-deployment-manager logs "{{ get_dm_pod_name.stdout }}" |
+            awk '(/ERROR/ && !/validation/ && !/waiting/ && !/Reconciler error/&& !(seen[$10, $NF]++)) {print}'
+          environment:
+            KUBECONFIG: "/etc/kubernetes/admin.conf"
+          register: get_logs_pre_unlock
+
+        - name: Show logs
+          debug:
+            msg:
+            - "Pod log: {{get_logs_pre_unlock.stdout}}"
+            - "err: {{get_logs_pre_unlock.stderr}}"
+
+        # If the task "Wait until unlock task triggered" failed, we export some
+        # useful information to the fail playbook msg.
+        - name: Output dm logs
+          fail:
+            msg:
+              - "Fail waiting for host unlock to be triggered. It could be due to DM config errors"
+              - "UNRECONCILED resources: {{get_recon_status_pre_unlock.stdout}}"
+              - "{{get_logs_pre_unlock.stdout}}"
+          register: fail_dm_logs
+          when: ("Unlocking" not in get_show_task_status.stdout)
+
+      when: (deploy_config is defined and "subcloud" in get_distributed_cloud_role.stdout)

--- a/go.mod
+++ b/go.mod
@@ -91,4 +91,4 @@ require (
 )
 
 // replace github.com/gophercloud/gophercloud => ./external/gophercloud
-replace github.com/gophercloud/gophercloud => github.com/wind-river/gophercloud v0.0.0-20220714135506-aac06588b172
+replace github.com/gophercloud/gophercloud => github.com/wind-river/gophercloud v0.0.0-20221123162006-d0bd787eabad

--- a/go.sum
+++ b/go.sum
@@ -468,8 +468,8 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/wind-river/gophercloud v0.0.0-20220714135506-aac06588b172 h1:xSeAummWb7dffFtdHq+Tqk1VeMdvxzk5N5k1m8M9wDA=
-github.com/wind-river/gophercloud v0.0.0-20220714135506-aac06588b172/go.mod h1:FMtdxT0Mwm0oqT7cUYr/C3LBaTZ2vpfVCVykBSTEu7o=
+github.com/wind-river/gophercloud v0.0.0-20221123162006-d0bd787eabad h1:Qy521YWsMFedTCo1EGcXglWOTBVJXdGNeNyQcVi0ytk=
+github.com/wind-river/gophercloud v0.0.0-20221123162006-d0bd787eabad/go.mod h1:FMtdxT0Mwm0oqT7cUYr/C3LBaTZ2vpfVCVykBSTEu7o=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/helm/wind-river-cloud-platform-deployment-manager/templates/crds.yaml
+++ b/helm/wind-river-cloud-platform-deployment-manager/templates/crds.yaml
@@ -574,8 +574,8 @@ spec:
               location:
                 description: Location defines the physical location of the host in the data centre.
                 type: string
-              maxCPUFrequency:
-                description: MaxCPUFrequency defines the maximum limit of the CPU frequency set on the host.
+              maxCPUMhzConfigured:
+                description: MaxCPUMhzConfigured defines the maximum limit of the CPU mhz configured on the host.
                 pattern: ^[1-9][0-9]*$
                 type: string
               memory:
@@ -1373,8 +1373,8 @@ spec:
                   location:
                     description: Location defines the physical location of the host in the data centre.
                     type: string
-                  maxCPUFrequency:
-                    description: MaxCPUFrequency defines the maximum limit of the CPU frequency set on the host.
+                  maxCPUMhzConfigured:
+                    description: MaxCPUMhzConfigured defines the maximum limit of the CPU mhz configured on the host.
                     pattern: ^[1-9][0-9]*$
                     type: string
                   memory:


### PR DESCRIPTION
Updated host config with renamed field MaxCPUMhzConfigured and updated go.mod and go .sum

Test Plan:

PASS: "make && DEBUG=yes and make docker-build" finished successfully

PASS: Tested the image and chart built for this commit in SM-1 lab and  ran deploy tool and observed the renamed field maxCPUMhzConfigured  in deployment-config.yaml. 

Signed-off-by: mmanthir <mahalakshmi.manthiram@windriver.com>