### PR TITLE
Support delete optional service parameters

### DIFF
--- a/api/v1/constructors.go
+++ b/api/v1/constructors.go
@@ -27,9 +27,10 @@ import (
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/serviceparameters"
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/storagebackends"
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/volumegroups"
+	common "github.com/wind-river/cloud-platform-deployment-manager/common"
 	v1info "github.com/wind-river/cloud-platform-deployment-manager/platform"
 	v1 "k8s.io/api/core/v1"
-	v1types "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -733,11 +734,11 @@ func parseBoardManagementInfo(profile *HostProfileSpec, host v1info.HostInfo) er
 
 func NewNamespace(name string) (*v1.Namespace, error) {
 	namespace := v1.Namespace{
-		TypeMeta: v1types.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Namespace",
 		},
-		ObjectMeta: v1types.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 	}
@@ -901,11 +902,11 @@ func NewHostProfileSpec(host v1info.HostInfo) (*HostProfileSpec, error) {
 func NewHostProfile(name string, namespace string, hostInfo v1info.HostInfo) (*HostProfile, error) {
 	name = fmt.Sprintf("%s-profile", name)
 	profile := HostProfile{
-		TypeMeta: v1types.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			APIVersion: APIVersion,
 			Kind:       KindHostProfile,
 		},
-		ObjectMeta: v1types.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
@@ -1151,11 +1152,11 @@ func NewSystemSpec(systemInfo v1info.SystemInfo) (*SystemSpec, error) {
 
 func NewSystem(namespace string, name string, systemInfo v1info.SystemInfo) (*System, error) {
 	system := System{
-		TypeMeta: v1types.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			APIVersion: APIVersion,
 			Kind:       KindSystem,
 		},
-		ObjectMeta: v1types.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
@@ -1187,11 +1188,11 @@ func NewBMSecret(name string, namespace string, username string) (*v1.Secret, er
 	fakePassword := []byte("")
 
 	secret := v1.Secret{
-		TypeMeta: v1types.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Secret",
 		},
-		ObjectMeta: v1types.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
@@ -1207,11 +1208,11 @@ func NewBMSecret(name string, namespace string, username string) (*v1.Secret, er
 
 func NewLicenseSecret(name string, namespace string, content string) (*v1.Secret, error) {
 	secret := v1.Secret{
-		TypeMeta: v1types.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Secret",
 		},
-		ObjectMeta: v1types.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
@@ -1230,11 +1231,11 @@ func NewCertificateSecret(name string, namespace string) (*v1.Secret, error) {
 	fakeInput := []byte("")
 
 	secret := v1.Secret{
-		TypeMeta: v1types.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Secret",
 		},
-		ObjectMeta: v1types.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
@@ -1270,11 +1271,11 @@ func NewHostSpec(hostInfo v1info.HostInfo) (*HostSpec, error) {
 
 func NewHost(name string, namespace string, hostInfo v1info.HostInfo) (*Host, error) {
 	host := Host{
-		TypeMeta: v1types.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			APIVersion: APIVersion,
 			Kind:       KindHost,
 		},
-		ObjectMeta: v1types.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
@@ -1323,11 +1324,11 @@ func NewDataNetworkSpec(net datanetworks.DataNetwork) (*DataNetworkSpec, error) 
 
 func NewDataNetwork(name string, namespace string, net datanetworks.DataNetwork) (*DataNetwork, error) {
 	dataNetwork := DataNetwork{
-		TypeMeta: v1types.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			APIVersion: APIVersion,
 			Kind:       KindDataNetwork,
 		},
-		ObjectMeta: v1types.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
@@ -1362,11 +1363,11 @@ func NewPtpInstanceSpec(inst ptpinstances.PTPInstance) (*PtpInstanceSpec, error)
 
 func NewPTPInstance(name string, namespace string, inst ptpinstances.PTPInstance) (*PtpInstance, error) {
 	ptpInstance := PtpInstance{
-		TypeMeta: v1types.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			APIVersion: APIVersion,
 			Kind:       KindPTPInstance,
 		},
-		ObjectMeta: v1types.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
@@ -1401,11 +1402,11 @@ func NewPtpInterfaceSpec(PTPint ptpinterfaces.PTPInterface) (*PtpInterfaceSpec, 
 
 func NewPTPInterface(name string, namespace string, PTPint ptpinterfaces.PTPInterface) (*PtpInterface, error) {
 	ptpInterface := PtpInterface{
-		TypeMeta: v1types.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			APIVersion: APIVersion,
 			Kind:       KindPTPInterface,
 		},
-		ObjectMeta: v1types.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
@@ -1452,11 +1453,11 @@ func NewPlatformNetworkSpec(pool addresspools.AddressPool, network_type string) 
 
 func NewPlatformNetwork(name string, namespace string, pool addresspools.AddressPool, network_type string) (*PlatformNetwork, error) {
 	platformNetwork := PlatformNetwork{
-		TypeMeta: v1types.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			APIVersion: APIVersion,
 			Kind:       KindPlatformNetwork,
 		},
-		ObjectMeta: v1types.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
@@ -1473,4 +1474,17 @@ func NewPlatformNetwork(name string, namespace string, pool addresspools.Address
 	spec.DeepCopyInto(&platformNetwork.Spec)
 
 	return &platformNetwork, nil
+}
+
+// IsDefaultServiceParameter returns if a service parameter is a default.
+// The default parameters are defined in common/constants.go.
+func IsDefaultServiceParameter(sp *ServiceParameterInfo) bool {
+	for _, defaultParameter := range common.DefaultParameters {
+		if sp.Service == defaultParameter.Service &&
+			sp.Section == defaultParameter.Section &&
+			sp.ParamName == defaultParameter.ParamName {
+			return true
+		}
+	}
+	return false
 }

--- a/api/v1/constructors_test.go
+++ b/api/v1/constructors_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/disks"
+	common "github.com/wind-river/cloud-platform-deployment-manager/common"
 	"github.com/wind-river/cloud-platform-deployment-manager/platform"
 )
 
@@ -105,6 +106,34 @@ var _ = Describe("Constructor utils for kind", func() {
 					got := FixDevicePath(tt.args.path, tt.args.host)
 					Expect(reflect.DeepEqual(got, tt.want)).To(BeTrue())
 				}
+			})
+		})
+	})
+
+	Describe("Test IsDefaultServiceParameter", func() {
+		Context("When filtering default service parameters", func() {
+			It("should return true", func() {
+				tests := common.DefaultParameters
+				for _, test := range tests {
+					singleServiceParameter := ServiceParameterInfo{
+						Service:   test.Service,
+						Section:   test.Section,
+						ParamName: test.ParamName,
+					}
+					got := IsDefaultServiceParameter(&singleServiceParameter)
+					Expect(got).To(BeTrue())
+				}
+			})
+		})
+		Context("When filtering not default service parameters", func() {
+			It("should return false", func() {
+				singleServiceParameter := ServiceParameterInfo{
+					Service:   "foo",
+					Section:   "bar",
+					ParamName: "foobar",
+				}
+				got := IsDefaultServiceParameter(&singleServiceParameter)
+				Expect(got).To(BeFalse())
 			})
 		})
 	})

--- a/build/build.go
+++ b/build/build.go
@@ -26,7 +26,7 @@ import (
 	"github.com/wind-river/cloud-platform-deployment-manager/controllers/manager"
 	v1info "github.com/wind-river/cloud-platform-deployment-manager/platform"
 	v1 "k8s.io/api/core/v1"
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const yamlSeparator = "---\n"
@@ -53,6 +53,10 @@ type DeploymentBuilder struct {
 	hostFilters    []HostFilter
 }
 
+var defaultSystemFilters = []SystemFilter{
+	NewServiceParametersSystemFilter(),
+}
+
 var defaultHostFilters = []HostFilter{
 	NewController0Filter(),
 	NewLoopbackInterfaceFilter(),
@@ -71,7 +75,58 @@ func NewDeploymentBuilder(client *gophercloud.ServiceClient, namespace string, n
 		namespace:      namespace,
 		name:           name,
 		progressWriter: progressWriter,
+		systemFilters:  defaultSystemFilters,
 		hostFilters:    defaultHostFilters}
+}
+
+// parseIncompleteSecret is a convenience unitilty function to parse an incompleteSecret
+// from v1.Secret to IncompleteSecret to add the warning message to the data of
+// secret to request the action from users.
+func parseIncompleteSecret(secret *v1.Secret) *IncompleteSecret {
+	warningMsg := "Warning: Incomplete secret, please replace it with the secret content"
+	if secret.Type == v1.SecretTypeTLS {
+		return &IncompleteSecret{
+			TypeMeta:   secret.TypeMeta,
+			ObjectMeta: secret.ObjectMeta,
+			Type:       secret.Type,
+			Data: map[string]string{
+				v1.TLSCertKey:              warningMsg,
+				v1.TLSPrivateKeyKey:        warningMsg,
+				v1.ServiceAccountRootCAKey: warningMsg,
+			},
+		}
+	}
+
+	if secret.Type == v1.SecretTypeBasicAuth {
+		return &IncompleteSecret{
+			TypeMeta:   secret.TypeMeta,
+			ObjectMeta: secret.ObjectMeta,
+			Type:       secret.Type,
+			Data: map[string]string{
+				v1.BasicAuthUsernameKey: string(secret.Data["username"]),
+				v1.BasicAuthPasswordKey: warningMsg,
+			},
+		}
+	}
+
+	// Return empty Data if the secret type is not listed above
+	return &IncompleteSecret{
+		TypeMeta:   secret.TypeMeta,
+		ObjectMeta: secret.ObjectMeta,
+		Type:       secret.Type,
+		Data: map[string]string{
+			"Fake Data": warningMsg,
+		},
+	}
+}
+
+// IncompleteSecret defines a struct that contains a warning message in the secret
+// data if the secret is incomplete
+type IncompleteSecret struct {
+	TypeMeta   metav1.TypeMeta
+	ObjectMeta metav1.ObjectMeta
+	Type       v1.SecretType
+	Data       map[string]string
 }
 
 // Deployment defines the structure used to store all of the details of a
@@ -80,7 +135,7 @@ func NewDeploymentBuilder(client *gophercloud.ServiceClient, namespace string, n
 type Deployment struct {
 	Namespace         v1.Namespace
 	Secrets           []*v1.Secret
-	IncompleteSecrets []*v1.Secret
+	IncompleteSecrets []*IncompleteSecret
 	System            starlingxv1.System
 	PlatformNetworks  []*starlingxv1.PlatformNetwork
 	DataNetworks      []*starlingxv1.DataNetwork
@@ -398,11 +453,11 @@ func NewEndpointSecretFromEnv(name string, namespace string) (*v1.Secret, error)
 	password := os.Getenv(manager.PasswordKey)
 
 	secret := v1.Secret{
-		TypeMeta: v12.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Secret",
 		},
-		ObjectMeta: v12.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
@@ -463,7 +518,8 @@ func (db *DeploymentBuilder) buildCertificateSecrets(d *Deployment) error {
 			if err != nil {
 				return err
 			}
-			d.IncompleteSecrets = append(d.IncompleteSecrets, cert)
+			incompleteSecret := parseIncompleteSecret(cert)
+			d.IncompleteSecrets = append(d.IncompleteSecrets, incompleteSecret)
 		}
 	}
 
@@ -714,7 +770,8 @@ func (db *DeploymentBuilder) buildHostsAndProfiles(d *Deployment) error {
 				// user is free to clone and modify the config on a per host
 				// basis if needed.
 				bmSecretGenerated = true
-				d.IncompleteSecrets = append(d.IncompleteSecrets, secret)
+				incompleteSecret := parseIncompleteSecret(secret)
+				d.IncompleteSecrets = append(d.IncompleteSecrets, incompleteSecret)
 			}
 		}
 

--- a/build/build_suite_test.go
+++ b/build/build_suite_test.go
@@ -1,0 +1,177 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2023 Wind River Systems, Inc. */
+
+package build
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBuild(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Build Suite")
+}
+
+var _ = Describe("Test Build utilities:", func() {
+	Describe("Test New NewDeploymentBuilder", func() {
+
+		client := gophercloud.ServiceClient{}
+		got := NewDeploymentBuilder(&client, "foo", "bar", os.Stdout)
+
+		expectSystemFilter := []SystemFilter{
+			NewServiceParametersSystemFilter()}
+		Expect(reflect.DeepEqual(
+			got.systemFilters, expectSystemFilter)).To(BeTrue())
+
+		expectHostFilter := []HostFilter{
+			NewController0Filter(),
+			NewLoopbackInterfaceFilter(),
+			NewLocationFilter(),
+			NewAddressFilter(),
+			NewBMAddressFilter(),
+			NewStorageMonitorFilter(),
+			NewInterfaceRemoveUuidFilter(),
+		}
+		Expect(reflect.DeepEqual(
+			got.hostFilters, expectHostFilter)).To(BeTrue())
+	})
+
+	Describe("Test parse incomplete secrets", func() {
+		warningMsg := "Warning: Incomplete secret, please replace it with the secret content"
+		Context("when there are incomplete TLS secrets", func() {
+			It("should return secret with warning message", func() {
+				fakeInput := []byte("")
+				secret := v1.Secret{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Secret",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "bar",
+					},
+					Type: v1.SecretTypeTLS,
+					Data: map[string][]byte{
+						v1.TLSCertKey:              fakeInput,
+						v1.TLSPrivateKeyKey:        fakeInput,
+						v1.ServiceAccountRootCAKey: fakeInput,
+					},
+				}
+				got := parseIncompleteSecret(&secret)
+				expect := IncompleteSecret{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Secret",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "bar",
+					},
+					Type: v1.SecretTypeTLS,
+					Data: map[string]string{
+						v1.TLSCertKey:              warningMsg,
+						v1.TLSPrivateKeyKey:        warningMsg,
+						v1.ServiceAccountRootCAKey: warningMsg,
+					},
+				}
+				Expect(got.TypeMeta).To(Equal(expect.TypeMeta))
+				Expect(got.ObjectMeta).To(Equal(expect.ObjectMeta))
+				Expect(got.Type).To(Equal(expect.Type))
+				Expect(got.Data).To(Equal(expect.Data))
+			})
+		})
+
+		Context("when there are incomplete bm secrets", func() {
+			It("should return secret with warning password", func() {
+				fakeInput := []byte("")
+				fakeUser := []byte("username")
+				secret := v1.Secret{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Secret",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "bar",
+					},
+					Type: v1.SecretTypeBasicAuth,
+					Data: map[string][]byte{
+						v1.BasicAuthUsernameKey: []byte(fakeUser),
+						v1.BasicAuthPasswordKey: fakeInput,
+					},
+				}
+				got := parseIncompleteSecret(&secret)
+				expect := IncompleteSecret{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Secret",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "bar",
+					},
+					Type: v1.SecretTypeBasicAuth,
+					Data: map[string]string{
+						v1.BasicAuthUsernameKey: string([]byte(fakeUser)),
+						v1.BasicAuthPasswordKey: warningMsg,
+					},
+				}
+				Expect(got.TypeMeta).To(Equal(expect.TypeMeta))
+				Expect(got.ObjectMeta).To(Equal(expect.ObjectMeta))
+				Expect(got.Type).To(Equal(expect.Type))
+				Expect(got.Data).To(Equal(expect.Data))
+			})
+		})
+
+		Context("when there are incomplete other secrets", func() {
+			It("should return secret with fake datum and error message", func() {
+				fakeInput := []byte("")
+				fakeUser := []byte("username")
+				secret := v1.Secret{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Secret",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "bar",
+					},
+					Type: "fake type",
+					Data: map[string][]byte{
+						v1.BasicAuthUsernameKey: []byte(fakeUser),
+						v1.BasicAuthPasswordKey: fakeInput,
+					},
+				}
+				got := parseIncompleteSecret(&secret)
+				expect := IncompleteSecret{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Secret",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "bar",
+					},
+					Type: "fake type",
+					Data: map[string]string{
+						"Fake Data": warningMsg,
+					},
+				}
+				Expect(got.TypeMeta).To(Equal(expect.TypeMeta))
+				Expect(got.ObjectMeta).To(Equal(expect.ObjectMeta))
+				Expect(got.Type).To(Equal(expect.Type))
+				Expect(got.Data).To(Equal(expect.Data))
+			})
+		})
+	})
+
+})

--- a/build/filter.go
+++ b/build/filter.go
@@ -793,25 +793,25 @@ func (in *CACertificateFilter) Filter(system *v1.System, deployment *Deployment)
 type ServiceParameterFilter struct {
 }
 
+// Filter out the default service parameters
 func NewServiceParametersSystemFilter() *ServiceParameterFilter {
 	return &ServiceParameterFilter{}
 }
 
-func IsDefaultServiceParameter(sp *v1.ServiceParameterInfo) bool {
-	return true
-}
-
-func (in *ServiceParameterFilter) Filter(system *v1.System, deployment *Deployment) error {
+func (in *ServiceParameterFilter) Filter(
+	system *v1.System, deployment *Deployment) error {
 	if system.Spec.ServiceParameters == nil {
 		return nil
 	}
 
 	result := make([]v1.ServiceParameterInfo, 0)
 	for _, sp := range *system.Spec.ServiceParameters {
-		// currently this skips everything
-		if IsDefaultServiceParameter(&sp) {
+
+		// If is a default service parameter, skip to add it
+		if v1.IsDefaultServiceParameter(&sp) {
 			continue
 		}
+
 		result = append(result, sp)
 	}
 
@@ -822,6 +822,20 @@ func (in *ServiceParameterFilter) Filter(system *v1.System, deployment *Deployme
 		system.Spec.ServiceParameters = nil
 	}
 
+	return nil
+}
+
+type NoServiceParameterFilter struct {
+}
+
+// Fileter out all the service parameters
+func NewNoServiceParametersSystemFilter() *NoServiceParameterFilter {
+	return &NoServiceParameterFilter{}
+}
+
+func (in *NoServiceParameterFilter) Filter(
+	system *v1.System, deployment *Deployment) error {
+	system.Spec.ServiceParameters = nil
 	return nil
 }
 

--- a/build/filter_test.go
+++ b/build/filter_test.go
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2023 Wind River Systems, Inc. */
+
+package build
+
+import (
+	v1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
+	utils "github.com/wind-river/cloud-platform-deployment-manager/common"
+	"reflect"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Test filters utilities:", func() {
+	Describe("Test ServiceParameterFilter", func() {
+		system := v1.System{}
+		deployment := Deployment{}
+		Context("If default service parameter fileter", func() {
+			It("defaults should be filtered", func() {
+				list := make([]v1.ServiceParameterInfo, 0)
+				for _, param := range utils.DefaultParameters {
+					sp := v1.ServiceParameterInfo{
+						Service:   param.Service,
+						Section:   param.Section,
+						ParamName: param.ParamName,
+					}
+					list = append(list, sp)
+				}
+				sp := v1.ServiceParameterInfo{
+					Service:   "foo",
+					Section:   "bar",
+					ParamName: "foobar",
+				}
+				list = append(list, sp)
+				spList := v1.ServiceParameterList(list)
+				system.Spec.ServiceParameters = &spList
+
+				spFilter := ServiceParameterFilter{}
+				spFilter.Filter(&system, &deployment)
+				got := system.Spec.ServiceParameters
+				expectSpArrary := make([]v1.ServiceParameterInfo, 0)
+				expectSpArrary = append(expectSpArrary, sp)
+				expectSpList := v1.ServiceParameterList(expectSpArrary)
+				Expect(reflect.DeepEqual(got, &expectSpList)).To(BeTrue())
+			})
+		})
+
+		Context("If no service parameter filter", func() {
+			It("all should be filtered", func() {
+				list := make([]v1.ServiceParameterInfo, 0)
+				for _, param := range utils.DefaultParameters {
+					sp := v1.ServiceParameterInfo{
+						Service:   param.Service,
+						Section:   param.Section,
+						ParamName: param.ParamName,
+					}
+					list = append(list, sp)
+				}
+				sp := v1.ServiceParameterInfo{
+					Service:   "foo",
+					Section:   "bar",
+					ParamName: "foobar",
+				}
+				list = append(list, sp)
+				spList := v1.ServiceParameterList(list)
+				system.Spec.ServiceParameters = &spList
+
+				//the default service parameter filter should be always applied
+				spFilter := ServiceParameterFilter{}
+				spFilter.Filter(&system, &deployment)
+
+				noSpFilter := NoServiceParameterFilter{}
+				noSpFilter.Filter(&system, &deployment)
+				got := system.Spec.ServiceParameters
+				Expect(got).To(BeNil())
+			})
+		})
+	})
+
+	Describe("Test new service parameters", func() {
+		Context("when default service parameters filter", func() {
+			It("should return an ServiceParameterFilter", func() {
+				got := NewServiceParametersSystemFilter()
+				expect := ServiceParameterFilter{}
+				Expect(reflect.DeepEqual(got, &expect)).To(BeTrue())
+			})
+		})
+
+		Context("when no service parameters filter", func() {
+			It("should return an NoServiceParameterFilter", func() {
+				got := NewNoServiceParametersSystemFilter()
+				expect := NoServiceParameterFilter{}
+				Expect(reflect.DeepEqual(got, &expect)).To(BeTrue())
+			})
+		})
+	})
+})

--- a/common/constants.go
+++ b/common/constants.go
@@ -1,0 +1,127 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2023 Wind River Systems, Inc. */
+
+package common
+
+// Service Parameter Service Types
+const ServiceTypeIdentity = "identity"
+const ServiceTypePlatform = "platform"
+const ServiceTypeRadosgw = "radosgw"
+const ServiceTypeHttp = "http"
+
+// Service Parameter Section
+const ServiceParamSectionHttpConfig = "config"
+const ServiceParamSectionPlatformConfig = "config"
+const ServiceParamSectionPlatformMaintenance = "maintenance"
+const ServiceParamSectionPlatformKernel = "kernel"
+const ServiceParamSectionIdentityConfig = "config"
+const ServiceParamSectionRadosgwConfig = "config"
+const ServiceParamSectionSecurityCompliance = "security_compliance"
+
+// Service Parameter Name
+const ServiceParamHttpPortHttp = "http_port"
+const ServiceParamHttpPortHttps = "https_port"
+const ServiceParamIdentityConfigTokenExpiration = "token_expiration"
+const ServiceParamNamePlatformAuditD = "audit"
+const ServiceParamNamePlatformMaxCpuPercentage = "cpu_max_freq_min_percentage"
+
+const ServiceParamNamePlatConfigIntelNicDriverVersion = "intel_nic_driver_version"
+const ServiceParamNamePlatConfigIntelPstate = "intel_pstate"
+const ServiceParamNameRadosgwFsSizeMB = "fs_size_mb"
+const ServiceParamNameRadosgwServiceEnabled = "service_enabled"
+const ServiceParamNameSecurityComplianceLockoutDuration = "lockout_seconds"
+
+const ServiceParamNameSecurityComplianceLockoutFailureAttempts = "lockout_retries"
+const ServiceParamPlatMtceControllerBootTimeout = "controller_boot_timeout"
+const ServiceParamPlatMtceHbsPERIOD = "heartbeat_period"
+const ServiceParamPlatMtceHbsDegradeThreshold = "heartbeat_degrade_threshold"
+const ServiceParamPlatMtceHbsFailureAction = "heartbeat_failure_action"
+const ServiceParamPlatMtceHbsFailureThreshold = "heartbeat_failure_threshold"
+const ServiceParamPlatMtceMnfaThreshold = "mnfa_threshold"
+const ServiceParamPlatMtceMnfaTimeout = "mnfa_timeout"
+const ServiceParamPlatMtceWorkerBootTimeout = "worker_boot_timeout"
+
+type ServiceParam struct {
+	Service   string
+	Section   string
+	ParamName string
+}
+
+var DefaultParameters = [...]ServiceParam{
+	ServiceParam{Service: ServiceTypeIdentity,
+		Section:   ServiceParamSectionIdentityConfig,
+		ParamName: ServiceParamIdentityConfigTokenExpiration,
+	},
+	ServiceParam{Service: ServiceTypeIdentity,
+		Section:   ServiceParamSectionSecurityCompliance,
+		ParamName: ServiceParamNameSecurityComplianceLockoutDuration,
+	},
+	ServiceParam{Service: ServiceTypeIdentity,
+		Section:   ServiceParamSectionSecurityCompliance,
+		ParamName: ServiceParamNameSecurityComplianceLockoutFailureAttempts,
+	},
+	ServiceParam{Service: ServiceTypePlatform,
+		Section:   ServiceParamSectionPlatformMaintenance,
+		ParamName: ServiceParamPlatMtceWorkerBootTimeout,
+	},
+	ServiceParam{Service: ServiceTypePlatform,
+		Section:   ServiceParamSectionPlatformMaintenance,
+		ParamName: ServiceParamPlatMtceControllerBootTimeout,
+	},
+	ServiceParam{Service: ServiceTypePlatform,
+		Section:   ServiceParamSectionPlatformMaintenance,
+		ParamName: ServiceParamPlatMtceHbsPERIOD,
+	},
+	ServiceParam{Service: ServiceTypePlatform,
+		Section:   ServiceParamSectionPlatformMaintenance,
+		ParamName: ServiceParamPlatMtceHbsFailureAction,
+	},
+	ServiceParam{Service: ServiceTypePlatform,
+		Section:   ServiceParamSectionPlatformMaintenance,
+		ParamName: ServiceParamPlatMtceHbsFailureThreshold,
+	},
+	ServiceParam{Service: ServiceTypePlatform,
+		Section:   ServiceParamSectionPlatformMaintenance,
+		ParamName: ServiceParamPlatMtceHbsDegradeThreshold,
+	},
+	ServiceParam{Service: ServiceTypePlatform,
+		Section:   ServiceParamSectionPlatformMaintenance,
+		ParamName: ServiceParamPlatMtceMnfaThreshold,
+	},
+	ServiceParam{Service: ServiceTypePlatform,
+		Section:   ServiceParamSectionPlatformMaintenance,
+		ParamName: ServiceParamPlatMtceMnfaTimeout,
+	},
+	ServiceParam{Service: ServiceTypePlatform,
+		Section:   ServiceParamSectionPlatformKernel,
+		ParamName: ServiceParamNamePlatformAuditD,
+	},
+	ServiceParam{Service: ServiceTypePlatform,
+		Section:   ServiceParamSectionPlatformConfig,
+		ParamName: ServiceParamNamePlatConfigIntelNicDriverVersion,
+	},
+	ServiceParam{Service: ServiceTypePlatform,
+		Section:   ServiceParamSectionPlatformConfig,
+		ParamName: ServiceParamNamePlatConfigIntelPstate,
+	},
+	ServiceParam{Service: ServiceTypeRadosgw,
+		Section:   ServiceParamSectionRadosgwConfig,
+		ParamName: ServiceParamNameRadosgwServiceEnabled,
+	},
+	ServiceParam{Service: ServiceTypeRadosgw,
+		Section:   ServiceParamSectionRadosgwConfig,
+		ParamName: ServiceParamNameRadosgwFsSizeMB,
+	},
+	ServiceParam{Service: ServiceTypeHttp,
+		Section:   ServiceParamSectionHttpConfig,
+		ParamName: ServiceParamHttpPortHttp,
+	},
+	ServiceParam{Service: ServiceTypeHttp,
+		Section:   ServiceParamSectionHttpConfig,
+		ParamName: ServiceParamHttpPortHttps,
+	},
+	ServiceParam{Service: ServiceTypePlatform,
+		Section:   ServiceParamSectionPlatformConfig,
+		ParamName: ServiceParamNamePlatformMaxCpuPercentage,
+	},
+}

--- a/controllers/system/system_controller.go
+++ b/controllers/system/system_controller.go
@@ -418,6 +418,18 @@ func serviceparametersUpdateRequired(spec *starlingxv1.ServiceParameterInfo, p *
 	return serviceparametersOpts, result
 }
 
+// RefreshServiceParameterList updates the service parameters list in SystemInfo
+func (r *SystemReconciler) RefreshServiceParameterList(client *gophercloud.ServiceClient, instance *starlingxv1.System, info *v1info.SystemInfo) error {
+	result, err := serviceparameters.ListServiceParameters(client)
+	if err != nil {
+		err = perrors.Wrap(err, "failed to refresh service parameters list")
+		return err
+	}
+	r.ReconcilerEventLogger.NormalEvent(instance, common.ResourceUpdated, "ServiceParameter list info has been updated")
+	info.ServiceParameters = result
+	return nil
+}
+
 // ReconcileServiceParameters configures the system resources to align with the desired ServiceParameter state.
 func (r *SystemReconciler) ReconcileServiceParameters(client *gophercloud.ServiceClient, instance *starlingxv1.System, spec *starlingxv1.SystemSpec, info *v1info.SystemInfo) error {
 	if !utils.IsReconcilerEnabled(utils.ServiceParameters) {
@@ -466,19 +478,60 @@ func (r *SystemReconciler) ReconcileServiceParameters(client *gophercloud.Servic
 			updated = true
 			r.ReconcilerEventLogger.NormalEvent(instance, common.ResourceCreated, "ServiceParameter %q %q %q has been created", result.Service, result.Section, result.ParamName)
 		}
+	}
 
-		// Note: There is no support in the reconcile for DELETE of service parameters, since there are
-		// default service parameters setup by the system, that would complicate a reconcile.
+	// update the system object with the list of service params
+	if updated {
+		error := r.RefreshServiceParameterList(client, instance, info)
+		if error != nil {
+			return error
+		}
+	}
+
+	updated = false
+
+	for _, info_sp := range info.ServiceParameters {
+		found := false
+		for _, spec_sp := range *spec.ServiceParameters {
+			// A match occurs when service, section and paramname are equal
+			if info_sp.Service == spec_sp.Service &&
+				info_sp.Section == spec_sp.Section &&
+				info_sp.ParamName == spec_sp.ParamName {
+				// do nothing as it should be able to be updated by previous section
+				found = true
+				break
+			}
+		}
+		if !found {
+			// Firstly check if it is a default service parameter as we are not
+			// deleting the default service parameters, this should not be happening
+			// as we delete the default parameters from spec in RemoveDefaultSystemSpecs
+			sp := starlingxv1.ServiceParameterInfo{
+				Service:   info_sp.Service,
+				Section:   info_sp.Section,
+				ParamName: info_sp.ParamName,
+			}
+			if starlingxv1.IsDefaultServiceParameter(&sp) {
+				msg := fmt.Sprintf("it is unsafe to delete default service parameters: %q %q %q", info_sp.Service, info_sp.Section, info_sp.ParamName)
+				return common.NewUserDataError(msg)
+			}
+
+			err := serviceparameters.Delete(client, info_sp.ID).ExtractErr()
+			if err != nil {
+				return err
+			}
+			// success
+			updated = true
+			r.ReconcilerEventLogger.NormalEvent(instance, common.ResourceDeleted, "ServiceParameter %q %q %q has been created", info_sp.Service, info_sp.Section, info_sp.ParamName)
+		}
+
 	}
 	// update the system object with the list of service params
 	if updated {
-		result, err := serviceparameters.ListServiceParameters(client)
+		err := r.RefreshServiceParameterList(client, instance, info)
 		if err != nil {
-			err = perrors.Wrap(err, "failed to refresh service parameters list")
 			return err
 		}
-		r.ReconcilerEventLogger.NormalEvent(instance, common.ResourceUpdated, "ServiceParameter list info has been updated")
-		info.ServiceParameters = result
 	}
 
 	return nil


### PR DESCRIPTION
Support delete optional service parameters
This commit adds support of:
1 Filter out default service parameters in deployctl.
2 Keep no service parameters filter.
3 Add support to delete optional service parameters.
4 Prevent deleting default service parameters, return user data error
in this case.
5 Remove the newly introduce filters in https://github.com/Wind-River/cloud-platform-deployment-manager/commit/b0508af53eebb3ba040ce51bc6abd66c659c5400, as the deployctl w/o
optional argument is expected to be used in Day-2 operation.
6 Add filters to "--no-default" in deployctl to filt out the arguments
to archieve https://github.com/Wind-River/cloud-platform-deployment-manager/commit/b0508af53eebb3ba040ce51bc6abd66c659c5400.
7 Include the filters in "--minimal-config".
8 Add a warning message to a secret data if the content is empty.

Test plan:
1 Generate deployment config by deployctl, check no default service
parameters in the output.
2 Generate deployment config by deployctl with --no-service-parameters
argument, check no service parameter in the output.
3 Generate deployment config by deployctl with --minimal-config
argument, check no service parameter in the output.
4 Deploy AIOSX with minimal config, check system can be inSync and
reconciled.
5 Deploy AIOSX with stardard config with service parameters, check
system can be inSync and reconciled.
6 Deploy AIOSX with optional service parameters, remove it from
deployment config, varified it can be removed with Day2 operation.
7 Generate deployment config with "--no-default", verify the
result w/o the DRBD, FS and certs as expected
8 Generate deployment config with "--minimal-config", verify the result
as expected.
9 Verify the warning message in the empty secrets.

Signed-off-by: Yuxing Jiang <Yuxing.Jiang@windriver.com>