### PR TITLE
Fix for subcloud deployment

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -535,7 +535,7 @@
               timeout: 450
               msg: Waiting after unlock due to apply DM config
             register: waiting_after_reboot
-            failed_when: false
+            ignore_errors: true
 
           # Retry block: sometimes system reboots twice
           - block:
@@ -565,7 +565,7 @@
               register: new_reboot
               when: waiting_after_new_reboot.failed
 
-            when: (waiting_after_reboot.rc != 0)
+            when: waiting_after_reboot.failed
 
 
           # After reboot, wait some time for resources to be reconciled.


### PR DESCRIPTION
Last playbook commit introduced a particular issue with the evaluated condition after unlocking (wait task is not always returning rc:0 in case of success). This commit aims to solve this recently introduced issue by replacing the condition.

Test plan:
PASS: deploy subcloud in environment without second
      reboot.
      verify that deploy is completed.
PASS: deploy subcloud in environment with second reboot.
      Verify deploy is completed.