### PR TITLE
Avoid subcloud error collecting after the initial unlock

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright(c) 2021-2023 Wind River Systems, Inc.
+# Copyright(c) 2021-2024 Wind River Systems, Inc.
 - name: Deployment Manager Playbook
   hosts: all
   gather_facts: false
@@ -194,11 +194,17 @@
       register: helmv3_dm_exists
       when: helmv3_installed
 
-    - name: Set reconfig fact
+    - name: Check nfv-vim.dor_complete flag
+      stat:
+        path: /var/run/.nfv-vim.dor_complete
+      register: dor_complete_file
+
+    - name: Set reconfiguration related facts
       set_fact:
         reconfig_flag: "{{ true if (helmv2_installed and helmv2_dm_exists.rc == 0)
                         or (helmv3_installed and helmv3_dm_exists.rc == 0)
                         else false }}"
+        initial_deploy: "{{ false if dor_complete_file.stat.exists else true }}"
 
     - name: Mark the bootstrap as finalized
       file:
@@ -506,14 +512,17 @@
             msg:
             - "administrative state: {{administrative_state}}"
 
-      when: (deploy_config is defined and "subcloud" in get_distributed_cloud_role.stdout
-             and "unlocked" not in current_administrativestate.stdout)
+      when:
+        - initial_deploy
+        - "'subcloud' in get_distributed_cloud_role.stdout"
+        - "'unlocked' not in current_administrativestate.stdout"
+
 
       # Main verification block.
       # Behavior:
       # This block waits until the host unlock is triggered.
       # - If the unlock is not triggered after a certain time, it might indicate DM failures.
-      #   In this case, it proceeds to the 'get failure information' block to collect details 
+      #   In this case, it proceeds to the 'get failure information' block to collect details
       #   about the potential cause.
       # - If the unlock process is in progress, it proceeds to the 'unlock verifications' block.
       #   Here, it waits for the host's port to be closed and then reopened. Following that, it checks
@@ -785,6 +794,8 @@
           when: ("Unlocking" in get_show_task_status.stdout
                  and get_unrecon_status_post.stdout != "")
 
-      when: (deploy_config is defined and "subcloud" in get_distributed_cloud_role.stdout
-             and "unlocked" not in current_administrativestate.stdout
-             and "unlocked" in administrative_state)
+      when:
+        - initial_deploy
+        - "'subcloud' in get_distributed_cloud_role.stdout"
+        - "'unlocked' not in current_administrativestate.stdout"
+        - "'unlocked' in administrative_state"


### PR DESCRIPTION
The error collecting is only designed in the initial deployment currently. The current logic relies on whether the "deploy_config" is offered is not correct as it can also be offered during reconfiguration.

This commit switches to use the initial_deploy flag, ensures the error reporting section will not be triggered after the initial deployment.

Test:
1. Passed - inital subcloud deployment successfully, verify the subcloud's error collecting during deployment.
2. Passed - reconfigure the subcloud, verify the subcloud's error collecting tasks are skipped.
3. Passed - lock a subcloud, reconfigure the subcloud's platform cores, verify the error collecting tasks are skipped.
4. Passed - Deploy a duplex subcloud and configure with DM
                  Swact the duplex subcloud controller-0
                  Reconfigure the duplex subcloud
                  Verify that error collection is skipped