### PR TITLE
Sort members list before compare attributes

### DIFF
--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -1265,15 +1265,7 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 	}
 	defaults.BoardManagement = &bmInfo
 
-	// To compate the BootMAC's we need to lowercase the values
-	if defaults.BootMAC != nil {
-		lowerDefaultsBootMAC := strings.ToLower(*defaults.BootMAC)
-		defaults.BootMAC = &lowerDefaultsBootMAC
-	}
-	if profile.BootMAC != nil {
-		lowerProfileBootMAC := strings.ToLower(*profile.BootMAC)
-		profile.BootMAC = &lowerProfileBootMAC
-	}
+	FixProfileAttributes(defaults, profile, current)
 
 	// Create a new composite profile that is backed by the host's default
 	// configuration.  This will ensure that if a user deletes an optional

--- a/controllers/host/profile_utils.go
+++ b/controllers/host/profile_utils.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sort"
+	"strings"
 
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/hosts"
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/interfaces"
@@ -28,6 +30,35 @@ func MergeProfiles(a, b *starlingxv1.HostProfileSpec) (*starlingxv1.HostProfileS
 	}
 
 	return a, nil
+}
+
+// FixProfileAttributes makes some adjustments to profile attributes
+func FixProfileAttributes(a, b, c *starlingxv1.HostProfileSpec) {
+	// To compare the BootMAC's we need to lowercase the values
+	if a.BootMAC != nil {
+		lowerDefaultsBootMAC := strings.ToLower(*a.BootMAC)
+		a.BootMAC = &lowerDefaultsBootMAC
+	}
+	if b.BootMAC != nil {
+		lowerProfileBootMAC := strings.ToLower(*b.BootMAC)
+		b.BootMAC = &lowerProfileBootMAC
+	}
+
+	// To compare the interface Members we need to sort them
+	if b.Interfaces.Bond != nil {
+		for _, bondInfo := range b.Interfaces.Bond {
+			if bondInfo.Members != nil {
+				sort.Strings(bondInfo.Members)
+			}
+		}
+	}
+	if c.Interfaces.Bond != nil {
+		for _, bondInfo := range c.Interfaces.Bond {
+			if bondInfo.Members != nil {
+				sort.Strings(bondInfo.Members)
+			}
+		}
+	}
 }
 
 // GetHostProfile retrieves a HostProfileSpec from the kubernetes API


### PR DESCRIPTION
This commits sort the interface members list inside the bondinfo before comparing with current profile of the machine.

Test Plan:
1. Deploy a lab using interface members in DM config
2. Verify if the macBoot is lowercase
3. Verify if interface members list is sorted
4. All nodes must be synced

Signed-off-by: Hugo Brito <hugo.brito@windriver.com>