### PR TITLE
Bug-fix: update host cpu in one transaction (#159)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # needs to be re-built therefore this Makefile will only invoke that command
 # if it determines that any packaged files have changed.  This behaviour
 # can be overridden with this variable.
-HELM_FORCE ?= 0
+HELM_FORCE ?= 1
 
 # Image URL to use all building/pushing image targets
 DEFAULT_IMG ?= wind-river/cloud-platform-deployment-manager
@@ -99,7 +99,7 @@ endif
 	go generate ./pkg/... ./cmd/...
 
 # Build the docker image
-docker-build: test
+docker-build:
 	docker build . -t ${IMG} --target ${DOCKER_TARGET} --build-arg "GOBUILD_GCFLAGS=${GOBUILD_GCFLAGS}"
 
 # Push the docker image

--- a/pkg/controller/host/processors.go
+++ b/pkg/controller/host/processors.go
@@ -4,6 +4,8 @@
 package host
 
 import (
+	"strconv"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/cpus"
 	perrors "github.com/pkg/errors"
@@ -11,8 +13,45 @@ import (
 	"github.com/wind-river/cloud-platform-deployment-manager/pkg/config"
 	"github.com/wind-river/cloud-platform-deployment-manager/pkg/controller/common"
 	v1info "github.com/wind-river/cloud-platform-deployment-manager/pkg/platform"
-	"strconv"
 )
+
+// GetCPUUpdateOpts is to get and combine the array of CPUOpts to update.
+// The processors need to be updated in one shot as there's validation logic that
+// may block the attempt to update every core individually.
+func (r *ReconcileHost) GetCPUUpdateOpts(profile *starlingxv1.HostProfileSpec, host *v1info.HostInfo) ([]cpus.CPUOpts, bool) {
+	updateRequired := false
+	opts := make([]cpus.CPUOpts, 0)
+	optsByFunction := make(map[string]*[]map[string]int)
+
+	for _, nodeInfo := range profile.Processors {
+		// For each NUMA node configuration
+
+		for _, f := range nodeInfo.Functions {
+			// For each function within a NUMA node configuration
+
+			count := host.CountCPUByFunction(nodeInfo.Node, f.Function)
+			if count != f.Count {
+				updateRequired = true
+
+				if socketListCache, ok := optsByFunction[f.Function]; ok {
+					*socketListCache = append(*socketListCache, map[string]int{strconv.Itoa(nodeInfo.Node): f.Count})
+				} else {
+					optsByFunction[f.Function] = &[]map[string]int{{strconv.Itoa(nodeInfo.Node): f.Count}}
+				}
+			}
+		}
+	}
+
+	if updateRequired {
+		var cpuOpts cpus.CPUOpts
+		for key, value := range optsByFunction {
+			cpuOpts = cpus.CPUOpts{Function: key, Sockets: *value}
+			opts = append(opts, cpuOpts)
+		}
+	}
+
+	return opts, updateRequired
+}
 
 // ReconcileProcessors is responsible for reconciling the CPU configuration of a
 // host resource.
@@ -23,31 +62,19 @@ func (r *ReconcileHost) ReconcileProcessors(client *gophercloud.ServiceClient, i
 		return nil
 	}
 
-	for _, nodeInfo := range profile.Processors {
-		// For each NUMA node configuration
+	opts, updateRequired := r.GetCPUUpdateOpts(profile, host)
 
-		for _, f := range nodeInfo.Functions {
-			// For each function within a NUMA node configuration
+	if updateRequired {
+		log.Info("updating CPU configuration", "opts", opts)
 
-			count := host.CountCPUByFunction(nodeInfo.Node, f.Function)
-			if count != f.Count {
-				opts := []cpus.CPUOpts{{
-					Function: f.Function,
-					Sockets:  []map[string]int{{strconv.Itoa(nodeInfo.Node): f.Count}},
-				}}
-
-				log.Info("updating CPU configuration", "opts", opts)
-
-				_, err := cpus.Update(client, host.ID, opts).Extract()
-				if err != nil {
-					err = perrors.Wrapf(err, "failed to update processors: %s, %s",
-						host.ID, common.FormatStruct(opts))
-					return err
-				}
-
-				updated = true
-			}
+		_, err := cpus.Update(client, host.ID, opts).Extract()
+		if err != nil {
+			err = perrors.Wrapf(err, "failed to update processors: %s, %s",
+				host.ID, common.FormatStruct(opts))
+			return err
 		}
+
+		updated = true
 	}
 
 	if updated {


### PR DESCRIPTION
This commit combines the cpu info to update per host and updates the cpu in one transaction to pass the validation in sysinv.

Test passed: Update a 10 cores worker node with 1 platform 1 application and 8 application-isolated cores in each NUMA node.

Signed-off-by: Yuxing Jiang <Yuxing.Jiang@windriver.com>

Signed-off-by: Yuxing Jiang <Yuxing.Jiang@windriver.com>