### PR TITLE
Add support for overriding the OS_REGION_NAME parameter

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -349,6 +349,24 @@
             deploy_config: "/home/{{ ansible_ssh_user }}/deployment-config.yaml"
           when: inventory_hostname != 'localhost'
 
+         # Configure required region value for subcloud
+        - name: Get subcloud region value from environment
+          shell: source /etc/platform/openrc; echo $OS_REGION_NAME
+          register: os_region_name_from_env
+
+        - name: Show subcloud region
+          debug:
+            msg:
+            - "Subcloud region value : {{os_region_name_from_env.stdout}}"
+
+        - name: Configure new subcloud region value
+          lineinfile:
+            path: "{{deploy_config}}"
+            regexp: 'OS_REGION_NAME'
+            line: "  OS_REGION_NAME: {{os_region_name_from_env.stdout}}"
+            state: present
+          when: ("subcloud" in get_distributed_cloud_role.stdout)
+
         - wait_for:
             # Pause for an arbitrary amount of time to allow the deployment
             # manager to come up and download its certificates.  It needs to


### PR DESCRIPTION
The Subcloud Name Reconfiguration feature includes a mechanism to override the OS_REGION_VALUE on the dcmanager side. This creates confusion when configuring the region value in the deployment file.

This commits adds the changes to override the OS_REGION_NAME parameter but on the DM side.

Test Plan:

PASS - Deploy a new Subcloud and check DM configuration to
       validate endpoint access. There should be no endpoint
       errors in DM logs and the subcloud should be operational.
PASS - Deploy DM to central and verify that the region has not
       been replaced, since the condition applies only to the
       subcloud role