### PR TITLE
Remove unnecessary logging

### DIFF
--- a/controllers/system/system_controller.go
+++ b/controllers/system/system_controller.go
@@ -1359,7 +1359,6 @@ func (r *SystemReconciler) GetScopeConfig(instance *starlingxv1.System) (scope s
 			if err == nil {
 				if status_config.Status.DeploymentScope != "" {
 					lowerCaseScope := strings.ToLower(status_config.Status.DeploymentScope)
-					logSystem.Info(fmt.Sprintf("lowerCaseScope: %s", lowerCaseScope))
 					switch lowerCaseScope {
 					case cloudManager.ScopeBootstrap:
 						deploymentScope = cloudManager.ScopeBootstrap

--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -108,24 +108,24 @@
         - set_fact:
             helm_chart_overrides: "/usr/local/share/applications/overrides/wind-river-cloud-platform-deployment-manager-overrides-subcloud.yaml"
             manager_chart: "/usr/local/share/applications/helm/wind-river-cloud-platform-deployment-manager-*.tgz"
-          
+
         - name: Check if helm-chart file exists in subcloud
           shell: ls {{ manager_chart }}
           ignore_errors: yes
           register: helm_chart_file
-         
+
         - name: Check if helm-overrides file exists in subcloud
           stat:
             path: "{{ helm_chart_overrides }}"
           register: helm_chart_overrides_file
-          
+
         - name: Fail helm-chart and overrides not exists in subcloud
-          fail: 
+          fail:
             msg: "Helm-chart and overrides not exists in subcloud"
           when: (helm_chart_file.stdout | length == 0 or helm_chart_overrides_file.stat.exists == False)
 
         when: ("subcloud" in get_distributed_cloud_role.stdout and user_uploaded_artifacts is false)
-      
+
       - name: Clean download directory
         file:
           path: "{{ temp.path }}"


### PR DESCRIPTION
Last commit introduced an unnecessary logging on System GetScopeConfig method.
This commit removes this line and also deletes some spaces in the DM playbook.