### PR TITLE
Check pod name before helmv2 installation

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -207,6 +207,18 @@
       become: yes
       when: not reconfig_flag
 
+    - block:
+      - name: Search for the pod of the Deployment Manager
+        shell: |
+          kubectl -n platform-deployment-manager get pods | grep platform-deployment-manager- | awk 'NR == 1 { print $1 }'
+        environment:
+          KUBECONFIG: "/etc/kubernetes/admin.conf"
+        register: deployment_manager_pod_name
+
+      - debug:
+          msg: "{{ deployment_manager_pod_name.stdout }}"
+      when: reconfig_flag
+
     # Follow a different reinstallation procedure if DM is installed in helmv2
     - block:
       - name: Get armada pod name
@@ -291,18 +303,6 @@
 
       when: helmv3_installed and helmv3_dm_exists.rc == 0
 
-    - block:
-      - name: Search for the pod of the Deployment Manager
-        shell: |
-          kubectl -n platform-deployment-manager get pods | grep platform-deployment-manager- | awk 'NR == 1 { print $1 }'
-        environment:
-          KUBECONFIG: "/etc/kubernetes/admin.conf"
-        register: deployment_manager_pod_name
-
-      - debug:
-          msg: "{{ deployment_manager_pod_name.stdout }}"
-      when: reconfig_flag
-
     - name: Install Deployment Manager
       shell: KUBECONFIG=/etc/kubernetes/admin.conf /usr/sbin/helm upgrade --install deployment-manager {% if helm_chart_overrides is defined %}--values {{ helm_chart_overrides }}{% endif %} {{ manager_chart }}
       when: helmv3_installed
@@ -320,7 +320,7 @@
         kubectl -n platform-deployment-manager delete pods {{ deployment_manager_pod_name.stdout }}
       environment:
         KUBECONFIG: "/etc/kubernetes/admin.conf"
-      when: deployment_manager_pod_name.stdout and reconfig_flag
+      when: deployment_manager_pod_name.stdout is defined and deployment_manager_pod_name.stdout
 
     - name: Wait for Deployment Manager to be ready
       shell: KUBECONFIG=/etc/kubernetes/admin.conf /bin/kubectl wait --namespace=platform-deployment-manager --for=condition=Ready pods --selector control-plane=controller-manager --timeout=60s


### PR DESCRIPTION
This commit moves the check of the old DM pod name before installation of the DM in helm_v2.

This commit is only to correct the logic in the DM, DM will no longer be installed in helm_v2 after stx9.

The test will be done as:

1 Deploy new AIOSX subcloud
2 Reonfig subcloud, verify the delete of the old pod