### PR TITLE
Bug-fix: delete correct DM pod when reconfig

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -291,6 +291,18 @@
 
       when: helmv3_installed and helmv3_dm_exists.rc == 0
 
+    - block:
+      - name: Search for the pod of the Deployment Manager
+        shell: |
+          kubectl -n platform-deployment-manager get pods | grep platform-deployment-manager- | awk 'NR == 1 { print $1 }'
+        environment:
+          KUBECONFIG: "/etc/kubernetes/admin.conf"
+        register: deployment_manager_pod_name
+
+      - debug:
+          msg: "{{ deployment_manager_pod_name.stdout }}"
+      when: reconfig_flag
+
     - name: Install Deployment Manager
       shell: KUBECONFIG=/etc/kubernetes/admin.conf /usr/sbin/helm upgrade --install deployment-manager {% if helm_chart_overrides is defined %}--values {{ helm_chart_overrides }}{% endif %} {{ manager_chart }}
       when: helmv3_installed
@@ -303,25 +315,12 @@
       when: dm_monitor_playbook
 
     # Restart Deployment Manager if it was reinstalled
-    - block:
-      - name: Search for the pod of the Deployment Manager
-        shell: |
-          kubectl -n platform-deployment-manager get pods | grep platform-deployment-manager- | awk 'NR == 1 { print $1 }'
-        environment:
-          KUBECONFIG: "/etc/kubernetes/admin.conf"
-        register: deployment_manager_pod_name
-
-      - debug:
-          msg: "{{ deployment_manager_pod_name.stdout }}"
-
-      - name: Restart Deployment Manager if reinstalled
-        command: >-
-          kubectl -n platform-deployment-manager delete pods {{ deployment_manager_pod_name.stdout }}
-        environment:
-          KUBECONFIG: "/etc/kubernetes/admin.conf"
-        when: deployment_manager_pod_name.stdout
-
-      when: reconfig_flag
+    - name: Restart Deployment Manager if reinstalled
+      command: >-
+        kubectl -n platform-deployment-manager delete pods {{ deployment_manager_pod_name.stdout }}
+      environment:
+        KUBECONFIG: "/etc/kubernetes/admin.conf"
+      when: deployment_manager_pod_name.stdout and reconfig_flag
 
     - name: Wait for Deployment Manager to be ready
       shell: KUBECONFIG=/etc/kubernetes/admin.conf /bin/kubectl wait --namespace=platform-deployment-manager --for=condition=Ready pods --selector control-plane=controller-manager --timeout=60s

--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -4,6 +4,11 @@
   hosts: all
   gather_facts: false
   become: false
+
+  vars:
+    helmv2_installed: false
+    helmv3_installed: false
+
   tasks:
     - set_fact:
         manager_chart: "{{ deployment_manager_chart | default('wind-river-cloud-platform-deployment-manager.tgz') }}"
@@ -157,11 +162,17 @@
       ignore_errors: yes
       register: helmv2_releases
 
+    # Ansible returns error code 2 to helmv2_releases if helmv2-cli does not exist
+    - name: Check if helmv2-cli is installed
+      set_fact:
+        helmv2_installed: "{{ false if helmv2_releases.rc == 2 else true }}"
+
     - name: Query for DM release in helmv2
       shell: |
         grep -iq '"name":"deployment-manager"' <<< {{ helmv2_releases.stdout_lines }}
       ignore_errors: yes
       register: helmv2_dm_exists
+      when: helmv2_installed
 
     - name: Get list of releases in helmv3
       command: >-
@@ -171,15 +182,22 @@
       ignore_errors: yes
       register: helmv3_releases
 
+    # Ansible returns error code 2 to helmv3_releases if helmv3 does not exist
+    - name: Check if helmv3 is installed
+      set_fact:
+        helmv3_installed: "{{ false if helmv3_releases.rc == 2 else true }}"
+
     - name: Query for DM release in helmv3
       shell: |
         grep -iq '"name":"deployment-manager"' <<< {{ helmv3_releases.stdout_lines }}
       ignore_errors: yes
       register: helmv3_dm_exists
+      when: helmv3_installed
 
     - name: Set reconfig fact
       set_fact:
-        reconfig_flag: "{{ true if helmv2_dm_exists.rc == 0 or helmv3_dm_exists.rc == 0
+        reconfig_flag: "{{ true if (helmv2_installed and helmv2_dm_exists.rc == 0)
+                        or (helmv3_installed and helmv3_dm_exists.rc == 0)
                         else false }}"
 
     - name: Mark the bootstrap as finalized
@@ -226,7 +244,7 @@
         environment:
           KUBECONFIG: "/etc/kubernetes/admin.conf"
 
-      when: helmv2_dm_exists.rc == 0
+      when: helmv2_installed and helmv2_dm_exists.rc == 0
 
     # Remove v1 webhook and webhook service
     - block:
@@ -271,11 +289,11 @@
           KUBECONFIG: "/etc/kubernetes/admin.conf"
         when: webhook_service_exists.rc == 0
 
-      when: helmv2_dm_exists.rc != 0
+      when: helmv3_installed and helmv3_dm_exists.rc == 0
 
     - name: Install Deployment Manager
       shell: KUBECONFIG=/etc/kubernetes/admin.conf /usr/sbin/helm upgrade --install deployment-manager {% if helm_chart_overrides is defined %}--values {{ helm_chart_overrides }}{% endif %} {{ manager_chart }}
-      when: helmv2_dm_exists.rc != 0
+      when: helmv3_installed
 
     # Install or Upgrade DM-Monitor
     - name: "Install or Upgrade DM-monitor"

--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -207,6 +207,18 @@
       become: yes
       when: not reconfig_flag
 
+    - block:
+      - name: Search for the pod of the Deployment Manager
+        shell: |
+          kubectl -n platform-deployment-manager get pods | grep platform-deployment-manager- | awk 'NR == 1 { print $1 }'
+        environment:
+          KUBECONFIG: "/etc/kubernetes/admin.conf"
+        register: deployment_manager_pod_name
+
+      - debug:
+          msg: "{{ deployment_manager_pod_name.stdout }}"
+      when: reconfig_flag
+
     # Follow a different reinstallation procedure if DM is installed in helmv2
     - block:
       - name: Get armada pod name
@@ -291,18 +303,6 @@
 
       when: helmv3_installed and helmv3_dm_exists.rc == 0
 
-    - block:
-      - name: Search for the pod of the Deployment Manager
-        shell: |
-          kubectl -n platform-deployment-manager get pods | grep platform-deployment-manager- | awk 'NR == 1 { print $1 }'
-        environment:
-          KUBECONFIG: "/etc/kubernetes/admin.conf"
-        register: deployment_manager_pod_name
-
-      - debug:
-          msg: "{{ deployment_manager_pod_name.stdout }}"
-      when: reconfig_flag
-
     - name: Install Deployment Manager
       shell: KUBECONFIG=/etc/kubernetes/admin.conf /usr/sbin/helm upgrade --install deployment-manager {% if helm_chart_overrides is defined %}--values {{ helm_chart_overrides }}{% endif %} {{ manager_chart }}
       when: helmv3_installed
@@ -320,7 +320,7 @@
         kubectl -n platform-deployment-manager delete pods {{ deployment_manager_pod_name.stdout }}
       environment:
         KUBECONFIG: "/etc/kubernetes/admin.conf"
-      when: deployment_manager_pod_name.stdout and reconfig_flag
+      when: deployment_manager_pod_name.stdout is defined and deployment_manager_pod_name.stdout
 
     - name: Wait for Deployment Manager to be ready
       shell: KUBECONFIG=/etc/kubernetes/admin.conf /bin/kubectl wait --namespace=platform-deployment-manager --for=condition=Ready pods --selector control-plane=controller-manager --timeout=60s


### PR DESCRIPTION
A bug was introduced in commit: #613fb38 when trying to search for
the old DM pod. This commit moves the task to search for the old
DM pod before the installation to ensure we have a unique DM pod
before installation, and deletes that pod after a reinstall.

Test plan:
Passed - deploy AIOSX subcloud
Passed - reconfig a subcloud successfully, check the dm pod name in
debug log which is not the new one in the system.

This commit also includes the support of the removal of helmv2 after
stx.9.