### PR TITLE
[WIP]Ignore network reconfiguration if deployscope bootstrap

### DIFF
--- a/controllers/manager/monitor_test.go
+++ b/controllers/manager/monitor_test.go
@@ -363,6 +363,24 @@ func (m *Dummymanager) ListStrategyRequired() string {
 func (m *Dummymanager) UpdateConfigVersion() {
 
 }
+func (m *Dummymanager) GetHostUpdateRoutinesRunning() bool {
+	return false
+}
+func (m *Dummymanager) SetHostUpdateRoutinesRunning(b bool) {
+
+}
+func (m *Dummymanager) ReceiveHostStrategyUpdate() HostStrategyInfo {
+	return HostStrategyInfo{}
+}
+func (m *Dummymanager) SendHostStrategyUpdate(host_strategy HostStrategyInfo) error {
+	return nil
+}
+func (m *Dummymanager) ReceiveHostReconciliationTrigger() HostStrategyInfo {
+	return HostStrategyInfo{}
+}
+func (m *Dummymanager) SendHostReconciliationTrigger(host_strategy HostStrategyInfo) error {
+	return nil
+}
 func (m *Dummymanager) GetConfigVersion() int {
 	return m.config_version
 }

--- a/controllers/platformnetwork_controller.go
+++ b/controllers/platformnetwork_controller.go
@@ -835,7 +835,17 @@ func (r *PlatformNetworkReconciler) ReconcileResource(client *gophercloud.Servic
 			return err
 		}
 		if instance.Status.DeploymentScope == cloudManager.ScopeBootstrap {
-			return nil
+			inSync := !update_pn
+			if instance.Status.InSync != inSync {
+				r.ReconcilerEventLogger.NormalEvent(instance, common.ResourceUpdated, "synchronization has changed to: %t", inSync)
+			}
+			instance.Status.InSync = inSync
+			instance.Status.Reconciled = inSync
+			err2 := r.Client.Status().Update(context.TODO(), instance)
+			if err2 != nil {
+				logPlatformNetwork.Error(err2, "failed to update platform network status")
+			}
+			return err2
 		} else if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
 			if update_pn {
 				host, is_aiosx, err := r.AIOSXHost(client)


### PR DESCRIPTION
After the platformNetwork configuration of the OAM/MGMT/ADMIN networks,
there is a chance that the networks configured in deployment config yaml
is not aligned with the bootstrap values.

DM shall not overwrite the networks configured during the bootstrap.
Resource platformNetworks shall be out-of-sync and not reconciled
thereby raising an alarm for user action.

Test Plan:

1. PASS: Deployment config yaml applied with deploymentScope: "bootstrap"
for platformNetwork resource, insync will be false, reconcile will be false,
and alarm will be raised.

2. PASS: Deployment config yaml applied with deploymentScope: "principal"
for platformNetwork resource, insync will be true, reconcile will be true,
and config will be overwritten.
