### PR TITLE
Update gophercloud references in go.sum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMo
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/Wind-River/gophercloud v0.0.0-20230804151513-effbe8155d7e h1:dTH8iga9UHftZcT0N1ShlbkT9Hl7lIdoWJh6pGlTt08=
-github.com/Wind-River/gophercloud v0.0.0-20230804151513-effbe8155d7e/go.mod h1:FMtdxT0Mwm0oqT7cUYr/C3LBaTZ2vpfVCVykBSTEu7o=
+github.com/Wind-River/gophercloud v0.0.0-20231115173645-26888044832d h1:PE4T0/MFkA98b0ETahnT9ejOJwcJEaBCfxBqU+FUyac=
+github.com/Wind-River/gophercloud v0.0.0-20231115173645-26888044832d/go.mod h1:FMtdxT0Mwm0oqT7cUYr/C3LBaTZ2vpfVCVykBSTEu7o=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=


### PR DESCRIPTION
Previous commit just updated the reference in go.mod, causing the build to fail since go.sum was not updated. This commit fix that error.

Test Plan:
PASS: Run 'make builder-run'. Verify it finishes successfully. PASS: Install the new image in a system. Verify that the gophercloud changes are added.