### PR TITLE
Filter kernel parameter from deployctl yaml

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -65,6 +65,7 @@ var defaultHostFilters = []HostFilter{
 	NewBMAddressFilter(),
 	NewStorageMonitorFilter(),
 	NewInterfaceRemoveUuidFilter(),
+	NewHostKernelFilter(),
 }
 
 // NewDeploymentBuilder returns an instantiation of a deployment builder

--- a/build/build_suite_test.go
+++ b/build/build_suite_test.go
@@ -40,6 +40,7 @@ var _ = Describe("Test Build utilities:", func() {
 			NewBMAddressFilter(),
 			NewStorageMonitorFilter(),
 			NewInterfaceRemoveUuidFilter(),
+			NewHostKernelFilter(),
 		}
 		Expect(reflect.DeepEqual(
 			got.hostFilters, expectHostFilter)).To(BeTrue())

--- a/build/filter.go
+++ b/build/filter.go
@@ -909,3 +909,22 @@ func (in *InterfaceRemoveUuidFilter) Filter(profile *v1.HostProfile, host *v1.Ho
 	}
 	return nil
 }
+
+// HostKernelFilter defines a profile and host filter that removes
+// kernel values from interfaces.
+type HostKernelFilter struct {
+}
+
+func NewHostKernelFilter() *HostKernelFilter {
+	return &HostKernelFilter{}
+}
+
+func (in *HostKernelFilter) Filter(profile *v1.HostProfile, host *v1.Host, deployment *Deployment) error {
+
+	// filter kernel parameter from hostprofile for hosts that are not worker/compute nodes
+	if !profile.Spec.HasWorkerSubFunction() {
+		profile.Spec.Kernel = nil
+	}
+
+	return nil
+}


### PR DESCRIPTION
This commit:
- filters kernel parameter from nodes that do not have worker personality e.g storage and standard controllers nodes
- fixes validation of generated deployctl yaml file

Test plan:

Tested Standard DX system:
- verified deployctl does not generate kernel parameter for controllers

Tested AIO-DX system:
- verified deployctl generates kernel parameter for controllers