### PR TITLE
Ignore the administrativeState when scope principal (#216)

### DIFF
--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -647,7 +647,9 @@ func (r *HostReconciler) ReconcilePowerState(client *gophercloud.ServiceClient, 
 // order to change certain attributes.
 func (r *HostReconciler) ReconcileInitialState(client *gophercloud.ServiceClient, instance *starlingxv1.Host, profile *starlingxv1.HostProfileSpec, host *v1info.HostInfo) error {
 	desiredState := profile.AdministrativeState
-	if desiredState != nil && *desiredState != host.AdministrativeState {
+
+	if desiredState != nil && *desiredState != host.AdministrativeState &&
+		instance.Status.DeploymentScope == cloudManager.ScopeBootstrap {
 		if *desiredState == hosts.AdminLocked {
 			action := hosts.ActionLock
 			opts := hosts.HostOpts{
@@ -687,7 +689,8 @@ const MinimumEnabledControllerNodesForNonController = 2
 // host if the desired state is different than the current state.
 func (r *HostReconciler) ReconcileFinalState(client *gophercloud.ServiceClient, instance *starlingxv1.Host, profile *starlingxv1.HostProfileSpec, host *v1info.HostInfo) error {
 	state := profile.AdministrativeState
-	if state == nil || *state == host.AdministrativeState {
+	if state == nil || *state == host.AdministrativeState ||
+		instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
 		// No action required.
 		return nil
 	}


### PR DESCRIPTION
The value "administrativeState" will be ignored when the deployment scope is "principal" to avoid current auto unlock by DM.

Test Plan:
PASS: "make && DEBUG=yes make docker-build" finish successfully PASS: Fresh install with administrative "locked"
PASS: Fresh install administrative "unlocked"
PASS: Apply new configuration with administrativeState "locked"
      on unlocked host and confirm host stays unlocked
PASS: Apply new configuration with administrativeState "unlocked"
      on locked host and confirm host stays locked

Signed-off-by: Takamasa Takenaka <takamasa.takenaka@windriver.com>
(cherry picked from commit 3ad5aadd90cefb1f5847076c52ba95c773183051)