### PR TITLE
Bug-fix: remove duplicates caused by device format

### DIFF
--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -105,6 +105,12 @@ func FormatStruct(obj interface{}) string {
 	return string(buf)
 }
 
+func CompareStructs(a, b interface{}) bool {
+	bufferA, _ := json.Marshal(a)
+	bufferB, _ := json.Marshal(b)
+	return string(bufferA) == string(bufferB)
+}
+
 // ReconcilerErrorHandler defines the interface type associated to any
 // reconciler error handler.
 type ReconcilerErrorHandler interface {

--- a/controllers/common/common_suite_test.go
+++ b/controllers/common/common_suite_test.go
@@ -7,9 +7,85 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	v1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
 )
 
 func TestCommon(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Common Suite")
 }
+
+var _ = Describe("CompareStructs utils", func() {
+	Describe("compare two structs", func() {
+		Context("with same string covered from structs ", func() {
+			It("should return true for PhysicalVolumeInfo", func() {
+				size1 := 128
+				size2 := 128
+				structA := v1.PhysicalVolumeInfo{
+					Type: "cgts",
+					Path: "/dev/disk/by-path/pci-0000:00:1.0-usb-0:1:1.0-scsi-0:0:0:0",
+					Size: &size1,
+				}
+				structB := v1.PhysicalVolumeInfo{
+					Type: "cgts",
+					Path: "/dev/disk/by-path/pci-0000:00:1.0-usb-0:1:1.0-scsi-0:0:0:0",
+					Size: &size2,
+				}
+				equalPhysicalVolumeInfo := CompareStructs(structA, structB)
+				Expect(equalPhysicalVolumeInfo).To(BeTrue())
+			})
+			It("should return false for PhysicalVolumeInfo", func() {
+				size1 := 128
+				size2 := 128
+				structA := v1.PhysicalVolumeInfo{
+					Type: "cgts",
+					Path: "/dev/disk/by-path/pci-0000:00:1.0-usb-0:1:1.0-scsi-0:0:0:0",
+					Size: &size1,
+				}
+				structB := v1.PhysicalVolumeInfo{
+					Type: "cgts",
+					Path: "/dev/disk/by-path/pci-0000:00:1.0-usb-0:1:2.0-scsi-0:0:0:0",
+					Size: &size2,
+				}
+				equalPhysicalVolumeInfo := CompareStructs(structA, structB)
+				Expect(equalPhysicalVolumeInfo).To(BeFalse())
+			})
+			It("should return true for OSDInfo", func() {
+				cluster1 := "ceph_cluster"
+				cluster2 := "ceph_cluster"
+				structC := v1.OSDInfo{
+					Function:    "osd",
+					Path:        "/dev/disk/by-id/wwn-0x60002ac0000000000000000800029aaa",
+					ClusterName: &cluster1,
+					Journal:     nil,
+				}
+				structD := v1.OSDInfo{
+					Function:    "osd",
+					Path:        "/dev/disk/by-id/wwn-0x60002ac0000000000000000800029aaa",
+					ClusterName: &cluster2,
+					Journal:     nil,
+				}
+				equalOSDInfo := CompareStructs(structC, structD)
+				Expect(equalOSDInfo).To(BeTrue())
+			})
+			It("should return false for OSDInfo", func() {
+				cluster1 := "ceph_cluster"
+				cluster2 := "ceph_cluster"
+				structC := v1.OSDInfo{
+					Function:    "osd",
+					Path:        "/dev/disk/by-id/wwn-0x60002ac0000000000000000800029aaa",
+					ClusterName: &cluster1,
+					Journal:     nil,
+				}
+				structD := v1.OSDInfo{
+					Function:    "osd",
+					Path:        "/dev/disk/by-id/wwn-0x60002ac0000000000000000800029aab",
+					ClusterName: &cluster2,
+					Journal:     nil,
+				}
+				equalOSDInfo := CompareStructs(structC, structD)
+				Expect(equalOSDInfo).To(BeFalse())
+			})
+		})
+	})
+})

--- a/controllers/host/profile_utils.go
+++ b/controllers/host/profile_utils.go
@@ -89,8 +89,24 @@ func FixOSDDevicePath(a *starlingxv1.HostProfileSpec, hostInfo *v1info.HostInfo)
 
 	result := make([]starlingxv1.OSDInfo, 0)
 	for _, o := range *a.Storage.OSDs {
+		found := false
 		o.Path = starlingxv1.FixDevicePath(o.Path, *hostInfo)
-		result = append(result, o)
+
+		// Check if the element exists with different format(short device node,
+		// full deveice node, device path etc.) in the result list, should
+		// not add duplication the profile.
+		if len(result) > 0 {
+			for _, elem := range result {
+				found = common.CompareStructs(o, elem)
+				if found {
+					break
+				}
+			}
+		}
+
+		if !found {
+			result = append(result, o)
+		}
 	}
 	list := starlingxv1.OSDList(result)
 	a.Storage.OSDs = &list
@@ -119,13 +135,29 @@ func FixPhysicalVolumesPath(a *starlingxv1.PhysicalVolumeList, hostInfo *v1info.
 
 	list := make([]starlingxv1.PhysicalVolumeInfo, 0)
 	for _, pv := range *a {
+		found := false
 		pvPath := starlingxv1.FixDevicePath(pv.Path, *hostInfo)
 		pvInfo := starlingxv1.PhysicalVolumeInfo{
 			Type: pv.Type,
 			Path: pvPath,
 			Size: pv.Size,
 		}
-		list = append(list, pvInfo)
+
+		// Check if the element exists with different format(short device node,
+		// full deveice node, device path etc.) in the result list, should
+		// not add duplication the profile.
+		if len(list) > 0 {
+			for _, elem := range list {
+				found = common.CompareStructs(pvInfo, elem)
+				if found {
+					break
+				}
+			}
+		}
+
+		if !found {
+			list = append(list, pvInfo)
+		}
 	}
 	result := starlingxv1.PhysicalVolumeList(list)
 	return result


### PR DESCRIPTION
After we translate the device node to device path after merge the defaults, the storage can be configured. However, in the case of the pod restart, the host default will be collected and merged with the spec again, in this case the collected the config will be use device path and the merge of the spec will insert a duplicated record as cannot merge the device path with device node.

This commit compares the objects after fixing the device path, prevent adding duplicates into the default config.

Test plan:
1 Deploy an AIOSX node with osd and pv configured with device node 2 After the deployment, check the host "inSync" status turns to true after the initial unlock(pod restart along with the host restart).