### PR TITLE
Adds back route reconciliation on disabled host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ COPY --from=builder /workspace/manager .
 ENTRYPOINT ["/manager"]
 
 # Copy the delve debugger into a debug image
-FROM ubuntu:mantic-20240216 as debug
+FROM ubuntu:mantic-20240405 as debug
 WORKDIR /
 RUN apt-get update && apt-get install -y tcpdump net-tools iputils-ping iproute2
 COPY --from=dlvbuilder /go/bin/dlv /

--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -1038,6 +1038,12 @@ func (r *HostReconciler) CompareDisabledAttributes(in *starlingxv1.HostProfileSp
 				return false
 			}
 		}
+
+		if utils.IsReconcilerEnabled(utils.Route) {
+			if !in.Routes.DeepEqual(&other.Routes) {
+				return false
+			}
+		}
 	}
 
 	if utils.IsReconcilerEnabled(utils.FileSystemTypes) {

--- a/controllers/host/networking.go
+++ b/controllers/host/networking.go
@@ -2000,5 +2000,14 @@ func (r *HostReconciler) ReconcileNetworking(client *gophercloud.ServiceClient, 
 		return err
 	}
 
+	// Update/Add routes
+	// Although routes can be reconciled on runtime, it is preferred to have it
+	// reconciled before the enabling the host to make the route available once
+	// the host is enabled.
+	err = r.ReconcileRoutes(client, instance, profile, host)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/controllers/system/system_suite_test.go
+++ b/controllers/system/system_suite_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -90,6 +91,16 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	cancel()
 	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	done := make(chan error, 1)
+	go func() {
+		done <- testEnv.Stop()
+	}()
+
+	select {
+	case err := <-done:
+		Expect(err).NotTo(HaveOccurred())
+	case <-time.After(time.Minute): // 1 minute, adjust timeout as necessary
+		By("timeout waiting for the test environment to stop")
+		// Implement additional logging or force-termination here
+	}
 })


### PR DESCRIPTION

This commit adds back the route reconciliation logic which was removed
in PR https://github.com/Wind-River/cloud-platform-deployment-manager/pull/316, ensures static routes available before the completion of
the initial unlock.

Test plan:
1. Deploy a DC with AIOSX subcloud.
2. Reconfigure the subcloud with an additional route, verifies the route
creation will not trigger the system config update strategy.

Signed-off-by: Yuxing Jiang <Yuxing.Jiang@windriver.com>