### PR TITLE
Correct cert-manager examples (#238)

### DIFF
--- a/examples/aio-dx-https-with-cert-manager.yaml
+++ b/examples/aio-dx-https-with-cert-manager.yaml
@@ -10,7 +10,7 @@ data:
   tls.key: ""
 kind: Secret
 metadata:
-  name: system-local-ca
+  name: custom-local-ca
   namespace: cert-manager
 type: kubernetes.io/tls
 ---
@@ -49,7 +49,7 @@ spec:
   - ""
   issuerRef:
     kind: ClusterIssuer
-    name: system-local-ca
+    name: custom-local-ca
   renewBefore: 360h
   secretName: system-registry-local-certificate
   subject:
@@ -74,7 +74,7 @@ spec:
   - ""
   issuerRef:
     kind: ClusterIssuer
-    name: system-local-ca
+    name: custom-local-ca
   renewBefore: 360h
   secretName: system-restapi-gui-certificate
   subject:
@@ -88,10 +88,10 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: system-local-ca
+  name: custom-local-ca
 spec:
   ca:
-    secretName: system-local-ca
+    secretName: custom-local-ca
 ---
 apiVersion: starlingx.windriver.com/v1
 kind: DataNetwork

--- a/examples/aio-dx/https-with-cert-manager/platform_certificate_certmanager.yaml
+++ b/examples/aio-dx/https-with-cert-manager/platform_certificate_certmanager.yaml
@@ -5,17 +5,17 @@ data:
   tls.key: ""
 kind: Secret
 metadata:
-  name: system-local-ca
+  name: custom-local-ca
   namespace: cert-manager
 type: kubernetes.io/tls
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: system-local-ca
+  name: custom-local-ca
 spec:
   ca:
-    secretName: system-local-ca
+    secretName: custom-local-ca
 ---
 # StarlingX REST & GUI Certificate
 apiVersion: cert-manager.io/v1
@@ -26,7 +26,7 @@ metadata:
 spec:
   secretName: system-restapi-gui-certificate
   issuerRef:
-    name: system-local-ca
+    name: custom-local-ca
     kind: ClusterIssuer
   duration: 2160h    # 90d
   renewBefore: 360h  # 15d
@@ -52,7 +52,7 @@ metadata:
 spec:
   secretName: system-registry-local-certificate
   issuerRef:
-    name: system-local-ca
+    name: custom-local-ca
     kind: ClusterIssuer
   duration: 2160h    # 90d
   renewBefore: 360h  # 15d

--- a/examples/aio-sx-https-with-cert-manager.yaml
+++ b/examples/aio-sx-https-with-cert-manager.yaml
@@ -10,7 +10,7 @@ data:
   tls.key: ""
 kind: Secret
 metadata:
-  name: system-local-ca
+  name: custom-local-ca
   namespace: cert-manager
 type: kubernetes.io/tls
 ---
@@ -49,7 +49,7 @@ spec:
   - ""
   issuerRef:
     kind: ClusterIssuer
-    name: system-local-ca
+    name: custom-local-ca
   renewBefore: 360h
   secretName: system-registry-local-certificate
   subject:
@@ -74,7 +74,7 @@ spec:
   - ""
   issuerRef:
     kind: ClusterIssuer
-    name: system-local-ca
+    name: custom-local-ca
   renewBefore: 360h
   secretName: system-restapi-gui-certificate
   subject:
@@ -88,10 +88,10 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: system-local-ca
+  name: custom-local-ca
 spec:
   ca:
-    secretName: system-local-ca
+    secretName: custom-local-ca
 ---
 apiVersion: starlingx.windriver.com/v1
 kind: DataNetwork

--- a/examples/aio-sx/https-with-cert-manager/platform_certificate_certmanager.yaml
+++ b/examples/aio-sx/https-with-cert-manager/platform_certificate_certmanager.yaml
@@ -5,17 +5,17 @@ data:
   tls.key: ""
 kind: Secret
 metadata:
-  name: system-local-ca
+  name: custom-local-ca
   namespace: cert-manager
 type: kubernetes.io/tls
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: system-local-ca
+  name: custom-local-ca
 spec:
   ca:
-    secretName: system-local-ca
+    secretName: custom-local-ca
 ---
 # StarlingX REST & GUI Certificate
 apiVersion: cert-manager.io/v1
@@ -26,7 +26,7 @@ metadata:
 spec:
   secretName: system-restapi-gui-certificate
   issuerRef:
-    name: system-local-ca
+    name: custom-local-ca
     kind: ClusterIssuer
   duration: 2160h    # 90d
   renewBefore: 360h  # 15d
@@ -52,7 +52,7 @@ metadata:
 spec:
   secretName: system-registry-local-certificate
   issuerRef:
-    name: system-local-ca
+    name: custom-local-ca
     kind: ClusterIssuer
   duration: 2160h    # 90d
   renewBefore: 360h  # 15d

--- a/examples/standard-https-with-cert-manager.yaml
+++ b/examples/standard-https-with-cert-manager.yaml
@@ -10,7 +10,7 @@ data:
   tls.key: ""
 kind: Secret
 metadata:
-  name: system-local-ca
+  name: custom-local-ca
   namespace: cert-manager
 type: kubernetes.io/tls
 ---
@@ -47,7 +47,7 @@ spec:
   - ""
   issuerRef:
     kind: ClusterIssuer
-    name: system-local-ca
+    name: custom-local-ca
   renewBefore: 360h
   secretName: system-registry-local-certificate
   subject:
@@ -72,7 +72,7 @@ spec:
   - ""
   issuerRef:
     kind: ClusterIssuer
-    name: system-local-ca
+    name: custom-local-ca
   renewBefore: 360h
   secretName: system-restapi-gui-certificate
   subject:
@@ -86,10 +86,10 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: system-local-ca
+  name: custom-local-ca
 spec:
   ca:
-    secretName: system-local-ca
+    secretName: custom-local-ca
 ---
 apiVersion: starlingx.windriver.com/v1
 kind: DataNetwork

--- a/examples/standard/https-with-cert-manager/platform_certificate_certmanager.yaml
+++ b/examples/standard/https-with-cert-manager/platform_certificate_certmanager.yaml
@@ -5,17 +5,17 @@ data:
   tls.key: ""
 kind: Secret
 metadata:
-  name: system-local-ca
+  name: custom-local-ca
   namespace: cert-manager
 type: kubernetes.io/tls
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: system-local-ca
+  name: custom-local-ca
 spec:
   ca:
-    secretName: system-local-ca
+    secretName: custom-local-ca
 ---
 # StarlingX REST & GUI Certificate
 apiVersion: cert-manager.io/v1
@@ -26,7 +26,7 @@ metadata:
 spec:
   secretName: system-restapi-gui-certificate
   issuerRef:
-    name: system-local-ca
+    name: custom-local-ca
     kind: ClusterIssuer
   duration: 2160h    # 90d
   renewBefore: 360h  # 15d
@@ -52,7 +52,7 @@ metadata:
 spec:
   secretName: system-registry-local-certificate
   issuerRef:
-    name: system-local-ca
+    name: custom-local-ca
     kind: ClusterIssuer
   duration: 2160h    # 90d
   renewBefore: 360h  # 15d


### PR DESCRIPTION
The Deployment Manager documentation examples for cert-manager is incorrect. We should not use the secret system-local-ca when creating issuers since it is reserved by the system.

This change updates the issuer name from system-local-ca to custom-local-ca.