### PR TITLE
Deploy tool inserts invalid MaxCpuMhzConfigured entry

### DIFF
--- a/api/v1/constructors.go
+++ b/api/v1/constructors.go
@@ -801,7 +801,9 @@ func NewHostProfileSpec(host v1info.HostInfo) (*HostProfileSpec, error) {
 	}
 	spec.Console = &host.Console
 	spec.InstallOutput = &host.InstallOutput
-	spec.MaxCPUMhzConfigured = &host.MaxCPUMhzConfigured
+	if host.MaxCPUMhzConfigured != "" {
+		spec.MaxCPUMhzConfigured = &host.MaxCPUMhzConfigured
+	}
 	if host.Location.Name != nil && *host.Location.Name != "" {
 		spec.Location = host.Location.Name
 	}


### PR DESCRIPTION
The fix in the previous PR #143 is overridden by #141

Signed-off-by: mmanthir <mahalakshmi.manthiram@windriver.com>