### PR TITLE
Add documentation for Day-2 Operations (#232)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright(c) 2019-2022 Wind River Systems, Inc.
+# Copyright(c) 2019-2023 Wind River Systems, Inc.
 
 # The Helm package command is not capable of figuring out if a package actually
 # needs to be re-built therefore this Makefile will only invoke that command
@@ -258,6 +258,8 @@ examples: kustomize
 	$(KUSTOMIZE) build examples/standard/app-armor > examples/standard-app-armor.yaml
 	$(KUSTOMIZE) build examples/standard/hw-settle > examples/standard-hw-settle.yaml
 	$(KUSTOMIZE) build examples/storage/default > examples/storage.yaml
+	$(KUSTOMIZE) build examples/storage/day2-operation/bootstrap > examples/storage-day2-bootstrap.yaml
+	$(KUSTOMIZE) build examples/storage/day2-operation/principal > examples/storage-day2-principal.yaml
 	$(KUSTOMIZE) build examples/aio-sx/default > examples/aio-sx.yaml
 	$(KUSTOMIZE) build examples/aio-sx/vxlan > examples/aio-sx-vxlan.yaml
 	$(KUSTOMIZE) build examples/aio-sx/https > examples/aio-sx-https.yaml
@@ -267,7 +269,11 @@ examples: kustomize
 	$(KUSTOMIZE) build examples/aio-sx/geo-location > examples/aio-sx-geo-location.yaml
 	$(KUSTOMIZE) build examples/aio-sx/app-armor > examples/aio-sx-app-armor.yaml
 	$(KUSTOMIZE) build examples/aio-sx/hw-settle > examples/aio-sx-hw-settle.yaml
+	$(KUSTOMIZE) build examples/aio-sx/day2-operation/bootstrap > examples/aio-sx-day2-bootstrap.yaml
+	$(KUSTOMIZE) build examples/aio-sx/day2-operation/principal > examples/aio-sx-day2-principal.yaml
 	$(KUSTOMIZE) build examples/aio-dx/default > examples/aio-dx.yaml
 	$(KUSTOMIZE) build examples/aio-dx/vxlan > examples/aio-dx-vxlan.yaml
 	$(KUSTOMIZE) build examples/aio-dx/https > examples/aio-dx-https.yaml
 	$(KUSTOMIZE) build examples/aio-dx/https-with-cert-manager > examples/aio-dx-https-with-cert-manager.yaml
+	$(KUSTOMIZE) build examples/aio-dx/day2-operation/bootstrap > examples/aio-dx-day2-bootstrap.yaml
+	$(KUSTOMIZE) build examples/aio-dx/day2-operation/principal > examples/aio-dx-day2-principal.yaml

--- a/examples/aio-dx-day2-bootstrap.yaml
+++ b/examples/aio-dx-day2-bootstrap.yaml
@@ -1,0 +1,205 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: deployment
+---
+apiVersion: v1
+data:
+  OS_PASSWORD: U3Q4cmxpbmdYKg==
+  OS_USERNAME: YWRtaW4=
+kind: Secret
+metadata:
+  name: system-endpoint
+  namespace: deployment
+stringData:
+  OS_AUTH_TYPE: password
+  OS_AUTH_URL: http://192.168.204.1:5000/v3
+  OS_ENDPOINT_TYPE: internalURL
+  OS_IDENTITY_API_VERSION: "3"
+  OS_INTERFACE: internal
+  OS_KEYSTONE_REGION_NAME: RegionOne
+  OS_PROJECT_DOMAIN_NAME: Default
+  OS_PROJECT_NAME: admin
+  OS_REGION_NAME: RegionOne
+type: Opaque
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data0
+  namespace: deployment
+spec:
+  description: group0 data networks for the tenant1 networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data0b
+  namespace: deployment
+spec:
+  description: group0 data networks for the shared internal networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data1
+  namespace: deployment
+spec:
+  description: group0 data networks for the tenant2 networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-ext0
+  namespace: deployment
+spec:
+  description: group0 data networks for the external networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-0
+  namespace: deployment
+spec:
+  match:
+    bootMAC: CONTROLLER0MAC
+  overrides:
+    interfaces:
+      ethernet:
+      - class: none
+        name: lo
+        platformNetworks: []
+        port:
+          name: lo
+    location: vbox
+    provisioningMode: dynamic
+  profile: controller-profile
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-1
+  namespace: deployment
+spec:
+  overrides:
+    bootMAC: CONTROLLER1MAC
+    interfaces:
+      ethernet:
+      - class: none
+        mtu: 1500
+        name: lo
+        platformNetworks: []
+        port:
+          name: lo
+    location: vbox
+  profile: controller-profile
+status:
+  desploymentScope: bootstrap
+---
+apiVersion: starlingx.windriver.com/v1
+kind: HostProfile
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-profile
+  namespace: deployment
+spec:
+  administrativeState: unlocked
+  bootDevice: /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0
+  console: tty0
+  installOutput: text
+  interfaces:
+    ethernet:
+    - class: platform
+      name: mgmt0
+      platformNetworks:
+      - mgmt
+      - cluster-host
+      port:
+        name: enp0s8
+    - class: platform
+      name: oam0
+      platformNetworks:
+      - oam
+      port:
+        name: enp0s3
+    - class: data
+      dataNetworks:
+      - group0-data0
+      - group0-data0b
+      - group0-ext0
+      name: data0
+      port:
+        name: eth1000
+    - class: data
+      dataNetworks:
+      - group0-data1
+      name: data1
+      port:
+        name: eth1001
+  labels:
+    openstack-compute-node: enabled
+    openstack-control-plane: enabled
+    openvswitch: enabled
+    sriov: enabled
+  personality: controller
+  processors:
+  - functions:
+    - count: 0
+      function: vswitch
+    node: 0
+  provisioningMode: static
+  rootDevice: /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0
+  storage:
+    osds:
+    - function: osd
+      path: /dev/disk/by-path/pci-0000:00:0d.0-ata-2.0
+    volumeGroups:
+    - name: nova-local
+      physicalVolumes:
+      - path: /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0
+        size: 4
+        type: partition
+  subfunctions:
+  - controller
+  - worker
+---
+apiVersion: starlingx.windriver.com/v1
+kind: System
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: vbox
+  namespace: deployment
+spec:
+  contact: info@windriver.com
+  description: Virtual Box Standard System
+  location: vbox
+  ntpServers:
+  - 0.pool.ntp.org
+  - 1.pool.ntp.org
+  - 2.pool.ntp.org
+  storage:
+    backends:
+    - name: ceph-store
+      type: ceph

--- a/examples/aio-dx-day2-principal.yaml
+++ b/examples/aio-dx-day2-principal.yaml
@@ -1,0 +1,205 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: deployment
+---
+apiVersion: v1
+data:
+  OS_PASSWORD: U3Q4cmxpbmdYKg==
+  OS_USERNAME: YWRtaW4=
+kind: Secret
+metadata:
+  name: system-endpoint
+  namespace: deployment
+stringData:
+  OS_AUTH_TYPE: password
+  OS_AUTH_URL: http://192.168.204.1:5000/v3
+  OS_ENDPOINT_TYPE: internalURL
+  OS_IDENTITY_API_VERSION: "3"
+  OS_INTERFACE: internal
+  OS_KEYSTONE_REGION_NAME: RegionOne
+  OS_PROJECT_DOMAIN_NAME: Default
+  OS_PROJECT_NAME: admin
+  OS_REGION_NAME: RegionOne
+type: Opaque
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data0
+  namespace: deployment
+spec:
+  description: group0 data networks for the tenant1 networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data0b
+  namespace: deployment
+spec:
+  description: group0 data networks for the shared internal networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data1
+  namespace: deployment
+spec:
+  description: group0 data networks for the tenant2 networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-ext0
+  namespace: deployment
+spec:
+  description: group0 data networks for the external networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-0
+  namespace: deployment
+spec:
+  match:
+    bootMAC: CONTROLLER0MAC
+  overrides:
+    interfaces:
+      ethernet:
+      - class: none
+        name: lo
+        platformNetworks: []
+        port:
+          name: lo
+    location: vbox
+    provisioningMode: dynamic
+  profile: controller-profile
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-1
+  namespace: deployment
+spec:
+  overrides:
+    bootMAC: CONTROLLER1MAC
+    interfaces:
+      ethernet:
+      - class: none
+        mtu: 1600
+        name: lo
+        platformNetworks: []
+        port:
+          name: lo
+    location: vbox
+  profile: controller-profile
+status:
+  desploymentScope: principal
+---
+apiVersion: starlingx.windriver.com/v1
+kind: HostProfile
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-profile
+  namespace: deployment
+spec:
+  administrativeState: unlocked
+  bootDevice: /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0
+  console: tty0
+  installOutput: text
+  interfaces:
+    ethernet:
+    - class: platform
+      name: mgmt0
+      platformNetworks:
+      - mgmt
+      - cluster-host
+      port:
+        name: enp0s8
+    - class: platform
+      name: oam0
+      platformNetworks:
+      - oam
+      port:
+        name: enp0s3
+    - class: data
+      dataNetworks:
+      - group0-data0
+      - group0-data0b
+      - group0-ext0
+      name: data0
+      port:
+        name: eth1000
+    - class: data
+      dataNetworks:
+      - group0-data1
+      name: data1
+      port:
+        name: eth1001
+  labels:
+    openstack-compute-node: enabled
+    openstack-control-plane: enabled
+    openvswitch: enabled
+    sriov: enabled
+  personality: controller
+  processors:
+  - functions:
+    - count: 0
+      function: vswitch
+    node: 0
+  provisioningMode: static
+  rootDevice: /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0
+  storage:
+    osds:
+    - function: osd
+      path: /dev/disk/by-path/pci-0000:00:0d.0-ata-2.0
+    volumeGroups:
+    - name: nova-local
+      physicalVolumes:
+      - path: /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0
+        size: 4
+        type: partition
+  subfunctions:
+  - controller
+  - worker
+---
+apiVersion: starlingx.windriver.com/v1
+kind: System
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: vbox
+  namespace: deployment
+spec:
+  contact: info@windriver.com
+  description: Virtual Box Standard System
+  location: vbox
+  ntpServers:
+  - 0.pool.ntp.org
+  - 1.pool.ntp.org
+  - 2.pool.ntp.org
+  storage:
+    backends:
+    - name: ceph-store
+      type: ceph

--- a/examples/aio-dx/day2-operation/bootstrap/aio-dx-day2-bootstrap.yaml
+++ b/examples/aio-dx/day2-operation/bootstrap/aio-dx-day2-bootstrap.yaml
@@ -1,0 +1,22 @@
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-1
+  namespace: deployment
+spec:
+  overrides:
+    interfaces:
+      ethernet:
+      - class: none
+        mtu: 1500
+        name: lo
+        platformNetworks: []
+        port:
+          name: lo
+    bootMAC: CONTROLLER1MAC
+    location: vbox
+  profile: controller-profile
+status:
+  desploymentScope: "bootstrap"

--- a/examples/aio-dx/day2-operation/bootstrap/kustomization.yaml
+++ b/examples/aio-dx/day2-operation/bootstrap/kustomization.yaml
@@ -1,0 +1,6 @@
+bases:
+  - ../../default
+
+patches:
+  - aio-dx-day2-bootstrap.yaml
+

--- a/examples/aio-dx/day2-operation/principal/aio-dx-day2-principal.yaml
+++ b/examples/aio-dx/day2-operation/principal/aio-dx-day2-principal.yaml
@@ -1,0 +1,22 @@
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-1
+  namespace: deployment
+spec:
+  overrides:
+    interfaces:
+      ethernet:
+      - class: none
+        mtu: 1600
+        name: lo
+        platformNetworks: []
+        port:
+          name: lo
+    bootMAC: CONTROLLER1MAC
+    location: vbox
+  profile: controller-profile
+status:
+  desploymentScope: "principal"

--- a/examples/aio-dx/day2-operation/principal/kustomization.yaml
+++ b/examples/aio-dx/day2-operation/principal/kustomization.yaml
@@ -1,0 +1,6 @@
+bases:
+  - ../../default
+
+patches:
+  - aio-dx-day2-principal.yaml
+

--- a/examples/aio-sx-day2-bootstrap.yaml
+++ b/examples/aio-sx-day2-bootstrap.yaml
@@ -1,0 +1,178 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: deployment
+---
+apiVersion: v1
+data:
+  OS_PASSWORD: U3Q4cmxpbmdYKg==
+  OS_USERNAME: YWRtaW4=
+kind: Secret
+metadata:
+  name: system-endpoint
+  namespace: deployment
+stringData:
+  OS_AUTH_TYPE: password
+  OS_AUTH_URL: http://192.168.204.1:5000/v3
+  OS_ENDPOINT_TYPE: internalURL
+  OS_IDENTITY_API_VERSION: "3"
+  OS_INTERFACE: internal
+  OS_KEYSTONE_REGION_NAME: RegionOne
+  OS_PROJECT_DOMAIN_NAME: Default
+  OS_PROJECT_NAME: admin
+  OS_REGION_NAME: RegionOne
+type: Opaque
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data0
+  namespace: deployment
+spec:
+  description: group0 data networks for the tenant1 networks.
+  mtu: 1500
+  type: vlan
+status:
+  desploymentScope: bootstrap
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data0b
+  namespace: deployment
+spec:
+  description: group0 data networks for the shared internal networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data1
+  namespace: deployment
+spec:
+  description: group0 data networks for the tenant2 networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-ext0
+  namespace: deployment
+spec:
+  description: group0 data networks for the external networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-0
+  namespace: deployment
+spec:
+  match:
+    bootMAC: CONTROLLER0MAC
+  overrides:
+    location: vbox
+  profile: controller-profile
+---
+apiVersion: starlingx.windriver.com/v1
+kind: HostProfile
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-profile
+  namespace: deployment
+spec:
+  administrativeState: unlocked
+  bootDevice: /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0
+  console: tty0
+  installOutput: text
+  interfaces:
+    ethernet:
+    - class: platform
+      name: lo
+      platformNetworks:
+      - mgmt
+      - cluster-host
+      port:
+        name: lo
+    - class: platform
+      name: oam0
+      platformNetworks:
+      - oam
+      port:
+        name: enp0s3
+    - class: data
+      dataNetworks:
+      - group0-data0
+      - group0-data0b
+      - group0-ext0
+      name: data0
+      port:
+        name: eth1000
+    - class: data
+      dataNetworks:
+      - group0-data1
+      name: data1
+      port:
+        name: eth1001
+  labels:
+    openstack-compute-node: enabled
+    openstack-control-plane: enabled
+    openvswitch: enabled
+    sriov: enabled
+  personality: controller
+  processors:
+  - functions:
+    - count: 0
+      function: vswitch
+    node: 0
+  provisioningMode: dynamic
+  rootDevice: /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0
+  storage:
+    osds:
+    - function: osd
+      path: /dev/disk/by-path/pci-0000:00:0d.0-ata-2.0
+    volumeGroups:
+    - name: nova-local
+      physicalVolumes:
+      - path: /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0
+        size: 4
+        type: partition
+  subfunctions:
+  - controller
+  - worker
+---
+apiVersion: starlingx.windriver.com/v1
+kind: System
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: vbox
+  namespace: deployment
+spec:
+  contact: info@windriver.com
+  description: Virtual Box Standard System
+  location: vbox
+  ntpServers:
+  - 0.pool.ntp.org
+  - 1.pool.ntp.org
+  - 2.pool.ntp.org
+  storage:
+    backends:
+    - name: ceph-store
+      type: ceph
+status:
+  desploymentScope: bootstrap

--- a/examples/aio-sx-day2-principal.yaml
+++ b/examples/aio-sx-day2-principal.yaml
@@ -1,0 +1,179 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: deployment
+---
+apiVersion: v1
+data:
+  OS_PASSWORD: U3Q4cmxpbmdYKg==
+  OS_USERNAME: YWRtaW4=
+kind: Secret
+metadata:
+  name: system-endpoint
+  namespace: deployment
+stringData:
+  OS_AUTH_TYPE: password
+  OS_AUTH_URL: http://192.168.204.1:5000/v3
+  OS_ENDPOINT_TYPE: internalURL
+  OS_IDENTITY_API_VERSION: "3"
+  OS_INTERFACE: internal
+  OS_KEYSTONE_REGION_NAME: RegionOne
+  OS_PROJECT_DOMAIN_NAME: Default
+  OS_PROJECT_NAME: admin
+  OS_REGION_NAME: RegionOne
+type: Opaque
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data0
+  namespace: deployment
+spec:
+  description: group0 data networks for the tenant1 networks.
+  mtu: 1400
+  type: vlan
+status:
+  desploymentScope: principal
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data0b
+  namespace: deployment
+spec:
+  description: group0 data networks for the shared internal networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data1
+  namespace: deployment
+spec:
+  description: group0 data networks for the tenant2 networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-ext0
+  namespace: deployment
+spec:
+  description: group0 data networks for the external networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-0
+  namespace: deployment
+spec:
+  match:
+    bootMAC: CONTROLLER0MAC
+  overrides:
+    location: vbox
+  profile: controller-profile
+---
+apiVersion: starlingx.windriver.com/v1
+kind: HostProfile
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-profile
+  namespace: deployment
+spec:
+  administrativeState: unlocked
+  bootDevice: /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0
+  console: tty0
+  installOutput: text
+  interfaces:
+    ethernet:
+    - class: platform
+      name: lo
+      platformNetworks:
+      - mgmt
+      - cluster-host
+      port:
+        name: lo
+    - class: platform
+      name: oam0
+      platformNetworks:
+      - oam
+      port:
+        name: enp0s3
+    - class: data
+      dataNetworks:
+      - group0-data0
+      - group0-data0b
+      - group0-ext0
+      name: data0
+      port:
+        name: eth1000
+    - class: data
+      dataNetworks:
+      - group0-data1
+      name: data1
+      port:
+        name: eth1001
+  labels:
+    openstack-compute-node: enabled
+    openstack-control-plane: enabled
+    openvswitch: enabled
+    sriov: enabled
+  personality: controller
+  processors:
+  - functions:
+    - count: 0
+      function: vswitch
+    node: 0
+  provisioningMode: dynamic
+  rootDevice: /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0
+  storage:
+    osds:
+    - function: osd
+      path: /dev/disk/by-path/pci-0000:00:0d.0-ata-2.0
+    volumeGroups:
+    - name: nova-local
+      physicalVolumes:
+      - path: /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0
+        size: 4
+        type: partition
+  subfunctions:
+  - controller
+  - worker
+---
+apiVersion: starlingx.windriver.com/v1
+kind: System
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: vbox
+  namespace: deployment
+spec:
+  contact: info@windriver.com
+  description: Virtual Box Standard System
+  location: vbox
+  ntpServers:
+  - 0.pool.ntp.org
+  - 1.pool.ntp.org
+  - 2.pool.ntp.org
+  - 3.pool.ntp.org
+  storage:
+    backends:
+    - name: ceph-store
+      type: ceph
+status:
+  desploymentScope: principal

--- a/examples/aio-sx/day2-operation/bootstrap/aio-sx-day2-bootstrap.yaml
+++ b/examples/aio-sx/day2-operation/bootstrap/aio-sx-day2-bootstrap.yaml
@@ -1,0 +1,36 @@
+kind: System
+apiVersion: starlingx.windriver.com/v1
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: vbox
+  namespace: deployment
+status:
+  desploymentScope:
+    "bootstrap"
+spec:
+  description: Virtual Box Standard System
+  location: vbox
+  contact: info@windriver.com
+  ntpServers:
+    - 0.pool.ntp.org
+    - 1.pool.ntp.org
+    - 2.pool.ntp.org
+  storage:
+    backends:
+    - name: ceph-store
+      type: ceph
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data0
+  namespace: deployment
+spec:
+  description: group0 data networks for the tenant1 networks.
+  mtu: 1500
+  type: vlan
+status:
+  desploymentScope: "bootstrap"

--- a/examples/aio-sx/day2-operation/bootstrap/kustomization.yaml
+++ b/examples/aio-sx/day2-operation/bootstrap/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+  - ../../default
+
+patches:
+  - aio-sx-day2-bootstrap.yaml

--- a/examples/aio-sx/day2-operation/principal/aio-sx-day2-principal.yaml
+++ b/examples/aio-sx/day2-operation/principal/aio-sx-day2-principal.yaml
@@ -1,0 +1,37 @@
+kind: System
+apiVersion: starlingx.windriver.com/v1
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: vbox
+  namespace: deployment
+status:
+  desploymentScope:
+    "principal"
+spec:
+  description: Virtual Box Standard System
+  location: vbox
+  contact: info@windriver.com
+  ntpServers:
+    - 0.pool.ntp.org
+    - 1.pool.ntp.org
+    - 2.pool.ntp.org
+    - 3.pool.ntp.org
+  storage:
+    backends:
+    - name: ceph-store
+      type: ceph
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data0
+  namespace: deployment
+spec:
+  description: group0 data networks for the tenant1 networks.
+  mtu: 1400
+  type: vlan
+status:
+  desploymentScope: "principal"

--- a/examples/aio-sx/day2-operation/principal/kustomization.yaml
+++ b/examples/aio-sx/day2-operation/principal/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+  - ../../default
+
+patches:
+  - aio-sx-day2-principal.yaml

--- a/examples/storage-day2-bootstrap.yaml
+++ b/examples/storage-day2-bootstrap.yaml
@@ -1,0 +1,285 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: deployment
+---
+apiVersion: v1
+data:
+  OS_PASSWORD: U3Q4cmxpbmdYKg==
+  OS_USERNAME: YWRtaW4=
+kind: Secret
+metadata:
+  name: system-endpoint
+  namespace: deployment
+stringData:
+  OS_AUTH_URL: http://192.168.204.1:5000/v3
+  OS_IDENTITY_API_VERSION: "3"
+  OS_INTERFACE: internal
+  OS_KEYSTONE_REGION_NAME: RegionOne
+  OS_PROJECT_DOMAIN_NAME: Default
+  OS_PROJECT_NAME: admin
+  OS_REGION_NAME: RegionOne
+type: Opaque
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data0
+  namespace: deployment
+spec:
+  description: group0 data networks for the tenant1 networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data0b
+  namespace: deployment
+spec:
+  description: group0 data networks for the shared internal networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data1
+  namespace: deployment
+spec:
+  description: group0 data networks for the tenant2 networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-ext0
+  namespace: deployment
+spec:
+  description: group0 data networks for the external networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: compute-0
+  namespace: deployment
+spec:
+  overrides:
+    bootMAC: COMPUTE0MAC
+  profile: worker-profile
+status:
+  desploymentScope: bootstrap
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: compute-1
+  namespace: deployment
+spec:
+  overrides:
+    bootMAC: COMPUTE1MAC
+  profile: worker-profile
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-0
+  namespace: deployment
+spec:
+  match:
+    bootMAC: CONTROLLER0MAC
+  overrides:
+    interfaces:
+      ethernet:
+      - class: none
+        name: lo
+        platformNetworks: []
+        port:
+          name: lo
+    location: vbox
+    provisioningMode: dynamic
+  profile: controller-profile
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-1
+  namespace: deployment
+spec:
+  overrides:
+    bootMAC: CONTROLLER1MAC
+  profile: controller-profile
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: storage-0
+  namespace: deployment
+spec:
+  overrides:
+    bootMAC: STORAGE0MAC
+  profile: storage-profile
+status:
+  desploymentScope: bootstrap
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: storage-1
+  namespace: deployment
+spec:
+  overrides:
+    bootMAC: STORAGE1MAC
+  profile: storage-profile
+status:
+  desploymentScope: bootstrap
+---
+apiVersion: starlingx.windriver.com/v1
+kind: HostProfile
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: common-profile
+  namespace: deployment
+spec:
+  administrativeState: unlocked
+  bootDevice: /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0
+  console: tty0
+  installOutput: text
+  interfaces:
+    ethernet:
+    - class: platform
+      name: mgmt0
+      platformNetworks:
+      - mgmt
+      - cluster-host
+      port:
+        name: enp0s8
+  provisioningMode: static
+  rootDevice: /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0
+---
+apiVersion: starlingx.windriver.com/v1
+kind: HostProfile
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-profile
+  namespace: deployment
+spec:
+  base: common-profile
+  interfaces:
+    ethernet:
+    - class: platform
+      name: oam0
+      platformNetworks:
+      - oam
+      port:
+        name: enp0s3
+  labels:
+    openstack-control-plane: enabled
+  personality: controller
+---
+apiVersion: starlingx.windriver.com/v1
+kind: HostProfile
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: storage-profile
+  namespace: deployment
+spec:
+  base: common-profile
+  personality: storage
+  storage:
+    osds:
+    - function: osd
+      path: /dev/disk/by-path/pci-0000:00:0d.0-ata-2.0
+---
+apiVersion: starlingx.windriver.com/v1
+kind: HostProfile
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: worker-profile
+  namespace: deployment
+spec:
+  base: common-profile
+  interfaces:
+    ethernet:
+    - class: data
+      dataNetworks:
+      - group0-data0
+      - group0-data0b
+      - group0-ext0
+      name: data0
+      port:
+        name: eth1000
+    - class: data
+      dataNetworks:
+      - group0-data1
+      name: data1
+      port:
+        name: eth1001
+  labels:
+    openstack-compute-node: enabled
+    openvswitch: enabled
+    sriov: enabled
+  personality: worker
+  processors:
+  - functions:
+    - count: 0
+      function: vswitch
+    node: 0
+  storage:
+    volumeGroups:
+    - name: nova-local
+      physicalVolumes:
+      - path: /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0
+        size: 4
+        type: partition
+  subfunctions:
+  - worker
+---
+apiVersion: starlingx.windriver.com/v1
+kind: System
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: vbox
+  namespace: deployment
+spec:
+  contact: info@windriver.com
+  description: Virtual Box Standard System
+  location: vbox
+  ntpServers:
+  - 0.pool.ntp.org
+  - 1.pool.ntp.org
+  - 2.pool.ntp.org
+  storage:
+    backends:
+    - name: ceph-store
+      type: ceph
+status:
+  desploymentScope: bootstrap

--- a/examples/storage-day2-principal.yaml
+++ b/examples/storage-day2-principal.yaml
@@ -1,0 +1,286 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: deployment
+---
+apiVersion: v1
+data:
+  OS_PASSWORD: U3Q4cmxpbmdYKg==
+  OS_USERNAME: YWRtaW4=
+kind: Secret
+metadata:
+  name: system-endpoint
+  namespace: deployment
+stringData:
+  OS_AUTH_URL: http://192.168.204.1:5000/v3
+  OS_IDENTITY_API_VERSION: "3"
+  OS_INTERFACE: internal
+  OS_KEYSTONE_REGION_NAME: RegionOne
+  OS_PROJECT_DOMAIN_NAME: Default
+  OS_PROJECT_NAME: admin
+  OS_REGION_NAME: RegionOne
+type: Opaque
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data0
+  namespace: deployment
+spec:
+  description: group0 data networks for the tenant1 networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data0b
+  namespace: deployment
+spec:
+  description: group0 data networks for the shared internal networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-data1
+  namespace: deployment
+spec:
+  description: group0 data networks for the tenant2 networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: DataNetwork
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: group0-ext0
+  namespace: deployment
+spec:
+  description: group0 data networks for the external networks.
+  mtu: 1500
+  type: vlan
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: compute-0
+  namespace: deployment
+spec:
+  overrides:
+    bootMAC: COMPUTE0-NEW-MAC
+  profile: worker-profile
+status:
+  desploymentScope: principal
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: compute-1
+  namespace: deployment
+spec:
+  overrides:
+    bootMAC: COMPUTE1MAC
+  profile: worker-profile
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-0
+  namespace: deployment
+spec:
+  match:
+    bootMAC: CONTROLLER0MAC
+  overrides:
+    interfaces:
+      ethernet:
+      - class: none
+        name: lo
+        platformNetworks: []
+        port:
+          name: lo
+    location: vbox
+    provisioningMode: dynamic
+  profile: controller-profile
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-1
+  namespace: deployment
+spec:
+  overrides:
+    bootMAC: CONTROLLER1MAC
+  profile: controller-profile
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: storage-0
+  namespace: deployment
+spec:
+  overrides:
+    bootMAC: STORAGE0-NEW-MAC
+  profile: storage-profile
+status:
+  desploymentScope: principal
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: storage-1
+  namespace: deployment
+spec:
+  overrides:
+    bootMAC: STORAGE1-NEW-MAC
+  profile: storage-profile
+status:
+  desploymentScope: principal
+---
+apiVersion: starlingx.windriver.com/v1
+kind: HostProfile
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: common-profile
+  namespace: deployment
+spec:
+  administrativeState: unlocked
+  bootDevice: /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0
+  console: tty0
+  installOutput: text
+  interfaces:
+    ethernet:
+    - class: platform
+      name: mgmt0
+      platformNetworks:
+      - mgmt
+      - cluster-host
+      port:
+        name: enp0s8
+  provisioningMode: static
+  rootDevice: /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0
+---
+apiVersion: starlingx.windriver.com/v1
+kind: HostProfile
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-profile
+  namespace: deployment
+spec:
+  base: common-profile
+  interfaces:
+    ethernet:
+    - class: platform
+      name: oam0
+      platformNetworks:
+      - oam
+      port:
+        name: enp0s3
+  labels:
+    openstack-control-plane: enabled
+  personality: controller
+---
+apiVersion: starlingx.windriver.com/v1
+kind: HostProfile
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: storage-profile
+  namespace: deployment
+spec:
+  base: common-profile
+  personality: storage
+  storage:
+    osds:
+    - function: osd
+      path: /dev/disk/by-path/pci-0000:00:0d.0-ata-2.0
+---
+apiVersion: starlingx.windriver.com/v1
+kind: HostProfile
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: worker-profile
+  namespace: deployment
+spec:
+  base: common-profile
+  interfaces:
+    ethernet:
+    - class: data
+      dataNetworks:
+      - group0-data0
+      - group0-data0b
+      - group0-ext0
+      name: data0
+      port:
+        name: eth1000
+    - class: data
+      dataNetworks:
+      - group0-data1
+      name: data1
+      port:
+        name: eth1001
+  labels:
+    openstack-compute-node: enabled
+    openvswitch: enabled
+    sriov: enabled
+  personality: worker
+  processors:
+  - functions:
+    - count: 0
+      function: vswitch
+    node: 0
+  storage:
+    volumeGroups:
+    - name: nova-local
+      physicalVolumes:
+      - path: /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0
+        size: 4
+        type: partition
+  subfunctions:
+  - worker
+---
+apiVersion: starlingx.windriver.com/v1
+kind: System
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: vbox
+  namespace: deployment
+spec:
+  contact: info@windriver.com
+  description: Virtual Box Standard System
+  location: vbox
+  ntpServers:
+  - 0.pool.ntp.org
+  - 1.pool.ntp.org
+  - 2.pool.ntp.org
+  - 3.pool.ntp.org
+  storage:
+    backends:
+    - name: ceph-store
+      type: ceph
+status:
+  desploymentScope: principal

--- a/examples/storage/day2-operation/bootstrap/kustomization.yaml
+++ b/examples/storage/day2-operation/bootstrap/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+  - ../../default
+
+patches:
+  - storage-day2-bootstrap.yaml

--- a/examples/storage/day2-operation/bootstrap/storage-day2-bootstrap.yaml
+++ b/examples/storage/day2-operation/bootstrap/storage-day2-bootstrap.yaml
@@ -1,0 +1,63 @@
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: storage-0
+  namespace: deployment
+status:
+  desploymentScope: "bootstrap"
+spec:
+  profile: storage-profile
+  overrides:
+    bootMAC: STORAGE0MAC
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: storage-1
+  namespace: deployment
+status:
+  desploymentScope: "bootstrap"
+spec:
+  profile: storage-profile
+  overrides:
+    bootMAC: STORAGE1MAC
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: compute-0
+  namespace: deployment
+status:
+  desploymentScope: "bootstrap"
+spec:
+  overrides:
+    bootMAC: COMPUTE0MAC
+  profile: worker-profile
+---
+apiVersion: starlingx.windriver.com/v1
+kind: System
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: vbox
+  namespace: deployment
+status:
+  desploymentScope: "bootstrap"
+spec:
+  contact: info@windriver.com
+  description: Virtual Box Standard System
+  location: vbox
+  ntpServers:
+  - 0.pool.ntp.org
+  - 1.pool.ntp.org
+  - 2.pool.ntp.org
+  storage:
+    backends:
+    - name: ceph-store
+      type: ceph

--- a/examples/storage/day2-operation/principal/kustomization.yaml
+++ b/examples/storage/day2-operation/principal/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+  - ../../default
+
+patches:
+  - storage-day2-principal.yaml

--- a/examples/storage/day2-operation/principal/storage-day2-principal.yaml
+++ b/examples/storage/day2-operation/principal/storage-day2-principal.yaml
@@ -1,0 +1,64 @@
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: storage-0
+  namespace: deployment
+status:
+  desploymentScope: "principal"
+spec:
+  profile: storage-profile
+  overrides:
+    bootMAC: STORAGE0-NEW-MAC
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: storage-1
+  namespace: deployment
+status:
+  desploymentScope: "principal"
+spec:
+  profile: storage-profile
+  overrides:
+    bootMAC: STORAGE1-NEW-MAC
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: compute-0
+  namespace: deployment
+status:
+  desploymentScope: "principal"
+spec:
+  overrides:
+    bootMAC: COMPUTE0-NEW-MAC
+  profile: worker-profile
+---
+apiVersion: starlingx.windriver.com/v1
+kind: System
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: vbox
+  namespace: deployment
+status:
+  desploymentScope: "principal"
+spec:
+  contact: info@windriver.com
+  description: Virtual Box Standard System
+  location: vbox
+  ntpServers:
+  - 0.pool.ntp.org
+  - 1.pool.ntp.org
+  - 2.pool.ntp.org
+  - 3.pool.ntp.org
+  storage:
+    backends:
+    - name: ceph-store
+      type: ceph


### PR DESCRIPTION
This commit updates the README file in order to add the new Day-2 operation.

Also, examples for AIO-SX, AIO-DX and STORAGE have been added for bootstrap and principal Scopes.

Signed-off-by: Enzo Candotti <enzo.candotti@windriver.com>
Co-authored-by: Enzo Candotti <enzo.candotti@windriver.com>
(cherry picked from commit eca0d5e27372f4b2ac82f08147ca106f1ad47cfb)