### PR TITLE
Support to reconcile new filesystem types with host-fs-add API before…

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -32,7 +32,8 @@ const (
 	Memory            ReconcilerName = "host.memory"
 	Processor         ReconcilerName = "host.processor"
 	Storage           ReconcilerName = "host.storage"
-	FileSystems       ReconcilerName = "host.storage.filesystems"
+	FileSystemTypes   ReconcilerName = "host.storage.fileSystemTypes"
+	FileSystemSizes   ReconcilerName = "host.storage.fileSystemSizes"
 	StorageMonitor    ReconcilerName = "host.storage.monitor"
 	OSD               ReconcilerName = "host.storage.osd"
 	Partition         ReconcilerName = "host.storage.partition"
@@ -66,7 +67,8 @@ var reconcilerDefaultStates = map[ReconcilerName]bool{
 	Memory:            true,
 	Processor:         true,
 	Storage:           true,
-	FileSystems:       true,
+	FileSystemTypes:   true,
+	FileSystemSizes:   true,
 	StorageMonitor:    true,
 	OSD:               true,
 	Partition:         true,

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/gophercloud/gophercloud v0.0.0-20221230131953-acb6bd9c1992 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
-	github.com/gophercloud/gophercloud v0.0.0-20221230131953-acb6bd9c1992 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect


### PR DESCRIPTION
… initial unlock (#157)

* Support reconcile file system types

This commit adds support to reconcile file system types(only allowed types, currently: instances and image-conversion) during the stage of reconciling the disabled hosts. The orginal file system reconciler is only to update the file system sized once the host is enabled and unlocked, rename it as the reconciler of the file system size.

Test passed:
Bring up a storage lab with instances configured on the compute nodes. The file system can be configured and the host can be in-synced.

Signed-off-by: Yuxing Jiang <Yuxing.Jiang@windriver.com>

* Update gophercloud reference

This commit updates the reference of the gophercloud from wind-river repository.

Test passed: make the new image after updating the reference in go module.

Signed-off-by: Yuxing Jiang <Yuxing.Jiang@windriver.com>

Signed-off-by: Yuxing Jiang <Yuxing.Jiang@windriver.com>
(cherry picked from commit f2fe21e1e833868e73b87d5a2aab43177d99b092)