### PR TITLE
Fix Host Lock Prevention During Admin Network Reconfiguration

### DIFF
--- a/controllers/manager/monitor_test.go
+++ b/controllers/manager/monitor_test.go
@@ -333,9 +333,6 @@ func (m *Dummymanager) NotifySystemDependencies(namespace string) error {
 func (m *Dummymanager) NotifyResource(object client.Object) error {
 	return nil
 }
-func (m *Dummymanager) NotifyHostController(object client.Object, deleteKey bool) error {
-	return nil
-}
 func (m *Dummymanager) SetSystemReady(namespace string, value bool) {
 
 }
@@ -407,7 +404,12 @@ func (m *Dummymanager) SetStrategyRetryCount(c int) error {
 func (m *Dummymanager) GetStrategyRetryCount() (int, error) {
 	return m.retryCount, nil
 }
+func (m *Dummymanager) IsPlatformNetworkReconciling() bool {
+	return false
+}
+func (m *Dummymanager) SetPlatformNetworkReconciling(status bool) {
 
+}
 func (m *Dummymanager) GcShow(c *gophercloud.ServiceClient) (*systemconfigupdate.SystemConfigUpdate, error) {
 	if len(m.gcShow) == 0 {
 		err := errors.New("test: no info available")


### PR DESCRIPTION
This commit intends to fix the host lock execution prevention due to Host
CRD update.

After successful reconciliation of platform networks, the platform
network controller adds annotation on Host reconciler which triggers
network reconciliation of the host.
In this case, Host resource was modified by creating the annotation just
before host reconciler was set to send lock_required strategy update in
order to create new admin VLAN interface.
As a consequence of this, lock_required strategy update failed due to
request target being obselete verion of Host CRD.

To address this issue, annotation as a way to signal host reconciler for
network reconciliation post platform network reconciliation is removed.
Instead we are setting host reconciliation status to 'false' and letting
host reconciler handle rest of it.

Test Cases:
1. PASS - Verify network reconfig is successful on AIO-SX systems by
          updating platform resource configurations with deploymentScope
          of "principal" for oam/mgmt/admin networks.
2. PASS - Verify network reconfig is successful on AIO-SX systems by
          applying new platform resource configurations with
          deploymentScope of "principal" for oam/mgmt/admin networks.
3. PASS - Verify that platform network reconciliation and host
          reconciliation are successful when new admin interface is
          created.
4. PASS - Verify request with emtpy opts is not sent to sysinv from
          gophercloud when ptpRole attribute is absent in the Host /
          HostProfile.
