### PR TITLE
Increase PlatformNetwork Controller UT Coverage to >70%

### DIFF
--- a/controllers/manager/monitor_test.go
+++ b/controllers/manager/monitor_test.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2023 Wind River Systems, Inc. */
+/* Copyright(c) 2023-2024 Wind River Systems, Inc. */
 
 package manager
 
@@ -445,4 +445,10 @@ func (m *Dummymanager) GcDelete(c *gophercloud.ServiceClient) (r systemconfigupd
 	m.strategyDeleted = true
 	re := systemconfigupdate.DeleteResult{}
 	return re
+}
+func (m *Dummymanager) SetDefaultGetPlatformClient() {
+
+}
+func (m *Dummymanager) SetGetPlatformClient(f func(namespace string) *gophercloud.ServiceClient) {
+
 }

--- a/controllers/platformnetwork_controller.go
+++ b/controllers/platformnetwork_controller.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019-2023 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2024 Wind River Systems, Inc. */
 
 package controllers
 
@@ -867,7 +867,7 @@ func (r *PlatformNetworkReconciler) GetHostInstance(hostname string, request_nam
 	host_namespace := types.NamespacedName{Namespace: request_namespace, Name: hostname}
 	err := r.Client.Get(context.TODO(), host_namespace, host_instance)
 	if err != nil {
-		logPlatformNetwork.Error(err, "Failed to get host resource from namespace %v", host_namespace)
+		logPlatformNetwork.Error(err, "Failed to get host resource from namespace")
 	}
 	return host_instance, err
 }
@@ -884,7 +884,7 @@ func (r *PlatformNetworkReconciler) HandleHostStrategyUpdates(host_strategy clou
 		host_instance.Status.StrategyRequired = host_strategy.StrategyRequired
 		err := r.Client.Status().Update(context.TODO(), host_instance)
 		if err != nil {
-			logPlatformNetwork.Error(err, "Failed to update status %v", host_instance.Status)
+			logPlatformNetwork.Error(err, "Failed to update status")
 			return err
 		}
 	}
@@ -914,7 +914,7 @@ func (r *PlatformNetworkReconciler) UpdateHostReconciledStatus(host_name string,
 		host_instance.Status.Reconciled = is_reconciled
 		err := r.Client.Status().Update(context.TODO(), host_instance)
 		if err != nil {
-			logPlatformNetwork.Error(err, "Failed to update status %v", host_instance.Status)
+			logPlatformNetwork.Error(err, "Failed to update status")
 			return common.NewResourceConfigurationDependency(
 				fmt.Sprintf("Failed to update %s/%s host instance reconciliation status to '%v'", host_name, request_namespace, host_instance.Status.Reconciled))
 		}
@@ -1243,7 +1243,7 @@ func (r *PlatformNetworkReconciler) Reconcile(ctx context.Context, request ctrl.
 			return reconcile.Result{}, nil
 		}
 
-		logPlatformNetwork.Error(err, "unable to read object: %v", request)
+		logPlatformNetwork.Error(err, "unable to read object")
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}

--- a/controllers/platformnetwork_controller_fixtures.go
+++ b/controllers/platformnetwork_controller_fixtures.go
@@ -1,0 +1,483 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2024 Wind River Systems, Inc. */
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/addresspools"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/networks"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
+	cloudManager "github.com/wind-river/cloud-platform-deployment-manager/controllers/manager"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+)
+
+const AddrPoolListBody = `
+{
+    "addrpools": [
+        {
+            "gateway_address": null,
+            "network": "192.168.204.0",
+            "name": "management",
+            "ranges": [
+                [
+                    "192.168.204.2",
+                    "192.168.204.50"
+                ]
+            ],
+			"floating_address": "192.168.204.2",
+			"controller0_address": "192.168.204.3",
+			"controller1_address": "192.168.204.4",
+            "prefix": 24,
+            "order": "random",
+            "uuid": "aa277c8e-7421-4721-ae6a-347771fe4fa6"
+        },
+		{
+            "gateway_address": "10.10.10.1",
+            "network": "10.10.10.0",
+            "name": "oam",
+            "ranges": [
+                [
+                    "10.10.10.2",
+                    "10.10.10.254"
+                ]
+            ],
+			"floating_address": "10.10.10.2",
+			"controller0_address": "10.10.10.3",
+			"controller1_address": "10.10.10.4",
+            "prefix": 24,
+            "order": "random",
+            "uuid": "384c6eb3-d48b-486e-8151-7dcecd3779df"
+        },
+		{
+            "gateway_address": "192.168.208.1",
+            "network": "192.168.208.0",
+            "name": "admin",
+            "ranges": [
+                [
+                    "192.168.208.2",
+                    "192.168.208.50"
+                ]
+            ],
+			"floating_address": "192.168.208.2",
+			"controller0_address": "192.168.208.3",
+			"controller1_address": "192.168.208.4",
+            "prefix": 24,
+            "order": "random",
+            "uuid": "be2eb19c-4b47-88ec-82c5-6b29097cf439"
+        },
+        {
+            "gateway_address": null,
+            "network": "169.254.202.0",
+            "name": "pxeboot",
+            "ranges": [
+                [
+                    "169.254.202.1",
+                    "169.254.202.254"
+                ]
+            ],
+			"floating_address": "169.254.202.2",
+			"controller0_address": "169.254.202.3",
+			"controller1_address": "169.254.202.4",
+            "prefix": 24,
+            "order": "random",
+            "uuid": "28f8fabb-43df-4458-a256-d9195e2b669e"
+        }
+    ]
+}
+`
+
+const NetworkListBody = `
+{
+    "networks": [
+        {
+			"dynamic": false,
+			"id": 1,
+			"name": "admin",
+			"pool_uuid": "be2eb19c-4b47-88ec-82c5-6b29097cf439",
+			"type": "admin",
+			"uuid": "c434c909-f2eb-4a4e-87f1-525cbe9b1ec2"
+        },
+        {
+			"dynamic": true,
+			"id": 2,
+			"name": "mgmt",
+			"pool_uuid": "aa277c8e-7421-4721-ae6a-347771fe4fa6",
+			"type": "mgmt",
+			"uuid": "a48a7b6d-9cfa-24a4-8d48-f0e25d35984a"
+        },
+		{
+			"dynamic": false,
+			"id": 3,
+			"name": "oam",
+			"pool_uuid": "384c6eb3-d48b-486e-8151-7dcecd3779df",
+			"type": "oam",
+			"uuid": "32665423-d48b-486e-8151-7dcecd3779df"
+		},
+		{
+			"dynamic": true,
+			"id": 4,
+			"name": "pxeboot",
+			"pool_uuid": "28f8fabb-43df-4458-a256-d9195e2b669e",
+			"type": "pxeboot",
+			"uuid": "0bebc4ef-e8e4-1248-b9d5-8694a79f58cc"
+		}
+    ]
+}
+`
+
+const OAMNetworkListBody = `
+{
+	"iextoams": [
+		{
+			"uuid": "32665423-d48b-486e-8151-7dcecd3779df",
+			"oam_subnet": "10.10.10.0/24",
+			"oam_gateway_ip": "10.10.10.1",
+			"oam_floating_ip": "10.10.10.2",
+			"oam_c0_ip": "10.10.10.3",
+			"oam_c1_ip": "10.10.10.4",
+			"oam_start_ip": "10.10.10.2",
+			"oam_end_ip": "10.10.10.254",
+			"region_config": false,
+			"isystem_uuid": "607671a2-15a7-4f97-9297-c4e1804cde12",
+			"links": [
+				{
+					"href": "http://192.168.204.2:6385/v1/iextoams/32665423-d48b-486e-8151-7dcecd3779df",
+					"rel": "self"
+				}, {
+					"href": "http://192.168.204.2:6385/iextoams/32665423-d48b-486e-8151-7dcecd3779df",
+					"rel": "bookmark"
+				}
+			],
+			"created_at": "2023-11-28T13:10:53.200531+00:00",
+			"updated_at": null
+		}
+	]
+}
+`
+
+const SingleSystemBody = `
+{
+	"isystems": [
+		{
+			"system_mode": "simplex",
+			"created_at": "2019-08-07T14:32:41.617713+00:00",
+			"links": [
+				{
+					"href": "http://192.168.204.2:6385/v1/isystems/5af5f7e5-1eea-4e76-b539-ac552e132e47",
+					"rel": "self"
+				},
+				{
+					"href": "http://192.168.204.2:6385/isystems/5af5f7e5-1eea-4e76-b539-ac552e132e47",
+					"rel": "bookmark"
+				}
+			],
+			"security_feature": "spectre_meltdown_v1",
+			"description": "Test System",
+			"software_version": "19.01",
+			"service_project_name": "services",
+			"updated_at": "2019-08-07T14:45:50.822509+00:00",
+			"distributed_cloud_role": null,
+			"location": "vbox",
+			"capabilities": {
+				"sdn_enabled": false,
+				"shared_services": "[]",
+				"bm_region": "External",
+				"vswitch_type": "none",
+				"https_enabled": false,
+				"region_config": false
+			},
+			"name": "Herp",
+			"contact": "info@windriver.com",
+			"system_type": "All-in-one",
+			"timezone": "UTC",
+			"region_name": "RegionOne",
+			"uuid": "5af5f7e5-1eea-4e76-b539-ac552e132e47"
+		}
+    ]
+}
+`
+
+const HostsListBody = `
+{
+  "ihosts": [
+    {
+      "action": "none",
+      "administrative": "unlocked",
+      "apparmor": "disabled",
+      "hw_settle": "0",
+      "availability": "online",
+      "bm_ip": null,
+      "bm_type": null,
+      "bm_username": null,
+      "boot_device": "/dev/disk/by-path/pci-0000:00:0d.0-ata-1.0",
+      "capabilities": {
+        "Personality": "Controller-Active",
+        "stor_function": "monitor"
+      },
+      "clock_synchronization": "ntp",
+      "config_applied": "53296bf3-d205-4675-8c57-411c875c164e",
+      "config_status": "Config out-of-date",
+      "config_target": "2da20c19-2157-4231-b9b3-194175e7dad0",
+      "console": "tty0",
+      "created_at": "2019-08-07T14:42:25.415277+00:00",
+      "hostname": "controller-0",
+      "id": 1,
+      "ihost_action": null,
+      "install_output": "text",
+      "install_state": null,
+      "install_state_info": null,
+      "inv_state": "inventoried",
+      "invprovision": "provisioning",
+      "iprofile_uuid": null,
+      "iscsi_initiator_name": null,
+      "isystem_uuid": "5af5f7e5-1eea-4e76-b539-ac552e132e47",
+      "links": [
+        {
+          "href": "http://192.168.204.2:6385/v1/ihosts/d99637e9-5451-45c6-98f4-f18968e43e91",
+          "rel": "self"
+        },
+        {
+          "href": "http://192.168.204.2:6385/ihosts/d99637e9-5451-45c6-98f4-f18968e43e91",
+          "rel": "bookmark"
+        }
+      ],
+      "location": {
+        "locn": "vbox"
+      },
+      "mgmt_ip": "1.2.3.4",
+      "mgmt_mac": "08:08:08:08:08:08",
+      "mtce_info": null,
+      "operational": "enabled",
+      "peers": null,
+      "personality": "controller",
+      "reserved": "False",
+      "rootfs_device": "/dev/disk/by-path/pci-0000:00:0d.0-ata-1.0",
+      "serialid": null,
+      "software_load": "19.01",
+      "subfunction_avail": "online",
+      "subfunction_oper": "enabled",
+      "subfunctions": "controller,worker",
+      "target_load": "19.01",
+      "task": null,
+      "tboot": "false",
+      "ttys_dcd": null,
+      "updated_at": "2019-08-07T15:01:23.348321+00:00",
+      "uptime": 3490,
+      "uuid": "d99637e9-5451-45c6-98f4-f18968e43e91",
+      "vim_progress_status": null,
+      "max_cpu_mhz_configured": "1800"
+    }
+  ]
+}
+`
+
+const DummyAddressPoolUpdateResponse = `
+{
+	"gateway_address": null,
+	"network": "169.254.202.0",
+	"name": "dummy",
+	"ranges": [
+		[
+			"169.254.202.1",
+			"169.254.202.254"
+		]
+	],
+	"floating_address": "169.254.202.2",
+	"controller0_address": "169.254.202.3",
+	"controller1_address": "169.254.202.4",
+	"prefix": 24,
+	"order": "random",
+	"uuid": "123914e3-36e4-41a8-a702-d9f6e54d7140"
+}
+`
+
+const DummyNetworkUpdateResponse = `
+{
+    "dynamic": false,
+    "id": 2,
+    "name": "dummy",
+    "pool_uuid": "c7ac5a0c-606b-4fe0-9065-28a8c8fb78cc",
+    "type": "oam",
+    "uuid": "f757b5c7-89ab-4d93-bfd7-a97780ec2c1e"
+}
+`
+
+const DummyOAMUpdateResponse = `
+{
+    "uuid": "727bd796-070f-40c2-8b9b-7ed674fd0fe7",
+	"oam_subnet": "10.10.20.0/24",
+	"oam_gateway_ip": null,
+	"oam_floating_ip": "10.10.20.5",
+	"oam_c0_ip": "10.10.20.3",
+	"oam_c1_ip": "10.10.20.4"
+}
+`
+
+var HostsListBodyResponse string
+var SingleSystemBodyResponse string
+
+func HandleAddressPoolRequests(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, AddrPoolListBody)
+	case http.MethodPost:
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, DummyAddressPoolUpdateResponse)
+	case http.MethodPatch:
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, DummyAddressPoolUpdateResponse)
+	case http.MethodDelete:
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.Error(w, `{"error": "Method not allowed"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+func AddressPoolAPIS() {
+	th.Mux.HandleFunc("/addrpools", HandleAddressPoolRequests)
+}
+
+func HandleNetworkRequests(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, NetworkListBody)
+	case http.MethodPost:
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, DummyNetworkUpdateResponse)
+	case http.MethodPatch:
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, DummyNetworkUpdateResponse)
+	case http.MethodDelete:
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.Error(w, `{"error": "Method not allowed"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+func NetworkAPIS() {
+	th.Mux.HandleFunc("/networks", HandleNetworkRequests)
+}
+
+func HandleOAMNetworkRequests(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, OAMNetworkListBody)
+	case http.MethodPatch:
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, DummyOAMUpdateResponse)
+	case http.MethodDelete:
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.Error(w, `{"error": "Method not allowed"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+func OAMNetworkAPIS() {
+	th.Mux.HandleFunc("/iextoam", HandleOAMNetworkRequests)
+}
+
+func HandleSystemRequests(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Content-Type", "application/json")
+	switch r.Method {
+	case http.MethodGet:
+		fmt.Fprint(w, SingleSystemBodyResponse)
+	default:
+		http.Error(w, `{"error": "Method not allowed"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+func SystemAPIS() {
+	th.Mux.HandleFunc("/isystems", HandleSystemRequests)
+}
+
+func HandleHostRequests(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Content-Type", "application/json")
+	switch r.Method {
+	case http.MethodGet:
+		fmt.Fprint(w, HostsListBodyResponse)
+	default:
+		http.Error(w, `{"error": "Method not allowed"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+func HostAPIS() {
+	th.Mux.HandleFunc("/ihosts", HandleHostRequests)
+}
+
+func GetPlatformNetworksFromFixtures(namespace string) map[string]*starlingxv1.PlatformNetwork {
+	PlatformNetworks := make(map[string]*starlingxv1.PlatformNetwork)
+
+	var Networks struct {
+		NetworkList []networks.Network `json:"networks"`
+	}
+	var AddressPools struct {
+		AddressPoolList []addresspools.AddressPool `json:"addrpools"`
+	}
+
+	_ = json.Unmarshal([]byte(NetworkListBody), &Networks)
+	_ = json.Unmarshal([]byte(AddrPoolListBody), &AddressPools)
+
+	for _, network := range Networks.NetworkList {
+		allocation_order := networks.AllocationOrderDynamic
+		if !network.Dynamic {
+			allocation_order = networks.AllocationOrderStatic
+		}
+
+		for _, addrpool := range AddressPools.AddressPoolList {
+			if network.PoolUUID == addrpool.ID {
+				PlatformNetworks[network.Type] = &starlingxv1.PlatformNetwork{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      network.Name,
+						Namespace: namespace,
+					},
+					Spec: starlingxv1.PlatformNetworkSpec{
+						Type:    network.Type,
+						Subnet:  addrpool.Network,
+						Prefix:  addrpool.Prefix,
+						Gateway: addrpool.Gateway,
+						Allocation: starlingxv1.AllocationInfo{
+							Type:   allocation_order,
+							Order:  &addrpool.Order,
+							Ranges: []starlingxv1.AllocationRange{{Start: addrpool.Ranges[0][0], End: addrpool.Ranges[0][1]}},
+						},
+						FloatingAddress:    addrpool.FloatingAddress,
+						Controller0Address: addrpool.Controller0Address,
+						Controller1Address: addrpool.Controller1Address,
+					},
+				}
+			}
+		}
+	}
+
+	return PlatformNetworks
+}
+
+func StartPlatformNetworkAPIHandlers() {
+	HostsListBodyResponse = HostsListBody
+	SingleSystemBodyResponse = SingleSystemBody
+	AddressPoolAPIS()
+	NetworkAPIS()
+	OAMNetworkAPIS()
+	SystemAPIS()
+	HostAPIS()
+
+	var Networks struct {
+		NetworkList []networks.Network `json:"networks"`
+	}
+	_ = json.Unmarshal([]byte(NetworkListBody), &Networks)
+
+	for _, network := range Networks.NetworkList {
+		if network.Type == cloudManager.OAMNetworkType {
+			th.Mux.HandleFunc("/iextoam/"+network.UUID, HandleOAMNetworkRequests)
+		} else {
+			th.Mux.HandleFunc("/networks/"+network.UUID, HandleNetworkRequests)
+		}
+		th.Mux.HandleFunc("/addrpools/"+network.PoolUUID, HandleAddressPoolRequests)
+	}
+}

--- a/controllers/platformnetwork_controller_test.go
+++ b/controllers/platformnetwork_controller_test.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2022 Wind River Systems, Inc. */
+/* Copyright(c) 2022-2024 Wind River Systems, Inc. */
 package controllers
 
 import (
@@ -11,9 +11,182 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/networks"
 	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
 	comm "github.com/wind-river/cloud-platform-deployment-manager/common"
+	cloudManager "github.com/wind-river/cloud-platform-deployment-manager/controllers/manager"
+	"strings"
 )
+
+const TestNamespace = "default"
+
+func IntroducePlatformNetworkChange(platform_network *starlingxv1.PlatformNetwork) {
+	allocation_order := networks.AllocationOrderStatic
+	if platform_network.Spec.Allocation.Type == networks.AllocationOrderStatic {
+		allocation_order = networks.AllocationOrderDynamic
+	}
+
+	addrpool_order := "random"
+	gateway := "100.100.100.1"
+	platform_network.Spec.Subnet = "100.100.100.0"
+	platform_network.Spec.Prefix = 24
+	platform_network.Spec.Gateway = &gateway
+	platform_network.Spec.FloatingAddress = "100.100.100.2"
+	platform_network.Spec.Controller0Address = "100.100.100.3"
+	platform_network.Spec.Controller1Address = "100.100.100.4"
+	platform_network.Spec.Allocation = starlingxv1.AllocationInfo{
+		Type:   allocation_order,
+		Order:  &addrpool_order,
+		Ranges: []starlingxv1.AllocationRange{{Start: "100.100.100.2", End: "100.100.100.254"}},
+	}
+}
+
+func CreateDummyHost(hostname string) {
+	annotations := make(map[string]string)
+	annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"status":{"deploymentScope":"bootstrap"}}`
+
+	personality_controller := "controller"
+	interfaces := &starlingxv1.InterfaceInfo{}
+	dummy_hostprofile := &starlingxv1.HostProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dummy-profile-for-" + hostname,
+			Namespace: TestNamespace,
+		},
+		Spec: starlingxv1.HostProfileSpec{
+			ProfileBaseAttributes: starlingxv1.ProfileBaseAttributes{
+				Personality: &personality_controller,
+			},
+			Interfaces: interfaces,
+		}}
+	Expect(k8sClient.Create(ctx, dummy_hostprofile)).To(Succeed())
+
+	bootMac := "01:02:03:04:05:06"
+	match := starlingxv1.MatchInfo{
+		BootMAC: &bootMac,
+	}
+	dummy_host := &starlingxv1.Host{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        hostname,
+			Namespace:   TestNamespace,
+			Annotations: annotations,
+		},
+		Spec: starlingxv1.HostSpec{
+			Profile: "dummy-profile-for-" + hostname,
+			Match:   &match,
+			Overrides: &starlingxv1.HostProfileSpec{
+				Addresses: []starlingxv1.AddressInfo{
+					{Interface: "enp0s3", Address: "1.2.3.10", Prefix: 24},
+				},
+			},
+		}}
+	Expect(k8sClient.Create(ctx, dummy_host)).To(Succeed())
+}
+
+func DeleteDummyHost(hostname string) {
+	for _, key := range []string{hostname, "dummy-profile-for-" + hostname} {
+		crd_key := types.NamespacedName{
+			Name:      key,
+			Namespace: TestNamespace,
+		}
+
+		if strings.Contains(key, "profile") {
+			crd_fetched := &starlingxv1.HostProfile{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, crd_key, crd_fetched)
+				if err == nil {
+					crd_fetched.ObjectMeta.Finalizers = []string{}
+					err = k8sClient.Update(ctx, crd_fetched)
+					if err == nil {
+						err = k8sClient.Delete(ctx, crd_fetched)
+						if err == nil {
+							return true
+						}
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, crd_key, crd_fetched)
+				return err != nil
+			}, timeout, interval).Should(BeTrue())
+
+		} else {
+			crd_fetched := &starlingxv1.Host{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, crd_key, crd_fetched)
+				if err == nil {
+					crd_fetched.ObjectMeta.Finalizers = []string{}
+					err = k8sClient.Update(ctx, crd_fetched)
+					if err == nil {
+						err = k8sClient.Delete(ctx, crd_fetched)
+						if err == nil {
+							return true
+						}
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, crd_key, crd_fetched)
+				return err != nil
+			}, timeout, interval).Should(BeTrue())
+		}
+	}
+}
+
+func DeletePlatformNetwork(nwk_name string) {
+	key := types.NamespacedName{
+		Name:      nwk_name,
+		Namespace: TestNamespace,
+	}
+
+	fetched := &starlingxv1.PlatformNetwork{}
+
+	Eventually(func() bool {
+		err := k8sClient.Get(ctx, key, fetched)
+		if err == nil {
+			fetched.ObjectMeta.Finalizers = []string{}
+			err = k8sClient.Update(ctx, fetched)
+			if err == nil {
+				err = k8sClient.Delete(ctx, fetched)
+				if err == nil {
+					return true
+				}
+			}
+		}
+		return false
+	}, timeout, interval).Should(BeTrue())
+
+	Eventually(func() bool {
+		err := k8sClient.Get(ctx, key, fetched)
+		return err != nil
+	}, timeout, interval).Should(BeTrue())
+}
+
+func SimulateVIMStrategyAction(hostname string, expect_strategy string) {
+	host_key := types.NamespacedName{
+		Name:      hostname,
+		Namespace: TestNamespace,
+	}
+	host_instance := &starlingxv1.Host{}
+
+	Eventually(func() bool {
+		err := k8sClient.Get(ctx, host_key, host_instance)
+		Expect(err).To(BeNil())
+		return (host_instance.Status.StrategyRequired == expect_strategy)
+	}, timeout, interval).Should(BeTrue())
+
+	if host_instance.Status.StrategyRequired == cloudManager.StrategyLockRequired {
+		HostsListBodyResponse = strings.Replace(HostsListBody, `"administrative": "unlocked",`, `"administrative": "locked",`, 1)
+		HostsListBodyResponse = strings.Replace(HostsListBodyResponse, `"operational": "enabled"`, `"operational": "disabled"`, 1)
+	} else {
+		HostsListBodyResponse = HostsListBody
+	}
+}
 
 var _ = Describe("Platformnetwork controller", func() {
 
@@ -22,44 +195,373 @@ var _ = Describe("Platformnetwork controller", func() {
 		interval = time.Millisecond * 250
 	)
 
-	Context("PlatformNetwork with data", func() {
-		It("Should created successfully", func() {
-			ctx := context.Background()
-			key := types.NamespacedName{
-				Name:      "foo",
-				Namespace: "default",
-			}
-			order := "sequential"
-			created := &starlingxv1.PlatformNetwork{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "default",
-				},
-				Spec: starlingxv1.PlatformNetworkSpec{
-					Type:   "mgmt",
-					Subnet: "1.2.3.0",
-					Prefix: 24,
-					Allocation: starlingxv1.AllocationInfo{
-						Type:  "static",
-						Order: &order,
-						Ranges: []starlingxv1.AllocationRange{
-							{Start: "1.2.3.10", End: "1.2.3.49"},
-							{Start: "1.2.3.129", End: "1.2.3.139"}},
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, created)).To(Succeed())
+	Context("PlatformNetwork with correct mgmt/admin/oam network data in Day-1", func() {
+		It("Should be created successfully and Reconciled & InSync should be 'true'", func() {
 
-			expected := created.DeepCopy()
+			tMgr := cloudManager.GetInstance(k8sManager)
+			StartPlatformNetworkAPIHandlers()
+			tMgr.SetSystemReady(TestNamespace, true)
+
+			network_names := []string{"mgmt", "admin", "oam"}
+			platform_networks := GetPlatformNetworksFromFixtures(TestNamespace)
+			ctx := context.Background()
+
+			for _, nwk_name := range network_names {
+				key := types.NamespacedName{
+					Name:      nwk_name,
+					Namespace: TestNamespace,
+				}
+
+				Expect(k8sClient.Create(ctx, platform_networks[nwk_name])).To(Succeed())
+
+				expected := platform_networks[nwk_name].DeepCopy()
+
+				fetched := &starlingxv1.PlatformNetwork{}
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, key, fetched)
+					return err == nil &&
+						fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion &&
+						fetched.Status.Reconciled == true &&
+						fetched.Status.InSync == true
+				}, timeout, interval).Should(BeTrue())
+				_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PlatformNetworkFinalizerName})
+				Expect(found).To(BeTrue())
+
+				DeletePlatformNetwork(nwk_name)
+			}
+		})
+	})
+
+	Context("PlatformNetwork with incorrect mgmt network data in Day-1", func() {
+		It("Should be created successfully and Reconciled should be 'true' and Insync should be 'false'", func() {
+
+			network_names := []string{"mgmt", "admin", "oam"}
+			platform_networks := GetPlatformNetworksFromFixtures(TestNamespace)
+			ctx := context.Background()
+
+			for _, nwk_name := range network_names {
+				key := types.NamespacedName{
+					Name:      nwk_name,
+					Namespace: TestNamespace,
+				}
+
+				IntroducePlatformNetworkChange(platform_networks[nwk_name])
+
+				Expect(k8sClient.Create(ctx, platform_networks[nwk_name])).To(Succeed())
+
+				expected := platform_networks[nwk_name].DeepCopy()
+
+				fetched := &starlingxv1.PlatformNetwork{}
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, key, fetched)
+					return err == nil &&
+						fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion &&
+						fetched.Status.Reconciled == true &&
+						fetched.Status.InSync == false
+				}, timeout, interval).Should(BeTrue())
+				_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PlatformNetworkFinalizerName})
+				Expect(found).To(BeTrue())
+
+				DeletePlatformNetwork(nwk_name)
+			}
+		})
+	})
+
+	Context("PlatformNetwork with incorrect network data for network other than oam / mgmt/ admin in Day-1", func() {
+		It("Should be created successfully and Reconciled should be 'true' and Insync should be 'true'", func() {
+			network_names := []string{"pxeboot"}
+			platform_networks := GetPlatformNetworksFromFixtures(TestNamespace)
+			ctx := context.Background()
+
+			for _, nwk_name := range network_names {
+				key := types.NamespacedName{
+					Name:      nwk_name,
+					Namespace: TestNamespace,
+				}
+
+				platform_networks[nwk_name].Spec.FloatingAddress = "100.100.100.100"
+
+				Expect(k8sClient.Create(ctx, platform_networks[nwk_name])).To(Succeed())
+
+				expected := platform_networks[nwk_name].DeepCopy()
+
+				fetched := &starlingxv1.PlatformNetwork{}
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, key, fetched)
+					return err == nil &&
+						fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion &&
+						fetched.Status.Reconciled == true &&
+						fetched.Status.InSync == true
+				}, timeout, interval).Should(BeTrue())
+				_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PlatformNetworkFinalizerName})
+				Expect(found).To(BeTrue())
+
+				DeletePlatformNetwork(nwk_name)
+			}
+		})
+	})
+
+	Context("PlatformNetwork with admin/oam network data in Day-2 (Network Reconfiguration)", func() {
+		It("Should be created successfully and Reconciled & InSync should be 'true'", func() {
+
+			network_names := []string{"admin", "oam"}
+			platform_networks := GetPlatformNetworksFromFixtures(TestNamespace)
+			ctx := context.Background()
+
+			CreateDummyHost("controller-0")
+			defer DeleteDummyHost("controller-0")
+
+			annotations := make(map[string]string)
+			annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"status":{"deploymentScope":"principal"}}`
+
+			for _, nwk_name := range network_names {
+				key := types.NamespacedName{
+					Name:      nwk_name,
+					Namespace: TestNamespace,
+				}
+
+				IntroducePlatformNetworkChange(platform_networks[nwk_name])
+
+				platform_networks[nwk_name].ObjectMeta.Annotations = annotations
+
+				Expect(k8sClient.Create(ctx, platform_networks[nwk_name])).To(Succeed())
+
+				expected := platform_networks[nwk_name].DeepCopy()
+
+				fetched := &starlingxv1.PlatformNetwork{}
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, key, fetched)
+					return err == nil &&
+						fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion &&
+						fetched.Status.Reconciled == true &&
+						fetched.Status.InSync == true
+				}, timeout, interval).Should(BeTrue())
+				_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PlatformNetworkFinalizerName})
+				Expect(found).To(BeTrue())
+
+				DeletePlatformNetwork(nwk_name)
+			}
+		})
+	})
+
+	Context("Reconfigure admin network on AIO-SX - Day 2", func() {
+		It("Should not trigger lock / unlock of host", func() {
+			platform_networks := GetPlatformNetworksFromFixtures(TestNamespace)
+			ctx := context.Background()
+
+			CreateDummyHost("controller-0")
+			defer DeleteDummyHost("controller-0")
+
+			nwk_name := "admin"
+			annotations := make(map[string]string)
+			annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"status":{"deploymentScope":"principal"}}`
+
+			key := types.NamespacedName{
+				Name:      nwk_name,
+				Namespace: TestNamespace,
+			}
+
+			IntroducePlatformNetworkChange(platform_networks[nwk_name])
+
+			platform_networks[nwk_name].ObjectMeta.Annotations = annotations
+
+			Expect(k8sClient.Create(ctx, platform_networks[nwk_name])).To(Succeed())
+
+			expected := platform_networks[nwk_name].DeepCopy()
+
+			SimulateVIMStrategyAction("controller-0", cloudManager.StrategyNotRequired)
 
 			fetched := &starlingxv1.PlatformNetwork{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, key, fetched)
 				return err == nil &&
-					fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion
+					fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion &&
+					fetched.Status.Reconciled == true &&
+					fetched.Status.InSync == true
 			}, timeout, interval).Should(BeTrue())
 			_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PlatformNetworkFinalizerName})
 			Expect(found).To(BeTrue())
+
+			DeletePlatformNetwork(nwk_name)
 		})
 	})
+
+	Context("Reconfigure OAM network on AIO-SX - Day 2", func() {
+		It("Should not trigger lock / unlock of host", func() {
+			platform_networks := GetPlatformNetworksFromFixtures(TestNamespace)
+			ctx := context.Background()
+
+			CreateDummyHost("controller-0")
+			defer DeleteDummyHost("controller-0")
+
+			nwk_name := "oam"
+			annotations := make(map[string]string)
+			annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"status":{"deploymentScope":"principal"}}`
+
+			key := types.NamespacedName{
+				Name:      nwk_name,
+				Namespace: TestNamespace,
+			}
+
+			IntroducePlatformNetworkChange(platform_networks[nwk_name])
+
+			platform_networks[nwk_name].ObjectMeta.Annotations = annotations
+
+			Expect(k8sClient.Create(ctx, platform_networks[nwk_name])).To(Succeed())
+
+			expected := platform_networks[nwk_name].DeepCopy()
+
+			SimulateVIMStrategyAction("controller-0", cloudManager.StrategyNotRequired)
+
+			fetched := &starlingxv1.PlatformNetwork{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil &&
+					fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion &&
+					fetched.Status.Reconciled == true &&
+					fetched.Status.InSync == true
+			}, timeout, interval).Should(BeTrue())
+			_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PlatformNetworkFinalizerName})
+			Expect(found).To(BeTrue())
+
+			DeletePlatformNetwork(nwk_name)
+		})
+	})
+
+	Context("Reconfigure management network on AIO-SX - Day 2", func() {
+		It("Should trigger lock / unlock of host", func() {
+			tMgr := cloudManager.GetInstance(k8sManager)
+			platform_networks := GetPlatformNetworksFromFixtures(TestNamespace)
+
+			ctx := context.Background()
+
+			CreateDummyHost("controller-0")
+			defer DeleteDummyHost("controller-0")
+
+			nwk_name := "mgmt"
+			annotations := make(map[string]string)
+			annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"status":{"deploymentScope":"principal"}}`
+
+			key := types.NamespacedName{
+				Name:      nwk_name,
+				Namespace: TestNamespace,
+			}
+
+			IntroducePlatformNetworkChange(platform_networks[nwk_name])
+
+			platform_networks[nwk_name].ObjectMeta.Annotations = annotations
+
+			Expect(k8sClient.Create(ctx, platform_networks[nwk_name])).To(Succeed())
+
+			expected := platform_networks[nwk_name].DeepCopy()
+
+			SimulateVIMStrategyAction("controller-0", cloudManager.StrategyLockRequired)
+
+			Expect(tMgr.IsPlatformNetworkReconciling()).To(BeTrue())
+
+			fetched := &starlingxv1.PlatformNetwork{}
+			// Timeout in this case is set to 45 seconds because we are returning NewResourceConfigurationDependency
+			// error while waiting for VIM strategy to lock the host.
+			// This means reconciliation is attempted after every 20 seconds. Setting the timeout to
+			// 45 seconds would allow at least two retries before marking the test case as failure.
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil &&
+					fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion &&
+					fetched.Status.Reconciled == true &&
+					fetched.Status.InSync == true
+			}, time.Second*45, interval).Should(BeTrue())
+			_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PlatformNetworkFinalizerName})
+			Expect(found).To(BeTrue())
+
+			Expect(tMgr.IsPlatformNetworkReconciling()).To(BeFalse())
+
+			DeletePlatformNetwork(nwk_name)
+		})
+	})
+
+	Context("Reconfigure management network on AIO-DX - Day 2", func() {
+		It("Should NOT attempt reconciliation", func() {
+			SingleSystemBodyResponse = strings.Replace(SingleSystemBody, `"system_mode": "simplex",`, `"system_mode": "duplex",`, 1)
+			platform_networks := GetPlatformNetworksFromFixtures(TestNamespace)
+			ctx := context.Background()
+
+			CreateDummyHost("controller-0")
+			defer DeleteDummyHost("controller-0")
+
+			nwk_name := "mgmt"
+			annotations := make(map[string]string)
+			annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"status":{"deploymentScope":"principal"}}`
+
+			key := types.NamespacedName{
+				Name:      nwk_name,
+				Namespace: TestNamespace,
+			}
+
+			IntroducePlatformNetworkChange(platform_networks[nwk_name])
+
+			platform_networks[nwk_name].ObjectMeta.Annotations = annotations
+
+			Expect(k8sClient.Create(ctx, platform_networks[nwk_name])).To(Succeed())
+
+			expected := platform_networks[nwk_name].DeepCopy()
+
+			fetched := &starlingxv1.PlatformNetwork{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil &&
+					fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion &&
+					fetched.Status.Reconciled == false &&
+					fetched.Status.InSync == false
+			}, timeout, interval).Should(BeTrue())
+			_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PlatformNetworkFinalizerName})
+			Expect(found).To(BeTrue())
+
+			DeletePlatformNetwork(nwk_name)
+		})
+	})
+
+	Context("Reconfigure networks other than management on AIO-DX - Day 2", func() {
+		It("Should reoncile the networks", func() {
+			SingleSystemBodyResponse = strings.Replace(SingleSystemBody, `"system_mode": "simplex",`, `"system_mode": "duplex",`, 1)
+			platform_networks := GetPlatformNetworksFromFixtures(TestNamespace)
+			ctx := context.Background()
+
+			CreateDummyHost("controller-0")
+			defer DeleteDummyHost("controller-0")
+
+			nwk_name := "pxeboot"
+			annotations := make(map[string]string)
+			annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"status":{"deploymentScope":"principal"}}`
+
+			key := types.NamespacedName{
+				Name:      nwk_name,
+				Namespace: TestNamespace,
+			}
+
+			IntroducePlatformNetworkChange(platform_networks[nwk_name])
+
+			platform_networks[nwk_name].ObjectMeta.Annotations = annotations
+
+			Expect(k8sClient.Create(ctx, platform_networks[nwk_name])).To(Succeed())
+
+			expected := platform_networks[nwk_name].DeepCopy()
+
+			fetched := &starlingxv1.PlatformNetwork{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, fetched)
+				return err == nil &&
+					fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion &&
+					fetched.Status.Reconciled == true &&
+					fetched.Status.InSync == true
+			}, timeout, interval).Should(BeTrue())
+			_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PlatformNetworkFinalizerName})
+			Expect(found).To(BeTrue())
+
+			DeletePlatformNetwork(nwk_name)
+		})
+	})
+
 })


### PR DESCRIPTION
This commit targets to increase unit test code coverage of platform network controller from about 10% to 70%.
Since gophercloud function calls were blocker for UT coverage of all the controllers, a new approach is introduced which essentially leverages gophercloud's testhelper to serve predefined responses for all the HTTP requests towards sysinv.
This commit also contains some fixes exposed by UT on the platform network controller.

Test Cases:
1. PASS - Execute all the unit test cases successfully.
2. PASS - Verify that coverage for platformnetwork_controller.go has increased more than 70%.
3. PASS - Verify that actual functionality of Deployment Manager itself is not broken due to changes made to manager.go.