### PR TITLE
Bug fix: fix volume group in default spec (#172)

### DIFF
--- a/api/v1/constructors.go
+++ b/api/v1/constructors.go
@@ -525,7 +525,7 @@ func parsePhysicalVolumeInfo(group *VolumeGroupInfo, vg *volumegroups.VolumeGrou
 // parsePartitionInfo is a utility which parses the partition data as it is
 // presented by the system API and stores the data in the form required by a
 // profile spec.
-func ParseVolumeGroupInfo(profile *HostProfileSpec, host v1info.HostInfo) error {
+func parseVolumeGroupInfo(profile *HostProfileSpec, host v1info.HostInfo) error {
 	result := make([]VolumeGroupInfo, len(host.VolumeGroups))
 
 	for i, vg := range host.VolumeGroups {
@@ -662,7 +662,7 @@ func parseStorageInfo(profile *HostProfileSpec, host v1info.HostInfo) error {
 	}
 
 	// Fill-in partition attributes
-	err = ParseVolumeGroupInfo(profile, host)
+	err = parseVolumeGroupInfo(profile, host)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The previous commit: b41223ff73d94bbe8c2c068fdbe942a11bb2b457(PR: #170) introduced a bug when fixing the device path of the physical volumes in volume groups. And it escaped the test in that commit without an extra volume configured.

This commit re-write the function to fix the device path of the physical volumes rather than re-using the exising parse fucntion in the constructor to address this issue.

Test plan:
Passed: deploy an AIOSX system with cgts-lv configured in sda and nova- local volume configured in sdc.

Signed-off-by: Yuxing Jiang <Yuxing.Jiang@windriver.com>
(cherry picked from commit 568f5a3f6c77af11e84d2188011e66532ef4985d)