### PR TITLE
Log enhancement (#254)

### DIFF
--- a/controllers/common/common_test.go
+++ b/controllers/common/common_test.go
@@ -1,0 +1,87 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2023 Wind River Systems, Inc. */
+
+package common
+
+import (
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/wind-river/cloud-platform-deployment-manager/controllers/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("Common utils", func() {
+	Describe("Check return for HandleReconcilerError", func() {
+		var testHandler *ErrorHandler
+		var request reconcile.Request
+		var sink *DummyLogSink
+		var mockLogger logr.Logger
+		BeforeEach(func() {
+			sink = &DummyLogSink{infoCalled: false, errorCalled: false, message: ""}
+			mockLogger = logr.New(sink)
+			testHandler = &ErrorHandler{Logger: mockLogger}
+			request = reconcile.Request{}
+		})
+		Context("when error is ErrResourceStatusDependency", func() {
+			It("should log info and return RetryValidationError", func() {
+				testError := ErrResourceStatusDependency{BaseError{"Test for status dependency"}}
+				result, _ := testHandler.HandleReconcilerError(request, testError)
+
+				Expect(result).To(Equal(RetryTransientError))
+				Expect(sink.infoCalled).To(BeTrue())
+				Expect(sink.errorCalled).To(BeFalse())
+				Expect(sink.message).To(Equal("waiting for dependency status"))
+			})
+		})
+		Context("when error is ErrResourceConfigurationDependency", func() {
+			It("should log error and return RetryValidationError", func() {
+				testError := ErrResourceConfigurationDependency{BaseError{"Test for config dependency"}}
+				result, _ := testHandler.HandleReconcilerError(request, testError)
+
+				Expect(result).To(Equal(RetryTransientError))
+				Expect(sink.infoCalled).To(BeFalse())
+				Expect(sink.errorCalled).To(BeTrue())
+				Expect(sink.message).To(Equal("resource configuration error"))
+			})
+		})
+		Context("when error is ErrResourceConfigurationDependency", func() {
+			It("should log error and return RetryValidationError", func() {
+				testError := manager.NewWaitForMonitor("Test for waiting monitor")
+				result, _ := testHandler.HandleReconcilerError(request, testError)
+
+				Expect(result).To(Equal(RetryNever))
+				Expect(sink.infoCalled).To(BeTrue())
+				Expect(sink.errorCalled).To(BeFalse())
+				Expect(sink.message).To(Equal("waiting for host monitor to trigger another reconciliation"))
+			})
+		})
+	})
+})
+
+type DummyLogSink struct {
+	infoCalled  bool
+	errorCalled bool
+	message     string
+}
+
+func (l *DummyLogSink) Init(info logr.RuntimeInfo) {
+}
+
+func (l *DummyLogSink) Enabled(level int) bool {
+	return true
+}
+func (l *DummyLogSink) Info(level int, msg string, keysAndValues ...interface{}) {
+	l.infoCalled = true
+	l.message = msg
+}
+func (l *DummyLogSink) Error(err error, msg string, keysAndValues ...interface{}) {
+	l.errorCalled = true
+	l.message = msg
+}
+func (l *DummyLogSink) WithValues(keysAndValues ...interface{}) logr.LogSink {
+	return nil
+}
+func (l *DummyLogSink) WithName(name string) logr.LogSink {
+	return nil
+}

--- a/controllers/common/errors.go
+++ b/controllers/common/errors.go
@@ -46,6 +46,13 @@ type ErrResourceStatusDependency struct {
 	BaseError
 }
 
+// ErrResourceConfigurationDependency defines an error to be used when reporting
+// that an operation is unable to continue because a resource is not configured
+// correctly.
+type ErrResourceConfigurationDependency struct {
+	BaseError
+}
+
 // ErrUserDataError defines an error to be used when reporting that an operation
 // is unable to continue because the requested configuration is incorrect or
 // incomplete.
@@ -93,7 +100,7 @@ func NewResourceStatusDependency(msg string) error {
 // NewResourceConfigurationDependency defines a constructor for the
 // ErrResourceStatusDependency error type.
 func NewResourceConfigurationDependency(msg string) error {
-	return ErrResourceStatusDependency{BaseError{msg}}
+	return ErrResourceConfigurationDependency{BaseError{msg}}
 }
 
 // NewUserDataError defines a constructor for the ErrUserDataError error type.

--- a/controllers/datanetwork_controller.go
+++ b/controllers/datanetwork_controller.go
@@ -19,6 +19,8 @@ import (
 	cloudManager "github.com/wind-river/cloud-platform-deployment-manager/controllers/manager"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -375,7 +377,7 @@ func (r *DataNetworkReconciler) GetScopeConfig(instance *starlingxv1.DataNetwork
 	if annotation != nil {
 		config, ok := annotation["kubectl.kubernetes.io/last-applied-configuration"]
 		if ok {
-			status_config := &starlingxv1.Host{}
+			status_config := &starlingxv1.DataNetwork{}
 			err := json.Unmarshal([]byte(config), &status_config)
 			if err == nil {
 				if status_config.Status.DeploymentScope != "" {
@@ -403,65 +405,89 @@ func (r *DataNetworkReconciler) GetScopeConfig(instance *starlingxv1.DataNetwork
 // ReconcileAfterInSync value will be:
 // "true"  if deploymentScope is "principal" because it is day 2 operation (update configuration)
 // "false" if deploymentScope is "bootstrap"
-// Then reflrect these values to cluster object
+// Then reflect these values to cluster object
 func (r *DataNetworkReconciler) UpdateConfigStatus(instance *starlingxv1.DataNetwork) (err error) {
-	deploymentScope, err := r.GetScopeConfig(instance)
-	if err != nil {
-		return err
-	}
-	logDataNetwork.V(2).Info("deploymentScope in configuration", "deploymentScope", deploymentScope)
-
-	// Put ReconcileAfterInSync values depends on scope
-	// "true"  if scope is "principal" because it is day 2 operation (update configuration)
-	// "false" if scope is "bootstrap" or None
-	afterInSync, ok := instance.Annotations[cloudManager.ReconcileAfterInSync]
-	if deploymentScope == cloudManager.ScopePrincipal {
-		if !ok || afterInSync != "true" {
-			instance.Annotations[cloudManager.ReconcileAfterInSync] = "true"
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := r.Client.Get(context.TODO(), types.NamespacedName{
+			Name:      instance.Name,
+			Namespace: instance.Namespace,
+		}, instance)
+		if err != nil {
+			return err
 		}
-	} else {
-		if ok && afterInSync == "true" {
-			delete(instance.Annotations, cloudManager.ReconcileAfterInSync)
+		deploymentScope, err := r.GetScopeConfig(instance)
+		if err != nil {
+			return err
 		}
-	}
+		logDataNetwork.V(2).Info("deploymentScope in configuration", "deploymentScope", deploymentScope)
 
-	// Update annotation
-	err = r.Client.Update(context.TODO(), instance)
+		// Put ReconcileAfterInSync values depends on scope
+		// "true"  if scope is "principal" because it is day 2 operation (update configuration)
+		// "false" if scope is "bootstrap" or None
+		afterInSync, ok := instance.Annotations[cloudManager.ReconcileAfterInSync]
+		if deploymentScope == cloudManager.ScopePrincipal {
+			if !ok || afterInSync != "true" {
+				instance.Annotations[cloudManager.ReconcileAfterInSync] = "true"
+			}
+		} else {
+			if ok && afterInSync == "true" {
+				delete(instance.Annotations, cloudManager.ReconcileAfterInSync)
+			}
+		}
+		return r.Client.Update(context.TODO(), instance)
+	})
+
 	if err != nil {
 		err = perrors.Wrapf(err, "failed to update profile annotation ReconcileAfterInSync")
 		return err
 	}
 
-	// Update scope status
-	instance.Status.DeploymentScope = deploymentScope
-
-	// Set default value for StrategyRequired
-	if instance.Status.StrategyRequired == "" {
-		instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
-	}
-
-	// Check configration is updated
-	if instance.Status.ObservedGeneration != instance.ObjectMeta.Generation {
-		if instance.Status.ObservedGeneration == 0 &&
-			instance.Status.Reconciled {
-			// Case: DM upgrade in reconceiled node
-			instance.Status.ConfigurationUpdated = false
-		} else {
-			// Case: Fresh install or Day-2 operation
-			instance.Status.ConfigurationUpdated = true
-			if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
-				instance.Status.Reconciled = false
-				// Update storategy required status for strategy monitor
-				r.CloudManager.UpdateConfigVersion()
-				r.CloudManager.SetResourceInfo(cloudManager.ResourceDatanetwork, "", instance.Name, instance.Status.Reconciled, cloudManager.StrategyNotRequired)
-			}
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := r.Client.Get(context.TODO(), types.NamespacedName{
+			Name:      instance.Name,
+			Namespace: instance.Namespace,
+		}, instance)
+		if err != nil {
+			return err
 		}
-		instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
-		// Reset strategy when new configration is applied
-		instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
-	}
 
-	err = r.Client.Status().Update(context.TODO(), instance)
+		// Update scope status
+		deploymentScope, err := r.GetScopeConfig(instance)
+		if err != nil {
+			return err
+		}
+		logDataNetwork.V(2).Info("deploymentScope in configuration", "deploymentScope", deploymentScope)
+		instance.Status.DeploymentScope = deploymentScope
+
+		// Set default value for StrategyRequired
+		if instance.Status.StrategyRequired == "" {
+			instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
+		}
+
+		// Check if the configuration is updated
+		if instance.Status.ObservedGeneration != instance.ObjectMeta.Generation {
+			if instance.Status.ObservedGeneration == 0 &&
+				instance.Status.Reconciled {
+				// Case: DM upgrade in reconciled node
+				instance.Status.ConfigurationUpdated = false
+			} else {
+				// Case: Fresh install or Day-2 operation
+				instance.Status.ConfigurationUpdated = true
+				if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
+					instance.Status.Reconciled = false
+					// Update strategy required status for strategy monitor
+					r.CloudManager.UpdateConfigVersion()
+					r.CloudManager.SetResourceInfo(cloudManager.ResourceDatanetwork, "", instance.Name, instance.Status.Reconciled, cloudManager.StrategyNotRequired)
+				}
+			}
+			instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
+			// Reset strategy when new configuration is applied
+			instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
+		}
+
+		return r.Client.Status().Update(context.TODO(), instance)
+	})
+
 	if err != nil {
 		err = perrors.Wrapf(err, "failed to update status: %s",
 			common.FormatStruct(instance.Status))

--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -672,7 +673,7 @@ func (r *HostReconciler) ReconcileInitialState(client *gophercloud.ServiceClient
 
 			// Return a retry result here because we know that it won't be possible to
 			// make any other changes until this change is complete.
-			return common.NewResourceStatusDependency("waiting for host state change")
+			return common.NewResourceStatusDependency("waiting for host state change in intial state")
 		}
 	}
 
@@ -730,7 +731,7 @@ func (r *HostReconciler) ReconcileFinalState(client *gophercloud.ServiceClient, 
 
 	// Return a retry result here because we know that it won't be possible to
 	// make any other changes until this change is complete.
-	return common.NewResourceStatusDependency("waiting for host state change")
+	return common.NewResourceStatusDependency("waiting for host state change in final state")
 }
 
 func (r *HostReconciler) ReconcileEnabledHost(client *gophercloud.ServiceClient, instance *starlingxv1.Host, profile *starlingxv1.HostProfileSpec, host *v1info.HostInfo) error {
@@ -1023,6 +1024,7 @@ func (r *HostReconciler) ReconcileHostByState(client *gophercloud.ServiceClient,
 						common.FormatStruct(instance.Status))
 					return err
 				}
+				logHost.V(2).Info("set lock required")
 			}
 			msg := "waiting for locked state before applying out-of-service attributes"
 			m := NewLockedDisabledHostMonitor(instance, host.ID)
@@ -1042,6 +1044,7 @@ func (r *HostReconciler) ReconcileHostByState(client *gophercloud.ServiceClient,
 		if !r.CompareEnabledAttributes(profile, current, instance, host.Personality) {
 			if principal {
 				instance.Status.StrategyRequired = cloudManager.StrategyUnlockRequired
+				logHost.V(2).Info("set unlock required: day2 operation. There are unlocked attributes")
 				r.CloudManager.SetResourceInfo(cloudManager.ResourceHost, host.Personality, instance.Name, instance.Status.Reconciled, instance.Status.StrategyRequired)
 				err := r.Client.Status().Update(context.TODO(), instance)
 				if err != nil {
@@ -1056,7 +1059,7 @@ func (r *HostReconciler) ReconcileHostByState(client *gophercloud.ServiceClient,
 		}
 
 	} else {
-		msg := "waiting for a stable state"
+		msg := "waiting for a stable state in unknown state"
 		m := NewStableHostMonitor(instance, host.ID)
 		return r.CloudManager.StartMonitor(m, msg)
 	}
@@ -1099,37 +1102,34 @@ func (r *HostReconciler) statusUpdateRequired(instance *starlingxv1.Host, host *
 		result = true
 	}
 
-	logHost.V(2).Info("Current Status", "InSync", status.InSync)
-	logHost.V(2).Info("Current Status", "Reconciled", status.Reconciled)
-	logHost.V(2).Info("Current Status", "ConfigurationUpdated", status.ConfigurationUpdated)
-	logHost.V(2).Info("Current Status", "HostProfileConfigurationUpdated", status.HostProfileConfigurationUpdated)
+	logHost.V(2).Info("Current Status", "status", status)
+	principal := instance.Status.DeploymentScope == cloudManager.ScopePrincipal
 
-	if status.InSync && status.Reconciled &&
-		instance.Status.DeploymentScope == cloudManager.ScopePrincipal &&
-		host.IsUnlockedAvailable() {
+	if status.InSync && status.Reconciled && principal && host.IsUnlockedAvailable() {
 		// Clean up strategy required status after Day-2 operation finished
 		logHost.V(2).Info("Clean up strategy required status after Day-2 operation finished")
 		status.StrategyRequired = cloudManager.StrategyNotRequired
+		logHost.V(2).Info("set not required: Day-2 operation finished")
 		result = true
 	}
 
 	if status.InSync && !status.Reconciled {
 		// Record the fact that we have reached inSync at least once.
 		logHost.V(2).Info("Insync=true so that change reconciled=true")
-		if instance.Status.DeploymentScope == cloudManager.ScopePrincipal &&
-			(host.IsLockedDisabled() && (status.ConfigurationUpdated || status.HostProfileConfigurationUpdated)) {
-			logHost.V(2).Info("Set StrategyUnlockRequired as config is applied in locked state")
+		if principal && host.IsLockedDisabled() && (status.ConfigurationUpdated || status.HostProfileConfigurationUpdated) {
 			// Unlock if current is locked in Day-2 operation
 			status.StrategyRequired = cloudManager.StrategyUnlockRequired
+			logHost.V(2).Info("set unlock required: day2 operation currently locked")
 		} else {
-			logHost.V(2).Info("Set StrategyNotRequired as strategy is not lock required")
 			status.StrategyRequired = cloudManager.StrategyNotRequired
+			logHost.V(2).Info("set not required: reconcile finished")
 		}
 		status.Reconciled = true
 		status.ConfigurationUpdated = false
 		status.HostProfileConfigurationUpdated = false
+		logHost.V(2).Info("set profile config updated false: reconcile finished")
 		// Update resource info for Day-2 operation
-		if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
+		if principal {
 			r.CloudManager.SetResourceInfo(cloudManager.ResourceHost, host.Personality, instance.Name, status.Reconciled, status.StrategyRequired)
 		}
 		result = true
@@ -1274,7 +1274,7 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 	var current *starlingxv1.HostProfileSpec
 
 	if !host.Stable() {
-		msg := "waiting for a stable state"
+		msg := "waiting for a stable state for existing host"
 		m := NewStableHostMonitor(instance, host.ID)
 		return r.CloudManager.StartMonitor(m, msg)
 	}
@@ -1731,86 +1731,119 @@ func (r *HostReconciler) GetScopeConfig(instance *starlingxv1.Host) (scope strin
 // If generation is updated (= apply new configuration);
 // - Set ConfigurationUpdated true
 // - Set Reconciled false (since it is going to reconcile with new configuration)
-// Then reflrect these values to cluster object
+// Then reflect these values to cluster object
 func (r *HostReconciler) UpdateConfigStatus(instance *starlingxv1.Host) (err error) {
-	deploymentScope, err := r.GetScopeConfig(instance)
-	if err != nil {
-		return err
-	}
-	logHost.V(2).Info("deploymentScope in configuration", "deploymentScope", deploymentScope)
-
-	// Put ReconcileAfterInSync values depends on scope
-	// "true"  if scope is "principal" because it is day 2 operation (update configuration)
-	// "false" if scope is "bootstrap" or None
-	afterInSync, ok := instance.Annotations[cloudManager.ReconcileAfterInSync]
-	if deploymentScope == cloudManager.ScopePrincipal {
-		if !ok || afterInSync != "true" {
-			logHost.V(2).Info("Add annotation: ReconcileAfterInSync=true")
-			instance.Annotations[cloudManager.ReconcileAfterInSync] = "true"
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := r.Client.Get(context.TODO(), types.NamespacedName{
+			Name:      instance.Name,
+			Namespace: instance.Namespace,
+		}, instance)
+		if err != nil {
+			return err
 		}
-	} else {
-		if ok && afterInSync == "true" {
-			logHost.V(2).Info("Delete annotation: ReconcileAfterInSync")
-			delete(instance.Annotations, cloudManager.ReconcileAfterInSync)
+		logHost.V(2).Info("update config before", "instance", instance)
+		deploymentScope, err := r.GetScopeConfig(instance)
+		if err != nil {
+			return err
 		}
-	}
+		logHost.V(2).Info("deploymentScope in configuration", "deploymentScope", deploymentScope)
 
-	// Update annotation
-	err = r.Client.Update(context.TODO(), instance)
+		// Put ReconcileAfterInSync values depends on scope
+		// "true"  if scope is "principal" because it is day 2 operation (update configuration)
+		// "false" if scope is "bootstrap" or None
+		afterInSync, ok := instance.Annotations[cloudManager.ReconcileAfterInSync]
+		if deploymentScope == cloudManager.ScopePrincipal {
+			if !ok || afterInSync != "true" {
+				instance.Annotations[cloudManager.ReconcileAfterInSync] = "true"
+			}
+		} else {
+			if ok && afterInSync == "true" {
+				delete(instance.Annotations, cloudManager.ReconcileAfterInSync)
+			}
+		}
+		logHost.V(2).Info("update config after", "instance", instance)
+		return r.Client.Update(context.TODO(), instance)
+	})
+
 	if err != nil {
 		err = perrors.Wrapf(err, "failed to update profile annotation ReconcileAfterInSync")
 		return err
 	}
 
-	// Update scope status
-	instance.Status.DeploymentScope = deploymentScope
-
-	// Set default value for StrategyRequired
-	if instance.Status.StrategyRequired == "" {
-		instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
-	}
-
-	// Check HostProfile configuration update
-	hostProfile, err := r.GetHostProfile(instance.Namespace, instance.Spec.Profile)
-	if err != err {
-		return err
-	}
-	if hostProfile != nil &&
-		instance.Status.ObservedHostProfileGeneration != hostProfile.ObjectMeta.Generation {
-		if (instance.Status.ObservedHostProfileGeneration == 0 && instance.Status.Reconciled) ||
-			instance.Status.DeploymentScope != cloudManager.ScopePrincipal {
-			// Case: DM upgrade in reconceiled node or update in bootstrap
-			instance.Status.HostProfileConfigurationUpdated = false
-		} else {
-			// Case: Fresh install or Day-2 operation
-			instance.Status.HostProfileConfigurationUpdated = true
-			instance.Status.Reconciled = false
-			instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := r.Client.Get(context.TODO(), types.NamespacedName{
+			Name:      instance.Name,
+			Namespace: instance.Namespace,
+		}, instance)
+		if err != nil {
+			return err
 		}
-		instance.Status.ObservedHostProfileGeneration = hostProfile.ObjectMeta.Generation
-	}
+		logHost.V(2).Info("update status before", "instance", instance)
+		// Update scope status
+		deploymentScope, err := r.GetScopeConfig(instance)
+		if err != nil {
+			return err
+		}
+		logHost.V(2).Info("deploymentScope in configuration", "deploymentScope", deploymentScope)
+		instance.Status.DeploymentScope = deploymentScope
 
-	// Check Host configuration update
-	if instance.Status.ObservedGeneration != instance.ObjectMeta.Generation {
-		if instance.Status.ObservedGeneration == 0 &&
-			instance.Status.Reconciled {
-			// Case: DM upgrade in reconceiled node
-			instance.Status.ConfigurationUpdated = false
-		} else {
-			// Case: Fresh install or Day-2 operation
-			instance.Status.ConfigurationUpdated = true
+		// Set default value for StrategyRequired
+		if instance.Status.StrategyRequired == "" {
 			instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
-			if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
+			logHost.V(2).Info("set not required: set initial value")
+		}
+
+		// Check if the HostProfile configuration is updated
+		hostProfile, err := r.GetHostProfile(instance.Namespace, instance.Spec.Profile)
+		if err != err {
+			return err
+		}
+		if hostProfile != nil &&
+			instance.Status.ObservedHostProfileGeneration != hostProfile.ObjectMeta.Generation {
+			if (instance.Status.ObservedHostProfileGeneration == 0 && instance.Status.Reconciled) ||
+				instance.Status.DeploymentScope != cloudManager.ScopePrincipal {
+				// Case: DM upgrade in reconciled node or update in bootstrap
+				instance.Status.HostProfileConfigurationUpdated = false
+				logHost.V(2).Info("set profile config updated false: bootstrap or DM upgrade")
+			} else {
+				// Case: Fresh install or Day-2 operation
+				instance.Status.HostProfileConfigurationUpdated = true
 				instance.Status.Reconciled = false
-				// Update storategy required status for strategy monitor
-				r.CloudManager.UpdateConfigVersion()
-				r.CloudManager.SetResourceInfo(cloudManager.ResourceHost, *hostProfile.Spec.Personality, instance.Name, instance.Status.Reconciled, cloudManager.StrategyNotRequired)
+				instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
+				logHost.V(2).Info("set profile config updated true: initial or day2 operation starts")
+				logHost.V(2).Info("set not required: initial or day2 operation starts. profile config updated")
 			}
+			instance.Status.ObservedHostProfileGeneration = hostProfile.ObjectMeta.Generation
+			logHost.V(2).Info("update observed profile config generation", "generation", hostProfile.ObjectMeta.Generation)
 		}
-		instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
-	}
 
-	err = r.Client.Status().Update(context.TODO(), instance)
+		// Check if the Host configuration is updated
+		if instance.Status.ObservedGeneration != instance.ObjectMeta.Generation {
+			if instance.Status.ObservedGeneration == 0 &&
+				instance.Status.Reconciled {
+				// Case: DM upgrade in reconciled node
+				instance.Status.ConfigurationUpdated = false
+				logHost.V(2).Info("set host config updated false: bootstrap or DM upgrade")
+			} else {
+				// Case: Fresh install or Day-2 operation
+				instance.Status.ConfigurationUpdated = true
+				instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
+				logHost.V(2).Info("set host config updated true: initial or day2 operation starts")
+				logHost.V(2).Info("set not required: initial or day2 operation starts. host config updated")
+				if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
+					instance.Status.Reconciled = false
+					// Update strategy required status for strategy monitor
+					r.CloudManager.UpdateConfigVersion()
+					r.CloudManager.SetResourceInfo(cloudManager.ResourceHost, *hostProfile.Spec.Personality, instance.Name, instance.Status.Reconciled, cloudManager.StrategyNotRequired)
+				}
+			}
+			instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
+		}
+
+		logHost.V(2).Info("update status after", "instance", instance)
+		return r.Client.Status().Update(context.TODO(), instance)
+	})
+
 	if err != nil {
 		err = perrors.Wrapf(err, "failed to update status: %s",
 			common.FormatStruct(instance.Status))
@@ -1850,6 +1883,9 @@ func (r *HostReconciler) Reconcile(ctx context.Context, request ctrl.Request) (r
 		return reconcile.Result{}, err
 	}
 
+	// Cancel any existing monitors
+	r.CloudManager.CancelMonitor(instance)
+
 	// Update scope from configuration
 	logHost.V(2).Info("before UpdateConfigStatus", "instance", instance)
 	err = r.UpdateConfigStatus(instance)
@@ -1858,9 +1894,6 @@ func (r *HostReconciler) Reconcile(ctx context.Context, request ctrl.Request) (r
 		return reconcile.Result{}, err
 	}
 	logHost.V(2).Info("after UpdateConfigStatus", "instance", instance)
-
-	// Cancel any existing monitors
-	r.CloudManager.CancelMonitor(instance)
 
 	if instance.DeletionTimestamp.IsZero() {
 		// Ensure that the object has a finalizer setup as a pre-delete hook so

--- a/controllers/manager/monitor.go
+++ b/controllers/manager/monitor.go
@@ -235,7 +235,7 @@ func StrategyRequiredMonitor(management CloudManager) {
 		time.Sleep(DefaultNewStrategyRequiredMonitorInterval)
 		finished := ManageStrategy(management)
 		if finished {
-			//Clear storategy
+			//Clear strategy
 			management.ClearStragey()
 			break
 		}
@@ -325,7 +325,7 @@ func monitorStrategyState(management CloudManager) bool {
 		return true
 
 	case StrategyApplied:
-		log.Error(err, "Strategy applied. Finish strategy monitor.")
+		log.Info("Strategy applied. Finish strategy monitor.")
 		deleteStrategy(management, client)
 		return true
 	}

--- a/controllers/platformnetwork_controller.go
+++ b/controllers/platformnetwork_controller.go
@@ -20,6 +20,8 @@ import (
 	cloudManager "github.com/wind-river/cloud-platform-deployment-manager/controllers/manager"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -634,7 +636,7 @@ func (r *PlatformNetworkReconciler) GetScopeConfig(instance *starlingxv1.Platfor
 	if annotation != nil {
 		config, ok := annotation["kubectl.kubernetes.io/last-applied-configuration"]
 		if ok {
-			status_config := &starlingxv1.Host{}
+			status_config := &starlingxv1.PlatformNetwork{}
 			err := json.Unmarshal([]byte(config), &status_config)
 			if err == nil {
 				if status_config.Status.DeploymentScope != "" {
@@ -662,65 +664,88 @@ func (r *PlatformNetworkReconciler) GetScopeConfig(instance *starlingxv1.Platfor
 // ReconcileAfterInSync value will be:
 // "true"  if deploymentScope is "principal" because it is day 2 operation (update configuration)
 // "false" if deploymentScope is "bootstrap"
-// Then reflrect these values to cluster object
+// Then reflect these values to cluster object
 func (r *PlatformNetworkReconciler) UpdateConfigStatus(instance *starlingxv1.PlatformNetwork) (err error) {
-	deploymentScope, err := r.GetScopeConfig(instance)
-	if err != nil {
-		return err
-	}
-	logPlatformNetwork.V(2).Info("deploymentScope in configuration", "deploymentScope", deploymentScope)
-
-	// Put ReconcileAfterInSync values depends on scope
-	// "true"  if scope is "principal" because it is day 2 operation (update configuration)
-	// "false" if scope is "bootstrap" or None
-	afterInSync, ok := instance.Annotations[cloudManager.ReconcileAfterInSync]
-	if deploymentScope == cloudManager.ScopePrincipal {
-		if !ok || afterInSync != "true" {
-			instance.Annotations[cloudManager.ReconcileAfterInSync] = "true"
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := r.Client.Get(context.TODO(), types.NamespacedName{
+			Name:      instance.Name,
+			Namespace: instance.Namespace,
+		}, instance)
+		if err != nil {
+			return err
 		}
-	} else {
-		if ok && afterInSync == "true" {
-			delete(instance.Annotations, cloudManager.ReconcileAfterInSync)
+		deploymentScope, err := r.GetScopeConfig(instance)
+		if err != nil {
+			return err
 		}
-	}
+		logPlatformNetwork.V(2).Info("deploymentScope in configuration", "deploymentScope", deploymentScope)
 
-	// Update annotation
-	err = r.Client.Update(context.TODO(), instance)
+		// Put ReconcileAfterInSync values depends on scope
+		// "true"  if scope is "principal" because it is day 2 operation (update configuration)
+		// "false" if scope is "bootstrap" or None
+		afterInSync, ok := instance.Annotations[cloudManager.ReconcileAfterInSync]
+		if deploymentScope == cloudManager.ScopePrincipal {
+			if !ok || afterInSync != "true" {
+				instance.Annotations[cloudManager.ReconcileAfterInSync] = "true"
+			}
+		} else {
+			if ok && afterInSync == "true" {
+				delete(instance.Annotations, cloudManager.ReconcileAfterInSync)
+			}
+		}
+		return r.Client.Update(context.TODO(), instance)
+	})
 	if err != nil {
 		err = perrors.Wrapf(err, "failed to update profile annotation ReconcileAfterInSync")
 		return err
 	}
 
-	// Update scope status
-	instance.Status.DeploymentScope = deploymentScope
-
-	// Set default value for StrategyRequired
-	if instance.Status.StrategyRequired == "" {
-		instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
-	}
-
-	// Check configration is updated
-	if instance.Status.ObservedGeneration != instance.ObjectMeta.Generation {
-		if instance.Status.ObservedGeneration == 0 &&
-			instance.Status.Reconciled {
-			// Case: DM upgrade in reconceiled node
-			instance.Status.ConfigurationUpdated = false
-		} else {
-			// Case: Fresh install or Day-2 operation
-			instance.Status.ConfigurationUpdated = true
-			if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
-				instance.Status.Reconciled = false
-				// Update storategy required status for strategy monitor
-				r.CloudManager.UpdateConfigVersion()
-				r.CloudManager.SetResourceInfo(cloudManager.ResourcePlatformnetwork, "", instance.Name, instance.Status.Reconciled, cloudManager.StrategyNotRequired)
-			}
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := r.Client.Get(context.TODO(), types.NamespacedName{
+			Name:      instance.Name,
+			Namespace: instance.Namespace,
+		}, instance)
+		if err != nil {
+			return err
 		}
-		instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
-		// Reset strategy when new configration is applied
-		instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
-	}
 
-	err = r.Client.Status().Update(context.TODO(), instance)
+		// Update scope status
+		deploymentScope, err := r.GetScopeConfig(instance)
+		if err != nil {
+			return err
+		}
+		logPlatformNetwork.V(2).Info("deploymentScope in configuration", "deploymentScope", deploymentScope)
+		instance.Status.DeploymentScope = deploymentScope
+
+		// Set default value for StrategyRequired
+		if instance.Status.StrategyRequired == "" {
+			instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
+		}
+
+		// Check if the configuration is updated
+		if instance.Status.ObservedGeneration != instance.ObjectMeta.Generation {
+			if instance.Status.ObservedGeneration == 0 &&
+				instance.Status.Reconciled {
+				// Case: DM upgrade in reconciled node
+				instance.Status.ConfigurationUpdated = false
+			} else {
+				// Case: Fresh install or Day-2 operation
+				instance.Status.ConfigurationUpdated = true
+				if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
+					instance.Status.Reconciled = false
+					// Update strategy required status for strategy monitor
+					r.CloudManager.UpdateConfigVersion()
+					r.CloudManager.SetResourceInfo(cloudManager.ResourcePlatformnetwork, "", instance.Name, instance.Status.Reconciled, cloudManager.StrategyNotRequired)
+				}
+			}
+			instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
+			// Reset strategy when new configuration is applied
+			instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
+		}
+
+		return r.Client.Status().Update(context.TODO(), instance)
+	})
+
 	if err != nil {
 		err = perrors.Wrapf(err, "failed to update status: %s",
 			common.FormatStruct(instance.Status))

--- a/controllers/ptpinstance_controller.go
+++ b/controllers/ptpinstance_controller.go
@@ -19,6 +19,8 @@ import (
 	cloudManager "github.com/wind-river/cloud-platform-deployment-manager/controllers/manager"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -431,7 +433,7 @@ func (r *PtpInstanceReconciler) GetScopeConfig(instance *starlingxv1.PtpInstance
 	if annotation != nil {
 		config, ok := annotation["kubectl.kubernetes.io/last-applied-configuration"]
 		if ok {
-			status_config := &starlingxv1.Host{}
+			status_config := &starlingxv1.PtpInstance{}
 			err := json.Unmarshal([]byte(config), &status_config)
 			if err == nil {
 				if status_config.Status.DeploymentScope != "" {
@@ -459,65 +461,88 @@ func (r *PtpInstanceReconciler) GetScopeConfig(instance *starlingxv1.PtpInstance
 // ReconcileAfterInSync value will be:
 // "true"  if deploymentScope is "principal" because it is day 2 operation (update configuration)
 // "false" if deploymentScope is "bootstrap"
-// Then reflrect these values to cluster object
+// Then reflect these values to cluster object
 func (r *PtpInstanceReconciler) UpdateConfigStatus(instance *starlingxv1.PtpInstance) (err error) {
-	deploymentScope, err := r.GetScopeConfig(instance)
-	if err != nil {
-		return err
-	}
-	logPtpInstance.V(2).Info("deploymentScope in configuration", "deploymentScope", deploymentScope)
-
-	// Put ReconcileAfterInSync values depends on scope
-	// "true"  if scope is "principal" because it is day 2 operation (update configuration)
-	// "false" if scope is "bootstrap" or None
-	afterInSync, ok := instance.Annotations[cloudManager.ReconcileAfterInSync]
-	if deploymentScope == cloudManager.ScopePrincipal {
-		if !ok || afterInSync != "true" {
-			instance.Annotations[cloudManager.ReconcileAfterInSync] = "true"
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := r.Client.Get(context.TODO(), types.NamespacedName{
+			Name:      instance.Name,
+			Namespace: instance.Namespace,
+		}, instance)
+		if err != nil {
+			return err
 		}
-	} else {
-		if ok && afterInSync == "true" {
-			delete(instance.Annotations, cloudManager.ReconcileAfterInSync)
+		deploymentScope, err := r.GetScopeConfig(instance)
+		if err != nil {
+			return err
 		}
-	}
+		logPtpInstance.V(2).Info("deploymentScope in configuration", "deploymentScope", deploymentScope)
 
-	// Update annotation
-	err = r.Client.Update(context.TODO(), instance)
+		// Put ReconcileAfterInSync values depends on scope
+		// "true"  if scope is "principal" because it is day 2 operation (update configuration)
+		// "false" if scope is "bootstrap" or None
+		afterInSync, ok := instance.Annotations[cloudManager.ReconcileAfterInSync]
+		if deploymentScope == cloudManager.ScopePrincipal {
+			if !ok || afterInSync != "true" {
+				instance.Annotations[cloudManager.ReconcileAfterInSync] = "true"
+			}
+		} else {
+			if ok && afterInSync == "true" {
+				delete(instance.Annotations, cloudManager.ReconcileAfterInSync)
+			}
+		}
+		return r.Client.Update(context.TODO(), instance)
+	})
 	if err != nil {
 		err = perrors.Wrapf(err, "failed to update profile annotation ReconcileAfterInSync")
 		return err
 	}
 
-	// Update scope status
-	instance.Status.DeploymentScope = deploymentScope
-
-	// Set default value for StrategyRequired
-	if instance.Status.StrategyRequired == "" {
-		instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
-	}
-
-	// Check configration is updated
-	if instance.Status.ObservedGeneration != instance.ObjectMeta.Generation {
-		if instance.Status.ObservedGeneration == 0 &&
-			instance.Status.Reconciled {
-			// Case: DM upgrade in reconceiled node
-			instance.Status.ConfigurationUpdated = false
-		} else {
-			// Case: Fresh install or Day-2 operation
-			instance.Status.ConfigurationUpdated = true
-			if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
-				instance.Status.Reconciled = false
-				// Update storategy required status for strategy monitor
-				r.CloudManager.UpdateConfigVersion()
-				r.CloudManager.SetResourceInfo(cloudManager.ResourcePtpinstance, "", instance.Name, instance.Status.Reconciled, cloudManager.StrategyNotRequired)
-			}
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := r.Client.Get(context.TODO(), types.NamespacedName{
+			Name:      instance.Name,
+			Namespace: instance.Namespace,
+		}, instance)
+		if err != nil {
+			return err
 		}
-		instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
-		// Reset strategy when new configration is applied
-		instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
-	}
 
-	err = r.Client.Status().Update(context.TODO(), instance)
+		// Update scope status
+		deploymentScope, err := r.GetScopeConfig(instance)
+		if err != nil {
+			return err
+		}
+		logPtpInstance.V(2).Info("deploymentScope in configuration", "deploymentScope", deploymentScope)
+		instance.Status.DeploymentScope = deploymentScope
+
+		// Set default value for StrategyRequired
+		if instance.Status.StrategyRequired == "" {
+			instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
+		}
+
+		// Check if the configuration is updated
+		if instance.Status.ObservedGeneration != instance.ObjectMeta.Generation {
+			if instance.Status.ObservedGeneration == 0 &&
+				instance.Status.Reconciled {
+				// Case: DM upgrade in reconciled node
+				instance.Status.ConfigurationUpdated = false
+			} else {
+				// Case: Fresh install or Day-2 operation
+				instance.Status.ConfigurationUpdated = true
+				if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
+					instance.Status.Reconciled = false
+					// Update strategy required status for strategy monitor
+					r.CloudManager.UpdateConfigVersion()
+					r.CloudManager.SetResourceInfo(cloudManager.ResourcePtpinstance, "", instance.Name, instance.Status.Reconciled, cloudManager.StrategyNotRequired)
+				}
+			}
+			instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
+			// Reset strategy when new configuration is applied
+			instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
+		}
+
+		return r.Client.Status().Update(context.TODO(), instance)
+	})
+
 	if err != nil {
 		err = perrors.Wrapf(err, "failed to update status: %s",
 			common.FormatStruct(instance.Status))

--- a/controllers/ptpinterface_controller.go
+++ b/controllers/ptpinterface_controller.go
@@ -20,6 +20,8 @@ import (
 	cloudManager "github.com/wind-river/cloud-platform-deployment-manager/controllers/manager"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -455,7 +457,7 @@ func (r *PtpInterfaceReconciler) GetScopeConfig(instance *starlingxv1.PtpInterfa
 	if annotation != nil {
 		config, ok := annotation["kubectl.kubernetes.io/last-applied-configuration"]
 		if ok {
-			status_config := &starlingxv1.Host{}
+			status_config := &starlingxv1.PtpInterface{}
 			err := json.Unmarshal([]byte(config), &status_config)
 			if err == nil {
 				if status_config.Status.DeploymentScope != "" {
@@ -483,65 +485,88 @@ func (r *PtpInterfaceReconciler) GetScopeConfig(instance *starlingxv1.PtpInterfa
 // ReconcileAfterInSync value will be:
 // "true"  if deploymentScope is "principal" because it is day 2 operation (update configuration)
 // "false" if deploymentScope is "bootstrap"
-// Then reflrect these values to cluster object
+// Then reflect these values to cluster object
 func (r *PtpInterfaceReconciler) UpdateConfigStatus(instance *starlingxv1.PtpInterface) (err error) {
-	deploymentScope, err := r.GetScopeConfig(instance)
-	if err != nil {
-		return err
-	}
-	logPtpInterface.V(2).Info("deploymentScope in configuration", "deploymentScope", deploymentScope)
-
-	// Put ReconcileAfterInSync values depends on scope
-	// "true"  if scope is "principal" because it is day 2 operation (update configuration)
-	// "false" if scope is "bootstrap" or None
-	afterInSync, ok := instance.Annotations[cloudManager.ReconcileAfterInSync]
-	if deploymentScope == cloudManager.ScopePrincipal {
-		if !ok || afterInSync != "true" {
-			instance.Annotations[cloudManager.ReconcileAfterInSync] = "true"
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := r.Client.Get(context.TODO(), types.NamespacedName{
+			Name:      instance.Name,
+			Namespace: instance.Namespace,
+		}, instance)
+		if err != nil {
+			return err
 		}
-	} else {
-		if ok && afterInSync == "true" {
-			delete(instance.Annotations, cloudManager.ReconcileAfterInSync)
+		deploymentScope, err := r.GetScopeConfig(instance)
+		if err != nil {
+			return err
 		}
-	}
+		logPtpInterface.V(2).Info("deploymentScope in configuration", "deploymentScope", deploymentScope)
 
-	// Update annotation
-	err = r.Client.Update(context.TODO(), instance)
+		// Put ReconcileAfterInSync values depends on scope
+		// "true"  if scope is "principal" because it is day 2 operation (update configuration)
+		// "false" if scope is "bootstrap" or None
+		afterInSync, ok := instance.Annotations[cloudManager.ReconcileAfterInSync]
+		if deploymentScope == cloudManager.ScopePrincipal {
+			if !ok || afterInSync != "true" {
+				instance.Annotations[cloudManager.ReconcileAfterInSync] = "true"
+			}
+		} else {
+			if ok && afterInSync == "true" {
+				delete(instance.Annotations, cloudManager.ReconcileAfterInSync)
+			}
+		}
+		return r.Client.Update(context.TODO(), instance)
+	})
 	if err != nil {
 		err = perrors.Wrapf(err, "failed to update profile annotation ReconcileAfterInSync")
 		return err
 	}
 
-	// Update scope status
-	instance.Status.DeploymentScope = deploymentScope
-
-	// Set default value for StrategyRequired
-	if instance.Status.StrategyRequired == "" {
-		instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
-	}
-
-	// Check configration is updated
-	if instance.Status.ObservedGeneration != instance.ObjectMeta.Generation {
-		if instance.Status.ObservedGeneration == 0 &&
-			instance.Status.Reconciled {
-			// Case: DM upgrade in reconceiled node
-			instance.Status.ConfigurationUpdated = false
-		} else {
-			// Case: Fresh install or Day-2 operation
-			instance.Status.ConfigurationUpdated = true
-			if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
-				instance.Status.Reconciled = false
-				// Update storategy required status for strategy monitor
-				r.CloudManager.UpdateConfigVersion()
-				r.CloudManager.SetResourceInfo(cloudManager.ResourcePtpinterface, "", instance.Name, instance.Status.Reconciled, cloudManager.StrategyNotRequired)
-			}
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := r.Client.Get(context.TODO(), types.NamespacedName{
+			Name:      instance.Name,
+			Namespace: instance.Namespace,
+		}, instance)
+		if err != nil {
+			return err
 		}
-		instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
-		// Reset strategy when new configration is applied
-		instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
-	}
 
-	err = r.Client.Status().Update(context.TODO(), instance)
+		// Update scope status
+		deploymentScope, err := r.GetScopeConfig(instance)
+		if err != nil {
+			return err
+		}
+		logPtpInterface.V(2).Info("deploymentScope in configuration", "deploymentScope", deploymentScope)
+		instance.Status.DeploymentScope = deploymentScope
+
+		// Set default value for StrategyRequired
+		if instance.Status.StrategyRequired == "" {
+			instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
+		}
+
+		// Check if the configuration is updated
+		if instance.Status.ObservedGeneration != instance.ObjectMeta.Generation {
+			if instance.Status.ObservedGeneration == 0 &&
+				instance.Status.Reconciled {
+				// Case: DM upgrade in reconciled node
+				instance.Status.ConfigurationUpdated = false
+			} else {
+				// Case: Fresh install or Day-2 operation
+				instance.Status.ConfigurationUpdated = true
+				if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
+					instance.Status.Reconciled = false
+					// Update strategy required status for strategy monitor
+					r.CloudManager.UpdateConfigVersion()
+					r.CloudManager.SetResourceInfo(cloudManager.ResourcePtpinterface, "", instance.Name, instance.Status.Reconciled, cloudManager.StrategyNotRequired)
+				}
+			}
+			instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
+			// Reset strategy when new configuration is applied
+			instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
+		}
+
+		return r.Client.Status().Update(context.TODO(), instance)
+	})
+
 	if err != nil {
 		err = perrors.Wrapf(err, "failed to update status: %s",
 			common.FormatStruct(instance.Status))


### PR DESCRIPTION
Suppressing unnecessary ERROR messages.
Currently the following error messages are shown
in DM log many times:
- please apply your changes to the latest version and try again
- waiting for a stable state The first message is occurred when instance revision is different. This message is harmless because it will reconcile again, and will obtain the latest instance.
The second message is not an error. It is
occurred when host monitor starts but this case is just waiting for the expected states to continue reconciling. These error messages are better to be suppressed because it might confuse the user when they see the logs.

This fix by:
- Retry to update instance status when revision is different
- Change log level error to info for starting state wait monitor

Retry is implemented in client-go.
Function RetryOnConflict is used to make an update to a resource when you have to worry about conflicts caused by other code making unrelated updates to the resource at the same time.
For the further information about RetryOnConflict, please refer https://github.com/kubernetes/client-go/blob/v0.23.5/util/retry/util.go

The DefaultRetry is used because it does not need to wait for some status. We just need to avoid some other code is updating after you read the status. So, we don't need to wait a long interval. Every time retry starts, It reads the latest status by Client.Get.

Test Plan:
PASS: make builder-run finish successfully.
PASS: make && DEBUG=yes make docker-build finish
      successfully.
PASS: Fresh install finish successfully and these error
      messages are not observed in DM log.
PASS: Day2 operation finish successfully and these error
      messages are not observed in DM log.

Signed-off-by: Takamasa Takenaka <takamasa.takenaka@windriver.com>
(cherry picked from commit c3325a4002a4a8a6c0ed0969ea91f63780ebc97e)