### PR TITLE
Check os region name before update it

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -368,22 +368,20 @@
             deploy_config: "/home/{{ ansible_ssh_user }}/deployment-config.yaml"
           when: inventory_hostname != 'localhost'
 
-         # Configure required region value for subcloud
-        - name: Get subcloud region value from environment
-          shell: source /etc/platform/openrc; echo $OS_REGION_NAME
-          register: os_region_name_from_env
+        - name: Configure required region value for subcloud
+          block:
+          - name: Get subcloud region value from environment
+            shell: source /etc/platform/openrc; echo $OS_REGION_NAME
+            register: os_region_name_from_env
 
-        - name: Show subcloud region
-          debug:
-            msg:
-            - "Subcloud region value : {{os_region_name_from_env.stdout}}"
+          - name: Show subcloud region
+            debug:
+              msg:
+              - "Subcloud region value : {{os_region_name_from_env.stdout}}"
 
-        - name: Configure new subcloud region value
-          lineinfile:
-            path: "{{deploy_config}}"
-            regexp: 'OS_REGION_NAME'
-            line: "  OS_REGION_NAME: {{os_region_name_from_env.stdout}}"
-            state: present
+          - name: Configure new subcloud region value
+            command: |
+              sed -i 's/^\(\s*OS_REGION_NAME:\).*/\1 {{ os_region_name_from_env.stdout }}/' {{ deploy_config }}
           when: ("subcloud" in get_distributed_cloud_role.stdout)
 
         - wait_for:


### PR DESCRIPTION
In some cases, the deployment config doesn't contain the os region name, the ansible lineinfile will append the os region name to the end of the configuration file which result failed to apply to the cluster.

This commit:
1. Avoids unnecessary tasks to get the region name if not a subcloud
2. Uses sed instead of lineinfile: a. avoids adding new line if not match b. keeps spaces before OS_REGION_NAME to avoid format error if there are four spaces before that.
   c. ensures all lines of the OS_REGION_NAME are updated(though should not happen in most cases).

Test plan:
1. Deploy AIOSX stand alone, and update it with the playbook.
2. Deploy AIOSX subcloud, and update it by 'dcmanager subcloud deploy config' with empty model.
3. Deploy AIOSX subcloud, and update it by 'dcmanager subcloud deploy config' with full model.

Signed-off-by: Yuxing Jiang <Yuxing.Jiang@windriver.com>
(cherry picked from commit e369ef5a66318156ece65c74c58ee54f046e9f0e)