### PR TITLE
Add strategy required monitor

### DIFF
--- a/controllers/datanetwork_controller.go
+++ b/controllers/datanetwork_controller.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2023 Wind River Systems, Inc. */
 
 package controllers
 
@@ -243,6 +243,9 @@ func (r *DataNetworkReconciler) statusUpdateRequired(instance *starlingxv1.DataN
 		status.Reconciled = true
 		status.ConfigurationUpdated = false
 		status.StrategyRequired = cloudManager.StrategyNotRequired
+		if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
+			r.CloudManager.SetResourceInfo(cloudManager.ResourceDatanetwork, "", instance.Name, status.Reconciled, status.StrategyRequired)
+		}
 		result = true
 	}
 
@@ -427,6 +430,11 @@ func (r *DataNetworkReconciler) UpdateConfigStatus(instance *starlingxv1.DataNet
 			// Case: Fresh install or Day-2 operation
 			instance.Status.ConfigurationUpdated = true
 			instance.Status.Reconciled = false
+			if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
+				// Update storategy required status for strategy monitor
+				r.CloudManager.UpdateConfigVersion()
+				r.CloudManager.SetResourceInfo(cloudManager.ResourceDatanetwork, "", instance.Name, instance.Status.Reconciled, cloudManager.StrategyNotRequired)
+			}
 		}
 		instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
 		// Reset strategy when new configration is applied

--- a/controllers/platformnetwork_controller.go
+++ b/controllers/platformnetwork_controller.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2023 Wind River Systems, Inc. */
 
 package controllers
 
@@ -555,6 +555,9 @@ func (r *PlatformNetworkReconciler) ReconcileResource(client *gophercloud.Servic
 		if instance.Status.Reconciled {
 			instance.Status.ConfigurationUpdated = false
 			instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
+			if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
+				r.CloudManager.SetResourceInfo(cloudManager.ResourcePlatformnetwork, "", instance.Name, instance.Status.Reconciled, cloudManager.StrategyNotRequired)
+			}
 		}
 
 		if r.statusUpdateRequired(instance, oldStatus) {
@@ -688,6 +691,11 @@ func (r *PlatformNetworkReconciler) UpdateConfigStatus(instance *starlingxv1.Pla
 			// Case: Fresh install or Day-2 operation
 			instance.Status.ConfigurationUpdated = true
 			instance.Status.Reconciled = false
+			if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
+				// Update storategy required status for strategy monitor
+				r.CloudManager.UpdateConfigVersion()
+				r.CloudManager.SetResourceInfo(cloudManager.ResourcePlatformnetwork, "", instance.Name, instance.Status.Reconciled, cloudManager.StrategyNotRequired)
+			}
 		}
 		instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
 		// Reset strategy when new configration is applied

--- a/controllers/ptpinstance_controller.go
+++ b/controllers/ptpinstance_controller.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2022 Wind River Systems, Inc. */
+/* Copyright(c) 2022-2023 Wind River Systems, Inc. */
 
 package controllers
 
@@ -217,6 +217,9 @@ func (r *PtpInstanceReconciler) statusUpdateRequired(instance *starlingxv1.PtpIn
 		status.Reconciled = true
 		status.ConfigurationUpdated = false
 		status.StrategyRequired = cloudManager.StrategyNotRequired
+		if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
+			r.CloudManager.SetResourceInfo(cloudManager.ResourcePtpinstance, "", instance.Name, status.Reconciled, status.StrategyRequired)
+		}
 		result = true
 	}
 
@@ -478,6 +481,11 @@ func (r *PtpInstanceReconciler) UpdateConfigStatus(instance *starlingxv1.PtpInst
 			// Case: Fresh install or Day-2 operation
 			instance.Status.ConfigurationUpdated = true
 			instance.Status.Reconciled = false
+			if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
+				// Update storategy required status for strategy monitor
+				r.CloudManager.UpdateConfigVersion()
+				r.CloudManager.SetResourceInfo(cloudManager.ResourcePtpinstance, "", instance.Name, instance.Status.Reconciled, cloudManager.StrategyNotRequired)
+			}
 		}
 		instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
 		// Reset strategy when new configration is applied

--- a/controllers/ptpinterface_controller.go
+++ b/controllers/ptpinterface_controller.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2022 Wind River Systems, Inc. */
+/* Copyright(c) 2022-2023 Wind River Systems, Inc. */
 
 package controllers
 
@@ -242,6 +242,9 @@ func (r *PtpInterfaceReconciler) statusUpdateRequired(instance *starlingxv1.PtpI
 		status.Reconciled = true
 		status.ConfigurationUpdated = false
 		status.StrategyRequired = cloudManager.StrategyNotRequired
+		if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
+			r.CloudManager.SetResourceInfo(cloudManager.ResourcePtpinterface, "", instance.Name, status.Reconciled, status.StrategyRequired)
+		}
 		result = true
 	}
 
@@ -502,6 +505,11 @@ func (r *PtpInterfaceReconciler) UpdateConfigStatus(instance *starlingxv1.PtpInt
 			// Case: Fresh install or Day-2 operation
 			instance.Status.ConfigurationUpdated = true
 			instance.Status.Reconciled = false
+			if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
+				// Update storategy required status for strategy monitor
+				r.CloudManager.UpdateConfigVersion()
+				r.CloudManager.SetResourceInfo(cloudManager.ResourcePtpinterface, "", instance.Name, instance.Status.Reconciled, cloudManager.StrategyNotRequired)
+			}
 		}
 		instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
 		// Reset strategy when new configration is applied

--- a/controllers/system/system_controller.go
+++ b/controllers/system/system_controller.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2023 Wind River Systems, Inc. */
 
 package system
 
@@ -516,6 +516,7 @@ func (r *SystemReconciler) FileSystemResizeAllowed(instance *starlingxv1.System,
 	if !r.ControllerNodesAvailable(required) {
 		if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
 			instance.Status.StrategyRequired = cloudManager.StrategyUnlockRequired
+			r.CloudManager.SetResourceInfo(cloudManager.ResourceSystem, "", instance.Name, instance.Status.Reconciled, instance.Status.StrategyRequired)
 			err := r.Client.Status().Update(context.TODO(), instance)
 			if err != nil {
 				err = perrors.Wrapf(err, "failed to update status: %s",
@@ -1063,6 +1064,9 @@ func (r *SystemReconciler) statusUpdateRequired(instance *starlingxv1.System, in
 		status.Reconciled = true
 		status.ConfigurationUpdated = false
 		status.StrategyRequired = cloudManager.StrategyNotRequired
+		if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
+			r.CloudManager.SetResourceInfo(cloudManager.ResourceSystem, "", instance.Name, status.Reconciled, status.StrategyRequired)
+		}
 		result = true
 	}
 
@@ -1410,6 +1414,11 @@ func (r *SystemReconciler) UpdateConfigStatus(instance *starlingxv1.System) (err
 			// Case: Fresh install or Day-2 operation
 			instance.Status.ConfigurationUpdated = true
 			instance.Status.Reconciled = false
+			if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
+				// Update storategy required status for strategy monitor
+				r.CloudManager.UpdateConfigVersion()
+				r.CloudManager.SetResourceInfo(cloudManager.ResourceSystem, "", instance.Name, instance.Status.Reconciled, cloudManager.StrategyNotRequired)
+			}
 		}
 		instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
 		// Reset strategy when new configration is applied

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.0
-	github.com/gophercloud/gophercloud v0.0.0-20230224150951-d211b6ea1eb4
+	github.com/gophercloud/gophercloud v0.0.0-20230605171524-742ad279b1e1
 	github.com/imdario/mergo v0.3.12
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo v1.16.5
@@ -91,4 +91,4 @@ require (
 )
 
 // replace github.com/gophercloud/gophercloud => ./external/gophercloud
-replace github.com/gophercloud/gophercloud => github.com/Wind-River/gophercloud v0.0.0-20230224150951-d211b6ea1eb4
+replace github.com/gophercloud/gophercloud => github.com/Wind-River/gophercloud v0.0.0-20230605171524-742ad279b1e1

--- a/go.sum
+++ b/go.sum
@@ -61,10 +61,8 @@ github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMo
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/Wind-River/gophercloud v0.0.0-20230119154844-fa8a1286cb56 h1:Y8TGaHv3Bc1dBa+9iyP68I8SimdOHcDYGEz6iW+nwwI=
-github.com/Wind-River/gophercloud v0.0.0-20230119154844-fa8a1286cb56/go.mod h1:FMtdxT0Mwm0oqT7cUYr/C3LBaTZ2vpfVCVykBSTEu7o=
-github.com/Wind-River/gophercloud v0.0.0-20230224150951-d211b6ea1eb4 h1:6s7J0fx4+x43Ja7ge3UaVB/hGLIPZQ+u5Fnw4R3J+Kg=
-github.com/Wind-River/gophercloud v0.0.0-20230224150951-d211b6ea1eb4/go.mod h1:FMtdxT0Mwm0oqT7cUYr/C3LBaTZ2vpfVCVykBSTEu7o=
+github.com/Wind-River/gophercloud v0.0.0-20230605171524-742ad279b1e1 h1:RPRBCbS7wy9IfaG8RqK267OZKlBWo4Pb9QmdZDnGvnE=
+github.com/Wind-River/gophercloud v0.0.0-20230605171524-742ad279b1e1/go.mod h1:FMtdxT0Mwm0oqT7cUYr/C3LBaTZ2vpfVCVykBSTEu7o=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -458,8 +456,6 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.8.1 h1:Kq1fyeebqsBfbjZj4EL7gj2IO0mMaiyjYUWcUsl2O44=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
-github.com/sselvara1/gophercloud v0.0.0-20230223101244-77c13c232f8c h1:rOCmZUK/TAwh5XnjlfxORmcm/9KDWZdlIXlvqEYD+1g=
-github.com/sselvara1/gophercloud v0.0.0-20230223101244-77c13c232f8c/go.mod h1:FMtdxT0Mwm0oqT7cUYr/C3LBaTZ2vpfVCVykBSTEu7o=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -474,8 +470,6 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/wind-river/gophercloud v0.0.0-20221230131953-acb6bd9c1992 h1:OcLSx93rzGZ50F6HQFS0OqUcQPbeNXzHo+5zeKuPQV4=
-github.com/wind-river/gophercloud v0.0.0-20221230131953-acb6bd9c1992/go.mod h1:FMtdxT0Mwm0oqT7cUYr/C3LBaTZ2vpfVCVykBSTEu7o=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Currently each reconciler has a status for strategy required. To send a strategy via VIM, DM needs to centralize to all resource strategy required status and judge if node needs the strategy.

This patch included:
- Add strategy required monitor which will create strategy request when needed
- Add resource information in manager to store strategy required status in each resource

Test Plan:
PASS: Create lock require strategy when lock required host
      parameter is applied in unlocked node
PASS: Create unlock require strategy when unlock required
      host parameter is applied in locked node
PASS: Create unlock require strategy when unlock required
      system parameter is applied in locked node
PASS: Not create strategy when no strategy required
      parameter is applied
PASS: Create strategy for controller when strategy
      required parameter is applied in controller
PASS: Create strategy for storage when strategy
      required parameter is applied in storage
PASS: Create strategy for worker when strategy
      required parameter is applied in worker