### PR TITLE
Add temporary support for provisioning optional filesystems

### DIFF
--- a/controllers/host/storage.go
+++ b/controllers/host/storage.go
@@ -678,6 +678,27 @@ func (r *HostReconciler) ReconcileFileSystems(client *gophercloud.ServiceClient,
 			}
 		}
 
+		// TODO: REMOVE ME: properly support host-fs-add API
+		//
+		// For now, check for non-existent optional filesystems that are not
+		// currently provisioned and send the request anyway so that the
+		// host-fs-modify API can create and resize as needed.
+		if !found {
+			opt_fs_list := [2]string{"instances", "image-conversion"}
+			for _, opt_fs := range opt_fs_list {
+				if fsInfo.Name == opt_fs {
+					found = true
+					opts := hostFilesystems.FileSystemOpts{
+						Name: fsInfo.Name,
+						Size: fsInfo.Size,
+					}
+
+					updates = append(updates, opts)
+					break
+				}
+			}
+		}
+
 		if !found {
 			msg := fmt.Sprintf("unknown host filesystem %q", fsInfo.Name)
 			return starlingxv1.NewMissingSystemResource(msg)


### PR DESCRIPTION
Deployment manager currently does not support adding optional filesystems as part of the deployment model. As only filesystem resizes are supported for select filesystems, add a exception for the 'instances' and 'image-conversion' filesystems. If either does not exist, still pass as resize request to the system inventory manager as the inventory manager with handle a creation and a resize operation for these filesystems.

Test Plan:
PASS - add optional filesystems to the deployment config and observe
       their creation after the host goes INSYNC=true

Signed-off-by: Robert Church <robert.church@windriver.com>

Co-Authored-By: Yuxing Jiang <yuxing.jiang@windriver.com>