### PR TITLE
Add support for device node mapper format

### DIFF
--- a/api/v1/constructors_test.go
+++ b/api/v1/constructors_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Constructor utils for kind", func() {
 		})
 	})
 
-	Describe("fixDevicePath utility", func() {
+	Describe("FixDevicePath utility", func() {
 		Context("with path data", func() {
 			It("should convert it to the newer format", func() {
 				type args struct {
@@ -61,6 +61,8 @@ var _ = Describe("Constructor utils for kind", func() {
 							DevicePath: "/dev/disk/by-path/pci-0000:00:16.0-usb-0:1:1.0-scsi-0:0:0:0"},
 						{DeviceNode: "/dev/sdb",
 							DevicePath: "/dev/disk/by-path/pci-0000:00:17.0-usb-0:1:1.0-scsi-0:0:0:0"},
+						{DeviceNode: "/dev/mapper/mpatha",
+							DevicePath: "/dev/disk/by-id/pci-0000:00:18.0-usb-0:1:1.0-scsi-0:0:0:0"},
 					},
 				}
 				tests := []struct {
@@ -86,6 +88,18 @@ var _ = Describe("Constructor utils for kind", func() {
 					{name: "not-found",
 						args: args{path: "/dev/sdc", host: host1},
 						want: "/dev/sdc"},
+					{name: "imcomplete-mapper-not-found",
+						args: args{path: "mpatha", host: host1},
+						want: "mpatha"},
+					{name: "mapper-form",
+						args: args{path: "/dev/mapper/mpatha", host: host1},
+						want: "/dev/disk/by-id/pci-0000:00:18.0-usb-0:1:1.0-scsi-0:0:0:0"},
+					{name: "path-form",
+						args: args{path: "/dev/disk/by-id/pci-0000:00:18.0-usb-0:1:1.0-scsi-0:0:0:0", host: host1},
+						want: "/dev/disk/by-id/pci-0000:00:18.0-usb-0:1:1.0-scsi-0:0:0:0"},
+					{name: "imcomplete-path-form-not-found",
+						args: args{path: "pci-0000:00:18.0-usb-0:1:1.0-scsi-0:0:0:0", host: host1},
+						want: "pci-0000:00:18.0-usb-0:1:1.0-scsi-0:0:0:0"},
 				}
 				for _, tt := range tests {
 					got := FixDevicePath(tt.args.path, tt.args.host)


### PR DESCRIPTION
This commit changes the method to identify the device path and device node. It returns the device path starts from /dev/disk/, then tries to use the string as device node to find the device path, finally returns the string as device path if finding nothing matches.

With this commit, the following format will be accepted: 1 Short format: e.g. sda
2 Long format: e.g. /dev/sda, /dev/sdaa, /dev/mapper/mpatha 3 Path format: e.g.
  /dev/disk/by-path/pci-0000:00:14.0-usb-0:1:1.0-scsi-0:0:0:0,
  /dev/disk/by-id/pci-0000:00:14.0-usb-0:1:1.0-scsi-0:0:0:0

Not supported format:
1 Incompelete long format of device node: e.g.
  mpatha
2 Incompelete shor format of device path: e.g.
  pci-0000:00:14.0-usb-0:1:1.0-scsi-0:0:0:0

Test plan:
1 Deploy use device node(long, short) - pass
2 Deploy use device path - pass