### PR TITLE
Bug-fix: catch error in controller fs update

### DIFF
--- a/controllers/system/system_controller.go
+++ b/controllers/system/system_controller.go
@@ -1048,6 +1048,8 @@ func (r *SystemReconciler) ReconcileSystem(client *gophercloud.ServiceClient, in
 
 	err = r.ReconcileSystemFinal(client, instance, spec, info)
 	if err != nil {
+		// Need to return true to unblock the other reconcilers to work with the
+		// system reconciler in parallel
 		return true, err
 	}
 
@@ -1287,11 +1289,11 @@ func (r *SystemReconciler) ReconcileResource(client *gophercloud.ServiceClient, 
 	ready, err := r.ReconcileSystem(client, instance, spec, &systemInfo)
 	inSync := err == nil
 
+	// Regardless of whether an error occurred, if the reconciling got
+	// far enough along to get the system in a state in which the other
+	// reconcilers can make progress than we need to mark the system as
+	// being ready. The error wil be returned in the end of this method.
 	if ready {
-		// Regardless of whether an error occurred, if the reconciling got
-		// far enough along to get the system in a state in which the other
-		// reconcilers can make progress than we need to mark the system as
-		// being ready.
 		if !r.CloudManager.GetSystemReady(instance.Namespace) {
 			// Set the system type which may be used by other reconcilers to make
 			// decisions about when to reconcile certain resources.
@@ -1305,13 +1307,13 @@ func (r *SystemReconciler) ReconcileResource(client *gophercloud.ServiceClient, 
 			r.ReconcilerEventLogger.NormalEvent(instance, common.ResourceUpdated,
 				"system is now ready for other reconcilers")
 
-			err = r.CloudManager.NotifySystemDependencies(instance.Namespace)
-			if err != nil {
+			err2 := r.CloudManager.NotifySystemDependencies(instance.Namespace)
+			if err2 != nil {
 				// Revert to not-ready so that when we reconcile the system
 				// resource again we will push the change out to all other
 				// reconcilers again.
 				r.CloudManager.SetSystemReady(instance.Namespace, false)
-				return err
+				return err2
 			}
 		}
 	}
@@ -1319,10 +1321,10 @@ func (r *SystemReconciler) ReconcileResource(client *gophercloud.ServiceClient, 
 	if r.statusUpdateRequired(instance, systemInfo, inSync) {
 		logSystem.Info("updating status for system", "status", instance.Status)
 
-		err2 := r.Client.Status().Update(context.TODO(), instance)
-		if err2 != nil {
-			err2 = perrors.Wrap(err2, "failed to update system status")
-			return err2
+		err3 := r.Client.Status().Update(context.TODO(), instance)
+		if err3 != nil {
+			err3 = perrors.Wrap(err3, "failed to update system status")
+			return err3
 		}
 	}
 


### PR DESCRIPTION
The error from the controller fs update in the system reconciler was overritten by the error produced when notifying the other reconcilers, therefore, if the controller fs update failed, the error will not be caught and there will be no retry afterwards.

This commit fixes this bug, avoids the error overritten and return the error in the end after notifying the dependencies.

Test plan:
Passed - deploy an AIOSX with controller_fs update, the system can be reconciled Passed - manually enforce the error response(400) in sysinv controller_fs controller, the error will be reported in the DM manager log. The controller can be unlocked, and host resource can be insync/reconciled. The retry of controller fs update can be seen in DM manager log. Passed - In case two, remove the error response, after a successful update of the controller_fs, the system resource can be insync/reconciled.