### PR TITLE
Correct typo in examples

### DIFF
--- a/examples/aio-dx-day2-bootstrap.yaml
+++ b/examples/aio-dx-day2-bootstrap.yaml
@@ -114,7 +114,7 @@ spec:
     location: vbox
   profile: controller-profile
 status:
-  desploymentScope: bootstrap
+  deploymentScope: bootstrap
 ---
 apiVersion: starlingx.windriver.com/v1
 kind: HostProfile

--- a/examples/aio-dx-day2-principal.yaml
+++ b/examples/aio-dx-day2-principal.yaml
@@ -114,7 +114,7 @@ spec:
     location: vbox
   profile: controller-profile
 status:
-  desploymentScope: principal
+  deploymentScope: principal
 ---
 apiVersion: starlingx.windriver.com/v1
 kind: HostProfile

--- a/examples/aio-dx/day2-operation/bootstrap/aio-dx-day2-bootstrap.yaml
+++ b/examples/aio-dx/day2-operation/bootstrap/aio-dx-day2-bootstrap.yaml
@@ -19,4 +19,4 @@ spec:
     location: vbox
   profile: controller-profile
 status:
-  desploymentScope: "bootstrap"
+  deploymentScope: "bootstrap"

--- a/examples/aio-dx/day2-operation/principal/aio-dx-day2-principal.yaml
+++ b/examples/aio-dx/day2-operation/principal/aio-dx-day2-principal.yaml
@@ -19,4 +19,4 @@ spec:
     location: vbox
   profile: controller-profile
 status:
-  desploymentScope: "principal"
+  deploymentScope: "principal"

--- a/examples/aio-sx-day2-bootstrap.yaml
+++ b/examples/aio-sx-day2-bootstrap.yaml
@@ -35,7 +35,7 @@ spec:
   mtu: 1500
   type: vlan
 status:
-  desploymentScope: bootstrap
+  deploymentScope: bootstrap
 ---
 apiVersion: starlingx.windriver.com/v1
 kind: DataNetwork
@@ -175,4 +175,4 @@ spec:
     - name: ceph-store
       type: ceph
 status:
-  desploymentScope: bootstrap
+  deploymentScope: bootstrap

--- a/examples/aio-sx-day2-principal.yaml
+++ b/examples/aio-sx-day2-principal.yaml
@@ -35,7 +35,7 @@ spec:
   mtu: 1400
   type: vlan
 status:
-  desploymentScope: principal
+  deploymentScope: principal
 ---
 apiVersion: starlingx.windriver.com/v1
 kind: DataNetwork
@@ -176,4 +176,4 @@ spec:
     - name: ceph-store
       type: ceph
 status:
-  desploymentScope: principal
+  deploymentScope: principal

--- a/examples/aio-sx/day2-operation/bootstrap/aio-sx-day2-bootstrap.yaml
+++ b/examples/aio-sx/day2-operation/bootstrap/aio-sx-day2-bootstrap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: vbox
   namespace: deployment
 status:
-  desploymentScope:
+  deploymentScope:
     "bootstrap"
 spec:
   description: Virtual Box Standard System
@@ -33,4 +33,4 @@ spec:
   mtu: 1500
   type: vlan
 status:
-  desploymentScope: "bootstrap"
+  deploymentScope: "bootstrap"

--- a/examples/aio-sx/day2-operation/principal/aio-sx-day2-principal.yaml
+++ b/examples/aio-sx/day2-operation/principal/aio-sx-day2-principal.yaml
@@ -6,7 +6,7 @@ metadata:
   name: vbox
   namespace: deployment
 status:
-  desploymentScope:
+  deploymentScope:
     "principal"
 spec:
   description: Virtual Box Standard System
@@ -34,4 +34,4 @@ spec:
   mtu: 1400
   type: vlan
 status:
-  desploymentScope: "principal"
+  deploymentScope: "principal"

--- a/examples/storage-day2-bootstrap.yaml
+++ b/examples/storage-day2-bootstrap.yaml
@@ -81,7 +81,7 @@ spec:
     bootMAC: COMPUTE0MAC
   profile: worker-profile
 status:
-  desploymentScope: bootstrap
+  deploymentScope: bootstrap
 ---
 apiVersion: starlingx.windriver.com/v1
 kind: Host
@@ -141,7 +141,7 @@ spec:
     bootMAC: STORAGE0MAC
   profile: storage-profile
 status:
-  desploymentScope: bootstrap
+  deploymentScope: bootstrap
 ---
 apiVersion: starlingx.windriver.com/v1
 kind: Host
@@ -155,7 +155,7 @@ spec:
     bootMAC: STORAGE1MAC
   profile: storage-profile
 status:
-  desploymentScope: bootstrap
+  deploymentScope: bootstrap
 ---
 apiVersion: starlingx.windriver.com/v1
 kind: HostProfile
@@ -282,4 +282,4 @@ spec:
     - name: ceph-store
       type: ceph
 status:
-  desploymentScope: bootstrap
+  deploymentScope: bootstrap

--- a/examples/storage-day2-principal.yaml
+++ b/examples/storage-day2-principal.yaml
@@ -81,7 +81,7 @@ spec:
     bootMAC: COMPUTE0-NEW-MAC
   profile: worker-profile
 status:
-  desploymentScope: principal
+  deploymentScope: principal
 ---
 apiVersion: starlingx.windriver.com/v1
 kind: Host
@@ -141,7 +141,7 @@ spec:
     bootMAC: STORAGE0-NEW-MAC
   profile: storage-profile
 status:
-  desploymentScope: principal
+  deploymentScope: principal
 ---
 apiVersion: starlingx.windriver.com/v1
 kind: Host
@@ -155,7 +155,7 @@ spec:
     bootMAC: STORAGE1-NEW-MAC
   profile: storage-profile
 status:
-  desploymentScope: principal
+  deploymentScope: principal
 ---
 apiVersion: starlingx.windriver.com/v1
 kind: HostProfile
@@ -283,4 +283,4 @@ spec:
     - name: ceph-store
       type: ceph
 status:
-  desploymentScope: principal
+  deploymentScope: principal

--- a/examples/storage/day2-operation/bootstrap/storage-day2-bootstrap.yaml
+++ b/examples/storage/day2-operation/bootstrap/storage-day2-bootstrap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: storage-0
   namespace: deployment
 status:
-  desploymentScope: "bootstrap"
+  deploymentScope: "bootstrap"
 spec:
   profile: storage-profile
   overrides:
@@ -20,7 +20,7 @@ metadata:
   name: storage-1
   namespace: deployment
 status:
-  desploymentScope: "bootstrap"
+  deploymentScope: "bootstrap"
 spec:
   profile: storage-profile
   overrides:
@@ -34,7 +34,7 @@ metadata:
   name: compute-0
   namespace: deployment
 status:
-  desploymentScope: "bootstrap"
+  deploymentScope: "bootstrap"
 spec:
   overrides:
     bootMAC: COMPUTE0MAC
@@ -48,7 +48,7 @@ metadata:
   name: vbox
   namespace: deployment
 status:
-  desploymentScope: "bootstrap"
+  deploymentScope: "bootstrap"
 spec:
   contact: info@windriver.com
   description: Virtual Box Standard System

--- a/examples/storage/day2-operation/principal/storage-day2-principal.yaml
+++ b/examples/storage/day2-operation/principal/storage-day2-principal.yaml
@@ -6,7 +6,7 @@ metadata:
   name: storage-0
   namespace: deployment
 status:
-  desploymentScope: "principal"
+  deploymentScope: "principal"
 spec:
   profile: storage-profile
   overrides:
@@ -20,7 +20,7 @@ metadata:
   name: storage-1
   namespace: deployment
 status:
-  desploymentScope: "principal"
+  deploymentScope: "principal"
 spec:
   profile: storage-profile
   overrides:
@@ -34,7 +34,7 @@ metadata:
   name: compute-0
   namespace: deployment
 status:
-  desploymentScope: "principal"
+  deploymentScope: "principal"
 spec:
   overrides:
     bootMAC: COMPUTE0-NEW-MAC
@@ -48,7 +48,7 @@ metadata:
   name: vbox
   namespace: deployment
 status:
-  desploymentScope: "principal"
+  deploymentScope: "principal"
 spec:
   contact: info@windriver.com
   description: Virtual Box Standard System


### PR DESCRIPTION
This commit corrects typo of deploymentScope in examples.