### PR TITLE
Adapt base profile in day-2 operation

### DIFF
--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -1766,13 +1766,6 @@ func (r *HostReconciler) ReconcileResource(
 		return err
 	}
 
-	logHost.V(2).Info("composite profile is:", "name", instance.Spec.Profile, "profile", profile)
-
-	err = r.ValidateProfile(instance, profile)
-	if err != nil {
-		return err
-	}
-
 	if host == nil {
 		// This host either needs to be provisioned for the first time or we
 		// need to audit the list of hosts so that we can find one that already
@@ -2017,7 +2010,7 @@ func (r *HostReconciler) UpdateConfigStatus(
 
 		// Check if the HostProfile configuration is updated
 		hostProfile, err := r.GetHostProfile(instance.Namespace, instance.Spec.Profile)
-		if err != err {
+		if err != nil {
 			return err
 		}
 		if hostProfile != nil &&
@@ -2059,11 +2052,6 @@ func (r *HostReconciler) UpdateConfigStatus(
 					if hostProfile.Spec.Personality == nil &&
 						profile.Personality != nil {
 						hostProfile.Spec.Personality = profile.Personality
-					} else {
-						msg := fmt.Sprintf(
-							"Missing Personality of host in hostprofile %s",
-							hostProfile.Name)
-						return common.NewSystemDependency(msg)
 					}
 					r.CloudManager.SetResourceInfo(cloudManager.ResourceHost, *hostProfile.Spec.Personality, instance.Name, instance.Status.Reconciled, cloudManager.StrategyNotRequired)
 				}
@@ -2153,7 +2141,7 @@ func (r *HostReconciler) Reconcile(ctx context.Context, request ctrl.Request) (r
 	}
 
 	// Build a composite profile based on the profile chain and host overrides
-	profile, err := r.BuildCompositeProfile(instance)
+	profile, err := r.BuildAndValidateCompositeProfile(instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/controllers/host/profile_utils.go
+++ b/controllers/host/profile_utils.go
@@ -47,20 +47,26 @@ func FixProfileAttributes(a, b, c *starlingxv1.HostProfileSpec, hostInfo *v1info
 	}
 
 	// To compare the interface Members we need to sort them
-	if b.Interfaces.Bond != nil {
+	if b.Interfaces != nil && b.Interfaces.Bond != nil {
 		for _, bondInfo := range b.Interfaces.Bond {
 			if bondInfo.Members != nil {
 				sort.Strings(bondInfo.Members)
 			}
 		}
 	}
-	if c.Interfaces.Bond != nil {
+	if b.Interfaces != nil && c.Interfaces.Bond != nil {
 		for _, bondInfo := range c.Interfaces.Bond {
 			if bondInfo.Members != nil {
 				sort.Strings(bondInfo.Members)
 			}
 		}
 	}
+
+	// If a hostprofile is composed based on a base profile, remove it to avoid
+	// delta between the final profile and the current config
+	a.Base = nil
+	b.Base = nil
+
 	FixProfileDevicePath(a, hostInfo)
 	FixKernelSubfunction(a)
 }
@@ -77,11 +83,11 @@ func FixProfileDevicePath(a *starlingxv1.HostProfileSpec, hostInfo *v1info.HostI
 		a.BootDevice = &bootDevice
 	}
 
-	if a.Storage.OSDs != nil {
+	if a.Storage != nil && a.Storage.OSDs != nil {
 		FixOSDDevicePath(a, hostInfo)
 	}
 
-	if a.Storage.VolumeGroups != nil {
+	if a.Storage != nil && a.Storage.VolumeGroups != nil {
 		FixVolumeGroupPath(a, hostInfo)
 	}
 }
@@ -262,6 +268,27 @@ func (r *HostReconciler) mergeProfileChain(namespace string, current *starlingxv
 
 	defaultCopy := DefaultHostProfile.DeepCopy()
 	return MergeProfiles(defaultCopy, current)
+}
+
+// BuildAndValidateCompositeProfile combines the methods of BuildCompositeProfile
+// and ValidateProfile, returns a combined profile which is validated
+func (r *HostReconciler) BuildAndValidateCompositeProfile(
+	host *starlingxv1.Host,
+) (*starlingxv1.HostProfileSpec, error) {
+	// Build a composite profile based on the profile chain and host overrides
+	profile, err := r.BuildCompositeProfile(host)
+	if err != nil {
+		return nil, err
+	}
+
+	logHost.V(2).Info("composite profile is:", "name", host.Spec.Profile, "profile", profile)
+
+	err = r.ValidateProfile(host, profile)
+	if err != nil {
+		return nil, err
+	}
+
+	return profile, nil
 }
 
 // BuildCompositeProfile combines the default profile, the profile inheritance

--- a/controllers/host/profile_utils_test.go
+++ b/controllers/host/profile_utils_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 
 	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
+	v1info "github.com/wind-river/cloud-platform-deployment-manager/platform"
 )
 
 var _ = Describe("Profile utils", func() {
@@ -596,6 +597,67 @@ var _ = Describe("Profile utils", func() {
 					specAfter := tt.args.spec
 					Expect(reflect.DeepEqual(specBefore, specAfter)).To(Equal(tt.nochange))
 					Expect(reflect.DeepEqual(tt.updatedSubfunctions, specAfter.SubFunctions)).To(BeTrue())
+				}
+			})
+		})
+	})
+
+	Describe("FixProfileAttributes", func() {
+		Context("with base profile spec data", func() {
+			It("should remove the base profile successfully", func() {
+				type args struct {
+					a    *starlingxv1.HostProfileSpec
+					b    *starlingxv1.HostProfileSpec
+					c    *starlingxv1.HostProfileSpec
+					info *v1info.HostInfo
+				}
+				base1 := "base-profile"
+				base2 := "base-profile"
+				tests := []struct {
+					name string
+					args args
+					want args
+				}{
+					{
+						name: "Profile has Base profile",
+						args: args{
+							a: &starlingxv1.HostProfileSpec{
+								Base: &base1,
+							},
+							b: &starlingxv1.HostProfileSpec{
+								Base: &base2,
+							},
+							c:    &starlingxv1.HostProfileSpec{},
+							info: &v1info.HostInfo{},
+						},
+						want: args{
+							a:    &starlingxv1.HostProfileSpec{},
+							b:    &starlingxv1.HostProfileSpec{},
+							c:    &starlingxv1.HostProfileSpec{},
+							info: &v1info.HostInfo{},
+						},
+					},
+					{
+						name: "Profile has no Base profile",
+						args: args{
+							a:    &starlingxv1.HostProfileSpec{},
+							b:    &starlingxv1.HostProfileSpec{},
+							c:    &starlingxv1.HostProfileSpec{},
+							info: &v1info.HostInfo{},
+						},
+						want: args{
+							a:    &starlingxv1.HostProfileSpec{},
+							b:    &starlingxv1.HostProfileSpec{},
+							c:    &starlingxv1.HostProfileSpec{},
+							info: &v1info.HostInfo{},
+						},
+					},
+				}
+				for _, tt := range tests {
+					FixProfileAttributes(tt.args.a, tt.args.b, tt.args.c, tt.args.info)
+					Expect(reflect.DeepEqual(tt.args.a, tt.want.a)).To(BeTrue())
+					Expect(reflect.DeepEqual(tt.args.b, tt.want.b)).To(BeTrue())
+					Expect(reflect.DeepEqual(tt.args.c, tt.want.c)).To(BeTrue())
 				}
 			})
 		})


### PR DESCRIPTION
The DM pod is crashed in Day-2 operation if the host base profile/host
profile doesn't contain the personality of the host. This commit
compose the hostprofile before updating the configuration status, get
the personality from profile in case this situation, prevents the pod
crash in this case.

After that, If the base profile is used to compose the hostprofile, it results
delta between the composed profiles(default and final) and the current
config, which blocks the unlock required status in the Day-2
operation. This commit set the base in the composed profiles to avoid
this problem.

Test plan:
1 Deploy AIOSX without base profile
2 Deploy AIOSX with personality configured only in base profile
3 Update platform cores without base profile
4 Update platform cores again with personality configured only in base
profile.
