### PR TITLE
Fix device path if it is offered as device node

### DIFF
--- a/api/v1/constructors.go
+++ b/api/v1/constructors.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2023 Wind River Systems, Inc. */
 
 package v1
 
@@ -525,7 +525,7 @@ func parsePhysicalVolumeInfo(group *VolumeGroupInfo, vg *volumegroups.VolumeGrou
 // parsePartitionInfo is a utility which parses the partition data as it is
 // presented by the system API and stores the data in the form required by a
 // profile spec.
-func parseVolumeGroupInfo(profile *HostProfileSpec, host v1info.HostInfo) error {
+func ParseVolumeGroupInfo(profile *HostProfileSpec, host v1info.HostInfo) error {
 	result := make([]VolumeGroupInfo, len(host.VolumeGroups))
 
 	for i, vg := range host.VolumeGroups {
@@ -662,7 +662,7 @@ func parseStorageInfo(profile *HostProfileSpec, host v1info.HostInfo) error {
 	}
 
 	// Fill-in partition attributes
-	err = parseVolumeGroupInfo(profile, host)
+	err = ParseVolumeGroupInfo(profile, host)
 	if err != nil {
 		return err
 	}
@@ -744,11 +744,11 @@ func NewNamespace(name string) (*v1.Namespace, error) {
 	return &namespace, nil
 }
 
-// fixDevicePath is a utility function that take a legacy formatted device
+// FixDevicePath is a utility function that take a legacy formatted device
 // path (e.g., sda or /dev/sda) and convert it to the newer format which is
 // more explicit
 // (e.g., /dev/disk/by-path/pci-0000:00:14.0-usb-0:1:1.0-scsi-0:0:0:0).
-func fixDevicePath(path string, host v1info.HostInfo) string {
+func FixDevicePath(path string, host v1info.HostInfo) string {
 	shortFormNode := regexp.MustCompile(`(?s)^\w+$`)
 	longFormNode := regexp.MustCompile(`(?s)^/dev/\w+$`)
 
@@ -806,9 +806,9 @@ func NewHostProfileSpec(host v1info.HostInfo) (*HostProfileSpec, error) {
 		spec.Location = host.Location.Name
 	}
 
-	bootDevice := fixDevicePath(host.BootDevice, host)
+	bootDevice := FixDevicePath(host.BootDevice, host)
 	spec.BootDevice = &bootDevice
-	rootDevice := fixDevicePath(host.RootDevice, host)
+	rootDevice := FixDevicePath(host.RootDevice, host)
 	spec.RootDevice = &rootDevice
 	clock := *host.ClockSynchronization
 	clockCopied := clock[0:] // Copy ClockSynchronization value
@@ -871,7 +871,7 @@ func NewHostProfileSpec(host v1info.HostInfo) (*HostProfileSpec, error) {
 		return nil, err
 	}
 
-	// Fill-in Route attributes
+	// Fill-in Storage attributes
 	err = parseStorageInfo(&spec, host)
 	if err != nil {
 		return nil, err

--- a/api/v1/constructors_test.go
+++ b/api/v1/constructors_test.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2023 Wind River Systems, Inc. */
 
 package v1
 
@@ -88,7 +88,7 @@ var _ = Describe("Constructor utils for kind", func() {
 						want: "/dev/sdc"},
 				}
 				for _, tt := range tests {
-					got := fixDevicePath(tt.args.path, tt.args.host)
+					got := FixDevicePath(tt.args.path, tt.args.host)
 					Expect(reflect.DeepEqual(got, tt.want)).To(BeTrue())
 				}
 			})

--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2023 Wind River Systems, Inc. */
 
 package host
 
@@ -1318,8 +1318,6 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 	}
 	defaults.BoardManagement = &bmInfo
 
-	FixProfileAttributes(defaults, profile, current)
-
 	// Create a new composite profile that is backed by the host's default
 	// configuration.  This will ensure that if a user deletes an optional
 	// attribute that we will know how to restore the original value.
@@ -1327,6 +1325,11 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 	if err != nil {
 		return err
 	}
+
+	// Fix attributes in profiles to a uniformed format
+	// As the Merge Profiles will overwrite some formate in the default profile
+	// parsed in the constructor, move this process after it.
+	FixProfileAttributes(defaults, profile, current, &hostInfo)
 
 	// TODO(alegacy): Need to move ProvisioningMode out of the profile or
 	//  find a way to populate it into profiles generated from the running

--- a/controllers/host/profile_utils.go
+++ b/controllers/host/profile_utils.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2023 Wind River Systems, Inc. */
 
 package host
 
@@ -16,6 +16,7 @@ import (
 	perrors "github.com/pkg/errors"
 	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
 	"github.com/wind-river/cloud-platform-deployment-manager/controllers/common"
+	v1info "github.com/wind-river/cloud-platform-deployment-manager/platform"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -33,7 +34,7 @@ func MergeProfiles(a, b *starlingxv1.HostProfileSpec) (*starlingxv1.HostProfileS
 }
 
 // FixProfileAttributes makes some adjustments to profile attributes
-func FixProfileAttributes(a, b, c *starlingxv1.HostProfileSpec) {
+func FixProfileAttributes(a, b, c *starlingxv1.HostProfileSpec, hostInfo *v1info.HostInfo) {
 	// To compare the BootMAC's we need to lowercase the values
 	if a.BootMAC != nil {
 		lowerDefaultsBootMAC := strings.ToLower(*a.BootMAC)
@@ -59,6 +60,43 @@ func FixProfileAttributes(a, b, c *starlingxv1.HostProfileSpec) {
 			}
 		}
 	}
+	FixProfileDevicePath(a, hostInfo)
+}
+
+// FixProfileDevicePath is to fix the device path if it is offered as device node
+func FixProfileDevicePath(a *starlingxv1.HostProfileSpec, hostInfo *v1info.HostInfo) {
+	if a.RootDevice != nil {
+		rootDevice := starlingxv1.FixDevicePath(*a.RootDevice, *hostInfo)
+		a.RootDevice = &rootDevice
+	}
+
+	if a.BootDevice != nil {
+		bootDevice := starlingxv1.FixDevicePath(*a.BootDevice, *hostInfo)
+		a.BootDevice = &bootDevice
+	}
+
+	if a.Storage.OSDs != nil {
+		FixOSDDevicePath(a, hostInfo)
+	}
+
+	if a.Storage.VolumeGroups != nil {
+		err := starlingxv1.ParseVolumeGroupInfo(a, *hostInfo)
+		if err != nil {
+			logHost.Error(err, "Failed to parse volume group")
+		}
+	}
+}
+
+// FixOSDDevicePath is to fix device path in the profile's OSD spec
+func FixOSDDevicePath(a *starlingxv1.HostProfileSpec, hostInfo *v1info.HostInfo) {
+
+	result := make([]starlingxv1.OSDInfo, 0)
+	for _, o := range *a.Storage.OSDs {
+		o.Path = starlingxv1.FixDevicePath(o.Path, *hostInfo)
+		result = append(result, o)
+	}
+	list := starlingxv1.OSDList(result)
+	a.Storage.OSDs = &list
 }
 
 // GetHostProfile retrieves a HostProfileSpec from the kubernetes API

--- a/controllers/host/storage.go
+++ b/controllers/host/storage.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2023 Wind River Systems, Inc. */
 
 package host
 


### PR DESCRIPTION
This commit fix the issue if the device path is offered as device node in the deployment configurations.

Test plan
1 . Deploy a storage system with the root_device, boot_device are configured as /dev/sda, the cgts-lv is configured as /dev/sda5, the osd is configured as /dev/sdb in the controller-0
2. Varify the system is deployed with the device path associated with the device node. All resource are in-sync and reconciled after the deployment.

Signed-off-by: Yuxing Jiang <Yuxing.Jiang@windriver.com>