### PR TITLE
Avoid lock_required for admin multi-netting

### DIFF
--- a/controllers/host/networking.go
+++ b/controllers/host/networking.go
@@ -1918,7 +1918,7 @@ func (r *HostReconciler) ReconcileRoutes(client *gophercloud.ServiceClient, inst
 	return nil
 }
 
-// ReconcileNetworking is responsible for reconciling the Memory configuration
+// ReconcileNetworking is responsible for reconciling the network configuration
 // of a host resource.
 func (r *HostReconciler) ReconcileNetworking(client *gophercloud.ServiceClient, instance *starlingxv1.Host, profile *starlingxv1.HostProfileSpec, host *v1info.HostInfo) error {
 	var err error
@@ -1996,12 +1996,6 @@ func (r *HostReconciler) ReconcileNetworking(client *gophercloud.ServiceClient, 
 
 	// Update/Add addresses
 	err = r.ReconcileAddresses(client, instance, profile, host)
-	if err != nil {
-		return err
-	}
-
-	// Update/Add routes
-	err = r.ReconcileRoutes(client, instance, profile, host)
 	if err != nil {
 		return err
 	}

--- a/controllers/manager/manager.go
+++ b/controllers/manager/manager.go
@@ -48,7 +48,8 @@ const (
 )
 
 const (
-	OAMNetworkType = "oam"
+	OAMNetworkType   = "oam"
+	AdminNetworkType = "admin"
 )
 
 const (


### PR DESCRIPTION
This commit prevents the lock/unlock actions triggered by DM when creating an admin network using multi-netting (shared interface). Additionally, it moves the route reconciliate to enabled host, as interface assignment triggers new route creation.

Test Plan:

[Day-2 Operation]
1. Modify the deployment configuration to include the new admin network.
- Add 'admin' to the platformNetwork of an existing interface (e.g. mgmt).
- Create the PlatformNetwork resource for the new admin network.
- Set deploymentScope = principal for the host and platformnetwork resources.
2. Apply the new configuration.
- admin address pool created.
- admin network created.
- admin network interface assigned.
- admin network route created.
- admin endpoints updated (~ 5 minutes).