### PR TITLE
Support to reconcile new filesystem types with host-fs-add API before initial unlock

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -32,7 +32,8 @@ const (
 	Memory            ReconcilerName = "host.memory"
 	Processor         ReconcilerName = "host.processor"
 	Storage           ReconcilerName = "host.storage"
-	FileSystems       ReconcilerName = "host.storage.filesystems"
+	FileSystemTypes   ReconcilerName = "host.storage.fileSystemTypes"
+	FileSystemSizes   ReconcilerName = "host.storage.fileSystemSizes"
 	StorageMonitor    ReconcilerName = "host.storage.monitor"
 	OSD               ReconcilerName = "host.storage.osd"
 	Partition         ReconcilerName = "host.storage.partition"
@@ -66,7 +67,8 @@ var reconcilerDefaultStates = map[ReconcilerName]bool{
 	Memory:            true,
 	Processor:         true,
 	Storage:           true,
-	FileSystems:       true,
+	FileSystemTypes:   true,
+	FileSystemSizes:   true,
 	StorageMonitor:    true,
 	OSD:               true,
 	Partition:         true,

--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -66,6 +66,9 @@ var DefaultHostProfile = starlingxv1.HostProfileSpec{
 
 var CephPrimaryGroup []string
 
+// Only the listed file systems are allow to create and delete
+var FileSystemCreationAllowed = []string{"instances", "image-conversion"}
+
 var _ reconcile.Reconciler = &HostReconciler{}
 
 // HostReconciler reconciles a Host object
@@ -741,7 +744,7 @@ func (r *HostReconciler) ReconcileEnabledHost(client *gophercloud.ServiceClient,
 		}
 	}
 
-	err = r.ReconcileFileSystems(client, instance, profile, host)
+	err = r.ReconcileFileSystemSizes(client, instance, profile, host)
 	if err != nil {
 		return err
 	}
@@ -804,6 +807,50 @@ func (r *HostReconciler) ReconcileDisabledHost(client *gophercloud.ServiceClient
 	}
 
 	return nil
+}
+
+// CompareFileSystemTypes determine if there is difference regarding optional
+// file system types between two profile specs.
+func (r *HostReconciler) CompareFileSystemTypes(in *starlingxv1.HostProfileSpec, other *starlingxv1.HostProfileSpec) bool {
+	if other == nil {
+		return false
+	}
+
+	if (in.Storage == nil) && (other.Storage == nil) {
+		return true
+	} else if in.Storage != nil {
+		if in.Storage.DeepEqual(other.Storage) {
+			// The full storage profile matches therefore the file systems match.
+			return true
+		}
+
+		configured := []string{}
+		current := []string{}
+
+		if in.Storage.FileSystems != nil {
+			for _, fsInfo := range *in.Storage.FileSystems {
+				configured = append(configured, fsInfo.Name)
+			}
+		}
+
+		if other.Storage != nil {
+			if other.Storage.FileSystems != nil {
+				for _, fs := range *other.Storage.FileSystems {
+					current = append(current, fs.Name)
+				}
+			}
+		}
+
+		// Find difference of file system types to add or remove
+		added, removed, _ := utils.ListDelta(current, configured)
+		_, _, fs_to_add := utils.ListDelta(added, FileSystemCreationAllowed)
+		_, _, fs_to_remove := utils.ListDelta(removed, FileSystemCreationAllowed)
+
+		if len(fs_to_remove) > 0 || len(fs_to_add) > 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // CompareOSDs determine if there has been a change to the list of OSDs between
@@ -881,7 +928,7 @@ func (r *HostReconciler) CompareEnabledAttributes(in *starlingxv1.HostProfileSpe
 		}
 	}
 
-	if utils.IsReconcilerEnabled(utils.FileSystems) {
+	if utils.IsReconcilerEnabled(utils.FileSystemSizes) {
 		if in.Storage != nil && in.Storage.FileSystems != nil {
 			if other.Storage == nil {
 				return false
@@ -896,9 +943,9 @@ func (r *HostReconciler) CompareEnabledAttributes(in *starlingxv1.HostProfileSpe
 	return true
 }
 
-// CompareEnabledAttributes determines if two profiles are identical for the
+// CompareDisabledAttributes determines if two profiles are identical for the
 // purpose of reconciling any attributes that can only be applied when the host
-// is enabled.
+// is disabled.
 func (r *HostReconciler) CompareDisabledAttributes(in *starlingxv1.HostProfileSpec, other *starlingxv1.HostProfileSpec, namespace, personality string) bool {
 	if other == nil {
 		return false
@@ -951,6 +998,12 @@ func (r *HostReconciler) CompareDisabledAttributes(in *starlingxv1.HostProfileSp
 			if !in.Routes.DeepEqual(&other.Routes) {
 				return false
 			}
+		}
+	}
+
+	if utils.IsReconcilerEnabled(utils.FileSystemTypes) {
+		if !r.CompareFileSystemTypes(in, other) {
+			return false
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.0
-	github.com/gophercloud/gophercloud v0.0.0-00010101000000-000000000000
 	github.com/imdario/mergo v0.3.12
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo v1.16.5
@@ -43,6 +42,7 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/gophercloud/gophercloud v0.0.0-20221228152023-b0d52f92f75b // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -91,4 +91,5 @@ require (
 )
 
 // replace github.com/gophercloud/gophercloud => ./external/gophercloud
-replace github.com/gophercloud/gophercloud => github.com/wind-river/gophercloud v0.0.0-20221123162006-d0bd787eabad
+
+replace github.com/gophercloud/gophercloud => github.com/yjian118/gophercloud v0.0.0-20221228152023-b0d52f92f75b

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
-	github.com/gophercloud/gophercloud v0.0.0-20221228152023-b0d52f92f75b // indirect
+	github.com/gophercloud/gophercloud v0.0.0-20221230131953-acb6bd9c1992 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -91,5 +91,4 @@ require (
 )
 
 // replace github.com/gophercloud/gophercloud => ./external/gophercloud
-
-replace github.com/gophercloud/gophercloud => github.com/yjian118/gophercloud v0.0.0-20221228152023-b0d52f92f75b
+replace github.com/gophercloud/gophercloud => github.com/wind-river/gophercloud v0.0.0-20221230131953-acb6bd9c1992

--- a/go.sum
+++ b/go.sum
@@ -468,9 +468,9 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/wind-river/gophercloud v0.0.0-20221230131953-acb6bd9c1992 h1:OcLSx93rzGZ50F6HQFS0OqUcQPbeNXzHo+5zeKuPQV4=
+github.com/wind-river/gophercloud v0.0.0-20221230131953-acb6bd9c1992/go.mod h1:FMtdxT0Mwm0oqT7cUYr/C3LBaTZ2vpfVCVykBSTEu7o=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
-github.com/yjian118/gophercloud v0.0.0-20221228152023-b0d52f92f75b h1:Gxy+JFKHjGnUvnghIp/KF77xPuo++vEbTkOx7iRpKjY=
-github.com/yjian118/gophercloud v0.0.0-20221228152023-b0d52f92f75b/go.mod h1:FMtdxT0Mwm0oqT7cUYr/C3LBaTZ2vpfVCVykBSTEu7o=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -468,9 +468,9 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/wind-river/gophercloud v0.0.0-20221123162006-d0bd787eabad h1:Qy521YWsMFedTCo1EGcXglWOTBVJXdGNeNyQcVi0ytk=
-github.com/wind-river/gophercloud v0.0.0-20221123162006-d0bd787eabad/go.mod h1:FMtdxT0Mwm0oqT7cUYr/C3LBaTZ2vpfVCVykBSTEu7o=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+github.com/yjian118/gophercloud v0.0.0-20221228152023-b0d52f92f75b h1:Gxy+JFKHjGnUvnghIp/KF77xPuo++vEbTkOx7iRpKjY=
+github.com/yjian118/gophercloud v0.0.0-20221228152023-b0d52f92f75b/go.mod h1:FMtdxT0Mwm0oqT7cUYr/C3LBaTZ2vpfVCVykBSTEu7o=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Support reconcile file system types
This commit adds support to reconcile file system types(only allowed
types, currently: instances and image-conversion) during the stage
of reconciling the disabled hosts. The orginal file system reconciler
is only to update the file system sized once the host is enabled and
unlocked, rename it as the reconciler of the file system size.

Test passed:
Bring up a storage lab with instances configured on the compute nodes.
The file system can be configured and the host can be in-synced.

Signed-off-by: Yuxing Jiang <Yuxing.Jiang@windriver.com>