### PR TITLE
Prevent restarting incorrect pod on playbook

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -238,7 +238,7 @@
     - block:
       - name: Search for the pod of the Deployment Manager
         shell: |
-          kubectl -n platform-deployment-manager get pods | awk 'NR == 2 { print $1 }'
+          kubectl -n platform-deployment-manager get pods | grep platform-deployment-manager- | awk 'NR == 1 { print $1 }'
         environment:
           KUBECONFIG: "/etc/kubernetes/admin.conf"
         register: deployment_manager_pod_name


### PR DESCRIPTION
This commit fix the issue of selecting the wrong pod to restart while running the task "Search for the pod of the Deployment Manager" on playbook "docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml". While running the mentioned task, if there are more pods on the platform-deployment-manager namespace, another pod could be selected instead of the Deployment Manager pod.

Test plan
1. On a system, verify that Deployment Manager is present and dm-monitor is not present
2. Run the playbook "docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml"
3. Check on the logs if the Deployment Manager pod was the one selected to be restarted
4. Install the dm-monitor
5. Verify that dm-monitor is listed on platform-deployment-manager namespace by running "kubectl -n platform-deployment-manager get pods"
6. Run the playbook "docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml"
7. Check on the logs that the Deployment Manager pod was the one selected to be restarted

Signed-off-by: Guilherme Costa <guilherme.costa@windriver.com>