### PR TITLE
Update system reconciler to check the cert type and report error on unexpected certs

### DIFF
--- a/api/v1/system_webhook.go
+++ b/api/v1/system_webhook.go
@@ -146,6 +146,7 @@ func validateCertificates(obj *System) error {
 			// - Openstack_CA/OpenLDAP/Docker/SSL(HTTPS)
 			if c.Type == OpenstackCACertificate || c.Type == OpenLDAPCertificate ||
 				c.Type == DockerCertificate || c.Type == PlatformCertificate {
+				systemlog.Info("unexpected certificate", "type", c.Type)
 				continue
 			}
 


### PR DESCRIPTION
Update system reconciler to check the cert type and throw log message on unexpected certs

DM should no longer check any platform cert other than ssl_ca. In system reconciler, we need to check the input and throw log message message on any unexpected cert type.

Test plan:

Day2 operation on AIO-SX VDM VM
DM upgrade