### PR TITLE
Append controller domain and get IP for AUTHURL

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -107,8 +107,6 @@ consider adding your user id to the local docker group.
 sudo usermod -a -G docker ${USER}
 newgrp docker
 ```
-## Install golangci
-curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
 
 ## Install other dependencies
 sudo apt-get install make

--- a/common/utilities.go
+++ b/common/utilities.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2024 Wind River Systems, Inc. */
 
 package common
 
@@ -131,3 +131,35 @@ func RemoveString(slice []string, s string) (result []string) {
 	}
 	return
 }
+
+// DedupeSlice is a utility function that removes a duplicated element from
+// a slice.
+// TODO(yuxing): switch to generic comparable after switch to go 1.20 which
+// supports comparable.
+func DedupeSlice[T string | int](sliceList []T) []T {
+	dedupeMap := make(map[T]bool)
+	list := []T{}
+	for _, item := range sliceList {
+		if _, value := dedupeMap[item]; !value {
+			dedupeMap[item] = true
+			list = append(list, item)
+		}
+	}
+	return list
+}
+
+/*
+func DedupeSlice[T comparable](sliceList []T) []T {
+    dedupeMap := make(map[T]bool)
+    list := []T{}
+
+    for _, item := range sliceList {
+        if _, value := dedupeMap[item]; !value {
+            dedupeMap[item] = true
+            list = append(list, item)
+        }
+    }
+
+    return list
+}
+*/

--- a/common/utilities_test.go
+++ b/common/utilities_test.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2024 Wind River Systems, Inc. */
 
 package common
 
@@ -344,6 +344,51 @@ var _ = Describe("Common utils", func() {
 				}
 				for _, tt := range tests {
 					gotResult := RemoveString(tt.args.slice, tt.args.s)
+					Expect(reflect.DeepEqual(gotResult, tt.wantResult)).To(BeTrue())
+				}
+			})
+		})
+	})
+
+	Describe("DedupeSlice utility", func() {
+		Context("with a slice with duplicates", func() {
+			It("should remove the string duplicates", func() {
+				stringTests := []struct {
+					name       string
+					given      []string
+					wantResult []string
+				}{
+					{name: "one string duplicate",
+						given:      []string{"foo0", "foo1", "foo1", "foo2", "foo3"},
+						wantResult: []string{"foo0", "foo1", "foo2", "foo3"},
+					},
+					{name: "two string duplicates",
+						given:      []string{"foo0", "foo1", "foo1", "foo2", "foo2"},
+						wantResult: []string{"foo0", "foo1", "foo2"},
+					},
+				}
+				for _, tt := range stringTests {
+					gotResult := DedupeSlice(tt.given)
+					Expect(reflect.DeepEqual(gotResult, tt.wantResult)).To(BeTrue())
+				}
+			})
+			It("should remove the int duplicates", func() {
+				intTests := []struct {
+					name       string
+					given      []int
+					wantResult []int
+				}{
+					{name: "one int duplicate",
+						given:      []int{101, 202, 303, 404, 303},
+						wantResult: []int{101, 202, 303, 404},
+					},
+					{name: "two int duplicates",
+						given:      []int{101, 101, 202, 303, 404, 101},
+						wantResult: []int{101, 202, 303, 404},
+					},
+				}
+				for _, tt := range intTests {
+					gotResult := DedupeSlice(tt.given)
 					Expect(reflect.DeepEqual(gotResult, tt.wantResult)).To(BeTrue())
 				}
 			})


### PR DESCRIPTION
After supporting the management reconfiguration in StarlingX, the openstack keystone endpoint address may change after updating the management network.

To avoid the DM cannot access the openstack endpoints after changing the endpoint address during network reconfiguration, this commit enables functions:

1. always append controller domain into the authURLs, which can be used to get the management floating IP address after DNSMask service enabled.
2. query IP address by domains in the authURLs.

Test plan:
1. Passed - deploy AIOSX with existing deployment configuratin.
2. Passed - update management network with new management subnet in the AIOSX, verified the DM can keep communicate with the sysinv API after unlock.
3. Passed - check V2 logs, verified the failure of get one IP address of a domain will not fail the client creation, verified the wrong format in the authURL will fail the client creation as expected, verified the duplicated IP address will be removed in the result.