### PR TITLE
Avoid create bootstrap_finalized during reconfig (#271)

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -148,12 +148,6 @@
       set_fact:
         config_permdir: "{{ platform_path + '/config/' + software_version }}"
 
-    - name: Mark the bootstrap as finalized
-      file:
-        path: "{{ config_permdir }}/.bootstrap_finalized"
-        state: touch
-      become: yes
-
     # Check if DM already exists in either helmv2 or helmv3
     - name: Get list of releases in helmv2
       command: >-
@@ -182,6 +176,18 @@
         grep -iq '"name":"deployment-manager"' <<< {{ helmv3_releases.stdout_lines }}
       ignore_errors: yes
       register: helmv3_dm_exists
+
+    - name: Set reconfig fact
+      set_fact:
+        reconfig_flag: "{{ true if helmv2_dm_exists.rc == 0 or helmv3_dm_exists.rc == 0
+                        else false }}"
+
+    - name: Mark the bootstrap as finalized
+      file:
+        path: "{{ config_permdir }}/.bootstrap_finalized"
+        state: touch
+      become: yes
+      when: not reconfig_flag
 
     # Follow a different reinstallation procedure if DM is installed in helmv2
     - block:
@@ -297,7 +303,7 @@
           KUBECONFIG: "/etc/kubernetes/admin.conf"
         when: deployment_manager_pod_name.stdout
 
-      when: helmv2_dm_exists.rc == 0 or helmv3_dm_exists.rc == 0
+      when: reconfig_flag
 
     - name: Wait for Deployment Manager to be ready
       shell: KUBECONFIG=/etc/kubernetes/admin.conf /bin/kubectl wait --namespace=platform-deployment-manager --for=condition=Ready pods --selector control-plane=controller-manager --timeout=60s


### PR DESCRIPTION
The bootstrap_finalized flag is only expected to be added after the bootstrap playbook, therefore, the task to add this flag is not necessary when re-applying the DM. This commit checks if the DM was installed before applying this playbook, avoids to create the flag file again if the DM was already installed.

Tests passed:
1. Applying this playbook on a freshly installed system, verified the system can be deloyed, the flag file was created.
2. Re-apply the playbook after the initial apply, verified the DM can be updated, the DM pod was re-created, the task of the flag file was skipped.

Signed-off-by: Yuxing Jiang <Yuxing.Jiang@windriver.com>
(cherry picked from commit c742ccbcfb356ff8793015cea28fe0329785c452)