### PR TITLE
Enable deployctl to generate PlatformNetwork CRD in deployment config file

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -562,7 +562,7 @@ func (db *DeploymentBuilder) buildPlatformNetworks(d *Deployment) error {
 	}
 
 	nets := make([]*starlingxv1.PlatformNetwork, 0)
-	always_generate_networks := []string{"storage"}
+	always_generate_networks := []string{"storage", "mgmt", "oam", "admin"}
 	sort.Strings(always_generate_networks)
 	for _, p := range pools {
 		skip := false


### PR DESCRIPTION
Enable deployctl to generate PlatformNetwork CRD in deployment config file

The PlatformNetwork resources that are present in the System are not getting 
added to the deployment config file that is generated by  the deployctl tool. 
The function buildPlatformNetworks from the file build/build.go has the network 
types array which contains only type storage as of now .So the array is 
populated with all the required network types.

Test Plan:
1) PASS: To generate the deployment config yaml file where PlatformNetwork
         resources are also shown  using deployctl tool
2) PASS: To use the generated deployment config file to the bring up the system 
         and check if PlatformNetwork resources are applied.
3) PASS:  To test  initial configuration(day1)
4) PASS: To test reconfiguration(day2)