### PR TITLE
Fix Incorrect PlatformNetwork Data Generated by Deployctl

### DIFF
--- a/build/build_suite_test.go
+++ b/build/build_suite_test.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2023 Wind River Systems, Inc. */
+/* Copyright(c) 2023-2024 Wind River Systems, Inc. */
 
 package build
 
@@ -44,6 +44,10 @@ var _ = Describe("Test Build utilities:", func() {
 		}
 		Expect(reflect.DeepEqual(
 			got.hostFilters, expectHostFilter)).To(BeTrue())
+
+		var expectPlatformNetworkFilters []PlatformNetworkFilter
+		Expect(reflect.DeepEqual(
+			got.platformNetworkFilters, expectPlatformNetworkFilters)).To(BeTrue())
 	})
 
 	Describe("Test parse incomplete secrets", func() {

--- a/build/filter.go
+++ b/build/filter.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019-2023 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2024 Wind River Systems, Inc. */
 
 package build
 
@@ -453,6 +453,7 @@ const (
 	clusterIface   = "cluster0"
 	oamNetwork     = "oam"
 	oamIface       = "oam0"
+	adminNetwork   = "admin"
 )
 
 func (in *InterfaceNamingFilter) CheckInterface(info *v1.CommonInterfaceInfo) {
@@ -721,6 +722,33 @@ func NewDRBDLinkUtilizationFilter() *DRBDLinkUtilizationFilter {
 
 func (in *DRBDLinkUtilizationFilter) Filter(system *v1.System, deployment *Deployment) error {
 	system.Spec.Storage.DRBD = nil
+	return nil
+}
+
+type PlatformNetworkFilter interface {
+	Filter(platform_network *v1.PlatformNetwork, deployment *Deployment) error
+}
+
+// Filter for PlatformNetworks
+// This will filter out platformnetworks of type oam, mgmt and admin
+type CoreNetworkFilter struct {
+}
+
+func NewCoreNetworkFilter() *CoreNetworkFilter {
+	return &CoreNetworkFilter{}
+}
+
+func (in *CoreNetworkFilter) Filter(platform_network *v1.PlatformNetwork, deployment *Deployment) error {
+	filtered_platform_networks := []*v1.PlatformNetwork{}
+	for _, pn := range deployment.PlatformNetworks {
+		if !(pn.Spec.Type == oamNetwork ||
+			pn.Spec.Type == mgmtNetwork ||
+			pn.Spec.Type == adminNetwork) {
+			filtered_platform_networks = append(filtered_platform_networks, pn)
+		}
+	}
+
+	deployment.PlatformNetworks = filtered_platform_networks
 	return nil
 }
 

--- a/build/filter_test.go
+++ b/build/filter_test.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2023 Wind River Systems, Inc. */
+/* Copyright(c) 2023-2024 Wind River Systems, Inc. */
 
 package build
 
@@ -224,4 +224,59 @@ var _ = Describe("Test filters utilities:", func() {
 		})
 
 	})
+
+	Describe("Test platform network filters", func() {
+		deployment := Deployment{}
+		deployment.PlatformNetworks = make([]*v1.PlatformNetwork, 0)
+		coreNetworkFilter := NewCoreNetworkFilter()
+		var get_platform_network = func(nwk_type string) *v1.PlatformNetwork {
+			gw := "10.10.10.1"
+			order := "random"
+			spec := v1.PlatformNetworkSpec{
+				Type:               nwk_type,
+				Subnet:             "10.10.10.0",
+				FloatingAddress:    "10.10.10.2",
+				Controller0Address: "10.10.10.3",
+				Controller1Address: "10.10.10.4",
+				Prefix:             24,
+				Gateway:            &gw,
+				Allocation: v1.AllocationInfo{
+					Type:  "dynamic",
+					Order: &order,
+					Ranges: []v1.AllocationRange{
+						v1.AllocationRange{
+							Start: "10.10.10.2",
+							End:   "10.10.10.50",
+						},
+					},
+				},
+			}
+			new_plat_nwk := v1.PlatformNetwork{}
+			new_plat_nwk.Spec = spec
+			return &new_plat_nwk
+		}
+		deployment.PlatformNetworks = []*v1.PlatformNetwork{
+			get_platform_network("oam"),
+			get_platform_network("mgmt"),
+			get_platform_network("admin"),
+			get_platform_network("storage")}
+
+		Context("when new core network filter", func() {
+			It("should return a CoreNetworkFilter", func() {
+				got := coreNetworkFilter
+				expect := CoreNetworkFilter{}
+				Expect(reflect.DeepEqual(got, &expect)).To(BeTrue())
+			})
+		})
+
+		Context("When core network filter is applied", func() {
+			It("deletes only oam/mgmt/admin platform networks", func() {
+				err := coreNetworkFilter.Filter(deployment.PlatformNetworks[0], &deployment)
+				Expect(err).To(BeNil())
+				Expect(len(deployment.PlatformNetworks)).To(Equal(1), "CoreNetworkFilter should not delete any platform networks other than oam/mgmt/admin")
+			})
+		})
+
+	})
+
 })

--- a/cmd/deployctl/cmd/build.go
+++ b/cmd/deployctl/cmd/build.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019-2023 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2024 Wind River Systems, Inc. */
 
 package cmd
 
@@ -40,6 +40,7 @@ func CollectCmdRun(cmd *cobra.Command, args []string) {
 	var normalizeConsole bool
 	var noCACertificates bool
 	var noDRBDLinkUtilization bool
+	var noCorePlatformNetworks bool
 	var noFileSystems bool
 	var noServiceParams bool
 	var outputFile *os.File
@@ -172,6 +173,7 @@ func CollectCmdRun(cmd *cobra.Command, args []string) {
 		noCACertificates = true
 		noDefaults = true
 		noDRBDLinkUtilization = true
+		noCorePlatformNetworks = true
 		noFileSystems = true
 		noInterfaceDefaults = true
 		normalizeInterfaces = true
@@ -310,6 +312,16 @@ func CollectCmdRun(cmd *cobra.Command, args []string) {
 
 	if len(systemFilters) > 0 {
 		builder.AddSystemFilters(systemFilters)
+	}
+
+	platformNetworkFilters := make([]build.PlatformNetworkFilter, 0)
+
+	if noCorePlatformNetworks {
+		platformNetworkFilters = append(platformNetworkFilters, build.NewCoreNetworkFilter())
+	}
+
+	if len(platformNetworkFilters) > 0 {
+		builder.AddPlatformNetworkFilters(platformNetworkFilters)
 	}
 
 	deployment, err := builder.Build()


### PR DESCRIPTION
    This commit fixes incorrect PlatformNetwork data such as the platform
    network name and the platform network allocation type being generated by
    the deployctl tool.

    Test Plan:
    1. PASS: Build "deployctl" tool successfully.
    2. PASS: Generate deployment-config.yaml with correct data using
             deployctl.
    3. PASS: Verify that deployment-config.yaml generated with
             "--minimal-config" option does not contain any of OAM,
             management and admin platform networks.
    4. PASS: Verify that OAM, management and admin platform networks part of
             full deployment config when applied onto another system
             in bootstrap scope reflects accurate "InSync" status.