### PR TITLE
Change logLevel for Host delta configuration

### DIFF
--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -1448,7 +1448,7 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 	}
 
 	if deltaString != "" {
-		logHost.Info(fmt.Sprintf("delta configuration:%s\n", deltaString))
+		logHost.V(2).Info(fmt.Sprintf("delta configuration:%s\n", deltaString))
 		instance.Status.Delta = deltaString
 
 		err = r.Client.Status().Update(context.TODO(), instance)


### PR DESCRIPTION
It was seen that the 'controller.host.deployment/controller-0 delta configuration' log was flooding the DM logs.

This change updates the logLevel for this particular log to level 2.

Test Plan:
PASS: Verify that the log is not being shown when the logLevel is not modified.
PASS: Re-install DM changing the logLevel to 2. Verify that the Host delta is being shown.