### PR TITLE
Fix for second reboot issue.

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -508,7 +508,7 @@
               timeout: 450
               msg: Waiting after unlock due to apply DM config
             register: waiting_after_reboot
-            failed_when: false
+            ignore_errors: true
 
           # Retry block: sometimes system reboots twice
           - block:
@@ -538,7 +538,7 @@
               register: new_reboot
               when: waiting_after_new_reboot.failed
 
-            when: (waiting_after_reboot.rc != 0)
+            when: waiting_after_reboot.failed
 
 
           # After reboot, wait some time for resources to be reconciled.

--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -475,6 +475,18 @@
         # if unlock was triggered, wait until unlock complete
         # and check resources and logs.
         - block:
+          # check close-open port before starting last verifications
+          - name: Waiting for port to be closed due to unlock task
+            local_action:
+              module: wait_for
+                port={{ ansible_port }}
+                host={{ ansible_host }}
+                delay={{ boot_wait_time }}
+                timeout={{ wait_for_timeout }}
+                state=stopped
+            retries: 20
+            delay: 20
+
           - name: Waiting for port to become open
             local_action:
               module: wait_for
@@ -483,14 +495,51 @@
                 delay={{ boot_wait_time }}
                 timeout={{ wait_for_timeout }}
                 state=started
-            register: waiting_unlock
             retries: 40
             delay: 20
 
           # Waiting task after unlock to catch right status
+          # This simple task usually doesn't fail. However, in some
+          # cases, after unlocking, we may encounter two reboots. In such
+          # situations, this task might fail due to a loss of connection.
+          # If that happens, the following block will wait for the
+          # subsequent reboot.
           - wait_for:
               timeout: 450
               msg: Waiting after unlock due to apply DM config
+            register: waiting_after_reboot
+            failed_when: false
+
+          # Retry block: sometimes system reboots twice
+          - block:
+            - name: Waiting for port to become open on second reboot
+              local_action:
+                module: wait_for
+                  port={{ ansible_port }}
+                  host={{ ansible_host }}
+                  delay={{ boot_wait_time }}
+                  timeout={{ wait_for_timeout }}
+                  state=started
+              retries: 40
+              delay: 20
+
+            # Waiting task after unlock to catch right status
+            - wait_for:
+                timeout: 450
+                msg: Waiting after unlock due to apply DM config
+              register: waiting_after_new_reboot
+              ignore_errors: true
+
+            - name: Fail in case of new loss of connection
+              fail:
+                msg:
+                  - "Unexpected loss of connection. Check subcloud status manually."
+                  - "Then, use subcloud reconfig command to complete deployment"
+              register: new_reboot
+              when: waiting_after_new_reboot.failed
+
+            when: (waiting_after_reboot.rc != 0)
+
 
           # After reboot, wait some time for resources to be reconciled.
           # If we have all of them reconciled, playbook won't fail.


### PR DESCRIPTION
In certain subcloud lab environments, there may be cases where a second reboot occurs after launching the unlock task. This situation can cause the subcloud deployment to be marked as failed.
To address this issue, this commit:
- Added a wait until the Ansible port is closed. This ensures that the subsequent 'wait until port become open' task waits for the connection to reopen after it has been effectively closed.
- Implemented a retry block to handle the possibility of a second reboot. This was necessary because, in practice, the 'wait_for' task sometimes fails due to a loss of connection during the second reboot.
- Included a brief message to highlight the potential issue in case a third reboot and recommend reconfiguring the subcloud.

Test plan:
PASS: Deploy subcloud in labs where the second reboot is being done.
      Verify desired behavior of the task:'Waiting for port to be
      closed due to unlock task'
      Verify desired behavior of the retry block and deploy-status
      complete after this.
PASS: Launch playbook without a second reboot.
      Verify the retry block is skipped.
PASS: Launch playbook forcing manually a third reboot.
      Verify playbook fails with message.

Signed-off-by: fperez <fabrizio.perez@windriver.com>
(cherry picked from commit 68d4d797f69e4bd3d8208f178310e265781b4326)