### PR TITLE
Ignore OpenLDAP certificate in system resource

### DIFF
--- a/api/v1/constructors.go
+++ b/api/v1/constructors.go
@@ -928,6 +928,10 @@ func parseCertificateInfo(spec *SystemSpec, certificates []certificates.Certific
 	result := make([]CertificateInfo, 0)
 
 	for index, c := range certificates {
+		// Ignore OpenLDAP certificate since it's being installed during the initial unlock.
+		if c.Type == "openldap" {
+			continue
+		}
 		cert := CertificateInfo{
 			Type: c.Type,
 			// Use a fixed naming so that we can document how we auto-generate


### PR DESCRIPTION
The OpenLDAP certificate is installed during the initial unlock, so it cannot be collected after the bootstrap. This is causeing the system resource to be insync=false after unlock.

This commit intends to ignore this certificate in the DM, so DM will not take action on it.

Test Plan:
PASS: Build an image with these changes. Install it on a system. Verify that after the initial unlock the type: openldap certificate is not present on the current spec.
PASS: Generate the deployment-config.yaml using deploytool. Verify that the openldap certificate is not included on the file.