### PR TITLE
Support Platform Network Reconciliation - Day-1 Workflows

### DIFF
--- a/common/utilities.go
+++ b/common/utilities.go
@@ -4,6 +4,8 @@
 package common
 
 import (
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/addresspools"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/networks"
 	"net"
 	"regexp"
 )
@@ -163,3 +165,72 @@ func DedupeSlice[T comparable](sliceList []T) []T {
     return list
 }
 */
+
+func NormalizeIPv6(address string) string {
+	var ret_ip string
+	ip := net.ParseIP(address)
+	if ip == nil {
+		// The address doesn't seem to be valid IPv6.
+		// Returning the address as is because semantic checks are
+		// beyond the scope of this function.
+		// Use it with along with "IsIPv6" function instead.
+		return address
+	}
+	ret_ip = ip.String()
+	return ret_ip
+}
+
+// IsIPAddressSame compares two addresses and returns
+// true when IP addresses are same and false when they
+// are not the same.
+func IsIPAddressSame(ip1 string, ip2 string) bool {
+	if ip1 != "" && IsIPv6(ip1) {
+		// Normalization of IP address is required in case of
+		// IPv6 due to different notations that could be employed.
+		// Example: fcff:1::0 is same as fcff:1:0:0:0::0 but string
+		// comparison would fail if IPs are not normalized.
+		ip1 = NormalizeIPv6(ip1)
+	}
+
+	if ip2 != "" && IsIPv6(ip2) {
+		ip2 = NormalizeIPv6(ip2)
+	}
+
+	return ip1 == ip2
+}
+
+func GetSystemAddrPoolByUUID(addrpool_list []addresspools.AddressPool, addrpool_uuid string) *addresspools.AddressPool {
+	for _, addrpool := range addrpool_list {
+		if addrpool.ID == addrpool_uuid {
+			return &addrpool
+		}
+	}
+	return nil
+}
+
+func GetSystemAddrPoolByName(addrpool_list []addresspools.AddressPool, addrpool_name string) *addresspools.AddressPool {
+	for _, addrpool := range addrpool_list {
+		if addrpool.Name == addrpool_name {
+			return &addrpool
+		}
+	}
+	return nil
+}
+
+func GetSystemNetworkByUUID(network_list []networks.Network, network_uuid string) *networks.Network {
+	for _, network := range network_list {
+		if network.UUID == network_uuid {
+			return &network
+		}
+	}
+	return nil
+}
+
+func GetSystemNetworkByName(network_list []networks.Network, network_name string) *networks.Network {
+	for _, network := range network_list {
+		if network.Name == network_name {
+			return &network
+		}
+	}
+	return nil
+}

--- a/controllers/addresspool_controller.go
+++ b/controllers/addresspool_controller.go
@@ -5,6 +5,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"github.com/go-logr/logr"
 	"github.com/gophercloud/gophercloud"
 	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
@@ -13,7 +14,6 @@ import (
 	cloudManager "github.com/wind-river/cloud-platform-deployment-manager/controllers/manager"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -56,27 +56,40 @@ func (r *AddressPoolReconciler) UpdateInsyncStatus(client *gophercloud.ServiceCl
 	return nil
 }
 
-// ReconcileResource interacts with the system API in order to reconcile the
-// state of a data network with the state stored in the k8s database.
-// TODO(sriram-gn): Fetch active controller's host instance and set
+// Fetch active controller's host instance and set
 // Reconciled/Insync to false only if Generation != ObservedGeneration.
+// Note that for deletion we are just cleaning up the finalizer and we
+// are not specifically deleting addresspool object on the system.
 func (r *AddressPoolReconciler) ReconcileResource(client *gophercloud.ServiceClient, instance *starlingxv1.AddressPool, request_namespace string) (err error) {
 	if instance.DeletionTimestamp.IsZero() {
-		host_instance := &starlingxv1.Host{}
-		host_namespace := types.NamespacedName{Namespace: instance.Namespace, Name: "controller-0"}
-		err := r.Client.Get(context.TODO(), host_namespace, host_instance)
-		if err != nil {
-			logAddressPool.Error(err, "Failed to get host resource from namespace")
-		}
+		if instance.Status.ObservedGeneration != instance.ObjectMeta.Generation {
+			host_instance, err := r.CloudManager.GetActiveHost(request_namespace, client)
+			if err != nil {
+				msg := "failed to get active host"
+				return common.NewUserDataError(msg)
+			}
 
-		host_instance.Status.InSync = false
-		host_instance.Status.Reconciled = false
-		err = r.Client.Status().Update(context.TODO(), host_instance)
-		if err != nil {
-			logAddressPool.Error(err, "Failed to update status")
-			return err
+			host_instance.Status.InSync = false
+			host_instance.Status.Reconciled = false
+			err = r.Client.Status().Update(context.TODO(), host_instance)
+			if err != nil {
+				msg := fmt.Sprintf("Failed to update '%s' host instance status", host_instance.Name)
+				logAddressPool.Error(err, msg)
+				return common.NewResourceConfigurationDependency(msg)
+			}
+
+			// Set Generation = ObservedGeneration only when active
+			// host controller is successfully notified.
+			instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
+			err = r.Client.Status().Update(context.TODO(), instance)
+			if err != nil {
+				msg := fmt.Sprintf(
+					"Failed to update '%s' addresspool instance observed generation, attempting retry.",
+					instance.Name)
+				logAddressPool.Error(err, msg)
+				return common.NewResourceConfigurationDependency(msg)
+			}
 		}
-		return nil
 	} else {
 		// Remove the finalizer so the kubernetes delete operation can
 		// continue.
@@ -86,7 +99,7 @@ func (r *AddressPoolReconciler) ReconcileResource(client *gophercloud.ServiceCli
 		}
 	}
 
-	return err
+	return nil
 }
 
 // Reconcile reads that state of the cluster for a AddressPool object and makes changes based on the state read
@@ -154,7 +167,14 @@ func (r *AddressPoolReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 		return common.RetrySystemNotReady, nil
 	}
 
-	err = r.ReconcileResource(platformClient, instance, request.NamespacedName.Namespace)
+	if !r.CloudManager.IsNotifyingActiveHost() {
+		r.CloudManager.SetNotifyingActiveHost(true)
+		err = r.ReconcileResource(platformClient, instance, request.NamespacedName.Namespace)
+		r.CloudManager.SetNotifyingActiveHost(false)
+	} else {
+		err = common.NewHostNotifyError("waiting to notify active host")
+	}
+
 	if err != nil {
 		return r.ReconcilerErrorHandler.HandleReconcilerError(request, err)
 	}

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -286,6 +286,20 @@ func (h *ErrorHandler) HandleReconcilerError(request reconcile.Request, in error
 		err = nil
 
 		h.Info("waiting for dependency status", "request", request)
+	case HostNotifyError:
+		resetClient = false
+		result = RetryImmediate
+		err = nil
+		h.V(2).Info("waiting to notify active host controller", "request", request)
+
+	case PlatformNetworkReconciliationError:
+		// This error is related to failure of platform network reconciliation
+		// which is most likely a transient error condition.
+		resetClient = false
+		result = RetryTransientError
+		err = nil
+
+		h.Info("waiting to reconcile platform networks", "request", request)
 
 	case manager.ClientError, ErrUserDataError,
 		starlingxv1.ErrMissingSystemResource, ErrMissingKubernetesResource:

--- a/controllers/common/errors.go
+++ b/controllers/common/errors.go
@@ -79,6 +79,21 @@ type ChangeAfterReconciled struct {
 	BaseError
 }
 
+// PlatformNetworkReconciliationError defines an error to be used when reconciliation
+// of platform network / address pool resources fail and the reconciliation request
+// needs to be requeued.
+type PlatformNetworkReconciliationError struct {
+	BaseError
+}
+
+// HostNotifyError defines an error to be used when active host controller
+// is already being notified while the address pool / platform network
+// reconciler attempts to notify.
+// Reconciliation request can be requeued immediately for such instances.
+type HostNotifyError struct {
+	BaseError
+}
+
 // NewSystemDependency defines a constructor for the ErrSystemDependency error
 // type.
 func NewSystemDependency(msg string) error {
@@ -123,4 +138,16 @@ func NewHTTPSClientRequired(msg string) error {
 // type.
 func NewChangeAfterInSync(msg string) error {
 	return ChangeAfterReconciled{BaseError{msg}}
+}
+
+// NewPlatformNetworkReconciliationError defines a constructor for the
+// PlatformNetworkReconciliationError error type.
+func NewPlatformNetworkReconciliationError(msg string) error {
+	return PlatformNetworkReconciliationError{BaseError{msg}}
+}
+
+// NewHostNotifyError defines a constructor for the
+// HostNotifyError error type.
+func NewHostNotifyError(msg string) error {
+	return HostNotifyError{BaseError{msg}}
 }

--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -139,6 +139,20 @@ const (
 	passwordKey = "password"
 )
 
+func (r *HostReconciler) IsActiveHost(client *gophercloud.ServiceClient, instance *starlingxv1.Host, request_namespace string) (bool, error) {
+	host_instance, err := r.CloudManager.GetActiveHost(request_namespace, client)
+	if err != nil {
+		msg := "failed to get active host"
+		return false, common.NewUserDataError(msg)
+	}
+
+	if host_instance.Name == instance.Name {
+		return true, nil
+	}
+
+	return false, nil
+}
+
 // getBMPasswordCredentials is a utility to retrieve the host's board management
 // credentials from the information stored in the specified secret.
 func (r *HostReconciler) getBMPasswordCredentials(namespace string, name string) (username, password string, err error) {
@@ -1137,10 +1151,6 @@ func (r *HostReconciler) ReconcileHostByState(client *gophercloud.ServiceClient,
 			logHost.Info("no disabled attribute changes required")
 		}
 
-		if r.CloudManager.IsPlatformNetworkReconciling() {
-			return common.NewResourceConfigurationDependency("waiting for platform networks to reconcile")
-		}
-
 		if !r.CompareEnabledAttributes(profile, current, instance, host.Personality) {
 			if principal || strategy_required {
 				instance.Status.StrategyRequired = cloudManager.StrategyUnlockRequired
@@ -1486,10 +1496,10 @@ func (r *HostReconciler) StopAfterInSync() bool {
 
 // ReconcileExistingHost is responsible for dealing with the provisioning of an
 // existing host.
-func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient, instance *starlingxv1.Host, profile *starlingxv1.HostProfileSpec, host *hosts.Host) error {
+func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient, instance *starlingxv1.Host, profile *starlingxv1.HostProfileSpec, host *hosts.Host, request_namespace string) error {
 	var defaults *starlingxv1.HostProfileSpec
 	var current *starlingxv1.HostProfileSpec
-
+	var platform_network_subreconciler_errs []error
 	if !host.Stable() {
 		msg := "waiting for a stable state for existing host"
 		m := NewStableHostMonitor(instance, host.ID)
@@ -1590,9 +1600,44 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 		SyncIFNameByUuid(profile, current)
 	}
 
-	err = r.ReconcilePlatformNetworks(client, instance, profile, &hostInfo)
+	is_active_host, err := r.IsActiveHost(client, instance, request_namespace)
 	if err != nil {
 		return err
+	}
+
+	if is_active_host {
+		system_info, err := r.CloudManager.GetSystemInfo(request_namespace, client)
+		if err != nil {
+			msg := "failed to get active host"
+			return common.NewUserDataError(msg)
+		}
+
+		// Only reconcile platform networks in active controller reconciliation
+		// loops to prevent concurrency issues.
+		// Also within active controller prevent potential concurrent reconciliation
+		// if IsPlatformNetworkReconciling.
+		if !r.CloudManager.IsPlatformNetworkReconciling() {
+			r.CloudManager.SetPlatformNetworkReconciling(true)
+
+			// Do not allow notifying active host until ReconcilePlatformNetworks
+			// is completed, this is to prevent unnecessary status update conflicts
+			// in addrpools and platform network resources.
+			r.CloudManager.SetNotifyingActiveHost(true)
+
+			platform_network_subreconciler_errs = r.ReconcilePlatformNetworks(client, instance, profile, &hostInfo, system_info)
+
+			r.CloudManager.SetPlatformNetworkReconciling(false)
+			r.CloudManager.SetNotifyingActiveHost(false)
+
+			if len(platform_network_subreconciler_errs) != 0 {
+				err_msg := "there were errors during platform network reconciliation"
+				return common.NewPlatformNetworkReconciliationError(err_msg)
+			}
+
+		} else {
+			err_msg := "waiting for platform network reconciled."
+			return common.NewPlatformNetworkReconciliationError(err_msg)
+		}
 	}
 
 	inSync := r.CompareAttributes(profile, current, instance, host.Personality)
@@ -1710,7 +1755,7 @@ func (r *HostReconciler) ReconcileResource(
 	client *gophercloud.ServiceClient,
 	instance *starlingxv1.Host,
 	profile *starlingxv1.HostProfileSpec,
-) (err error) {
+	request_namespace string) (err error) {
 	var host *hosts.Host
 	var inSync bool
 
@@ -1787,7 +1832,10 @@ func (r *HostReconciler) ReconcileResource(
 	}
 
 	// Check that the current configuration of a host matches the desired state.
-	err = r.ReconcileExistingHost(client, instance, profile, host)
+	// This also captures errors from platform network subreconciler separately
+	// thus enabling conditional handling of certain errors coming from
+	// platform network subreconciler in future.
+	err = r.ReconcileExistingHost(client, instance, profile, host, request_namespace)
 
 	inSync = err == nil
 	oldInSync := instance.Status.InSync
@@ -2223,7 +2271,7 @@ func (r *HostReconciler) Reconcile(ctx context.Context, request ctrl.Request) (r
 		logHost.V(2).Info("not storage node or in ceph primary group. continue")
 	}
 
-	err = r.ReconcileResource(platformClient, instance, profile)
+	err = r.ReconcileResource(platformClient, instance, profile, request.Namespace)
 	if err != nil {
 		return r.ReconcilerErrorHandler.HandleReconcilerError(request, err)
 	}

--- a/controllers/host/platformnetworks.go
+++ b/controllers/host/platformnetworks.go
@@ -5,72 +5,903 @@ package host
 
 import (
 	"context"
+	"fmt"
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/addresspools"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/networkAddressPools"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/networks"
 	perrors "github.com/pkg/errors"
 	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
 	utils "github.com/wind-river/cloud-platform-deployment-manager/common"
+	"github.com/wind-river/cloud-platform-deployment-manager/controllers/common"
+	cloudManager "github.com/wind-river/cloud-platform-deployment-manager/controllers/manager"
 	v1info "github.com/wind-river/cloud-platform-deployment-manager/platform"
 	"k8s.io/apimachinery/pkg/types"
 	kubeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
 )
 
-// TODO(sriram-gn): All platform network reconciliation workflows will be implemented here.
-// Currently we are just setting status of Reconciled / InSync of every platform network
-// and address pool instances to true just to acknowledge these objects are accepted.
-func (r *HostReconciler) ReconcilePlatformNetworks(client *gophercloud.ServiceClient, instance *starlingxv1.Host, profile *starlingxv1.HostProfileSpec, host *v1info.HostInfo) error {
+// makeRangeArray converts an array of range structs to an array of arrays where
+// the inner array contains two elements.  The first element is the range start
+// address and the second element is the range end address.  This is to align
+// with the system API formatting which represents a pair as an array of two
+// elements.
+func makeRangeArray(ranges []starlingxv1.AllocationRange) [][]string {
+	result := make([][]string, len(ranges))
+	for index, r := range ranges {
+		result[index] = []string{r.Start, r.End}
+	}
+
+	return result
+}
+
+// compareRangeArrays compares two range arrays and returns true if they are
+// equal.
+func compareRangeArrays(x, y [][]string) bool {
+	if len(x) != len(y) {
+		return false
+	}
+
+	count := 0
+	for _, o := range x {
+		for _, i := range y {
+			if strings.EqualFold(o[0], i[0]) && strings.EqualFold(o[1], i[1]) {
+				count++
+			}
+		}
+	}
+
+	return len(x) == count
+}
+
+func GetSystemAddrPool(client *gophercloud.ServiceClient, addrpool_instance *starlingxv1.AddressPool) (*addresspools.AddressPool, error) {
+	var found_addrpool *addresspools.AddressPool
+	addrpool_list, err := addresspools.ListAddressPools(client)
+	if err != nil {
+		logHost.Error(err, "failed to fetch addresspools from system")
+		return nil, err
+	}
+	// Preferably fetch the addresspool using UUID.
+	if addrpool_instance.Status.ID != nil {
+		found_addrpool = utils.GetSystemAddrPoolByUUID(addrpool_list, *addrpool_instance.Status.ID)
+		if found_addrpool != nil {
+			return found_addrpool, nil
+		}
+	}
+
+	found_addrpool = utils.GetSystemAddrPoolByName(addrpool_list, addrpool_instance.Name)
+
+	return found_addrpool, nil
+}
+
+func GetSystemNetwork(client *gophercloud.ServiceClient, network_instance *starlingxv1.PlatformNetwork) (*networks.Network, error) {
+	var found_network *networks.Network
+	network_list, err := networks.ListNetworks(client)
+	if err != nil {
+		logHost.Error(err, "failed to fetch networks from system")
+		return nil, err
+	}
+
+	// Preferably fetch the network using UUID.
+	if network_instance.Status.ID != nil {
+		found_network = utils.GetSystemNetworkByUUID(network_list, *network_instance.Status.ID)
+		if found_network != nil {
+			return found_network, nil
+		}
+	}
+
+	found_network = utils.GetSystemNetworkByName(network_list, network_instance.Name)
+
+	return found_network, nil
+}
+
+// ValidateAddressPool validates the addresspool spec specific to the network it will be associated with.
+// This is different from validations done in addresspool webhook which is more primitive in nature.
+// Result of this validation determines if at all reconciliation request has to be requeued.
+func (r *HostReconciler) ValidateAddressPool(
+	network_instance *starlingxv1.PlatformNetwork,
+	addrpool_instance *starlingxv1.AddressPool,
+	system_info *cloudManager.SystemInfo) bool {
+
+	spec := addrpool_instance.Spec
+	if network_instance.Spec.Type == cloudManager.OAMNetworkType {
+		if system_info.SystemType == cloudManager.SystemTypeAllInOne &&
+			system_info.SystemMode == cloudManager.SystemModeSimplex {
+
+			if spec.FloatingAddress == nil ||
+				spec.Gateway == nil {
+
+				msg := "The 'floatingAddress' and 'gateway' are mandatory parameters for oam address pool in AIO-SX."
+				logHost.Info(msg)
+				return false
+			}
+		} else {
+			// Multinode system
+			if spec.FloatingAddress == nil ||
+				spec.Gateway == nil ||
+				spec.Controller0Address == nil ||
+				spec.Controller1Address == nil {
+
+				msg := fmt.Sprintf(
+					"The %s are mandatory parameters for oam address pool in multinode setup.",
+					"'floatingAddress', 'gateway', 'controller0Address' and 'controller1Address'")
+				logHost.Info(msg)
+				return false
+			}
+		}
+	} else if network_instance.Spec.Type == cloudManager.MgmtNetworkType ||
+		network_instance.Spec.Type == cloudManager.ClusterHostNetworkType ||
+		network_instance.Spec.Type == cloudManager.PXEBootNetworkType {
+
+		if spec.FloatingAddress == nil ||
+			spec.Controller0Address == nil ||
+			spec.Controller1Address == nil {
+
+			msg := fmt.Sprintf(
+				"The %s are mandatory parameters for %s address pools.",
+				"'floatingAddress', 'controller0Address' and 'controller1Address'",
+				"management, cluster-host and pxeboot")
+			logHost.Info(msg)
+			return false
+		}
+
+		if network_instance.Spec.Type == cloudManager.PXEBootNetworkType && utils.IsIPv6(addrpool_instance.Spec.Subnet) {
+			log_msg := fmt.Sprintf(
+				"Network of type pxeboot only supports pool of family IPv4. AddressPool '%s' will not be reconciled.",
+				addrpool_instance.Name)
+			logHost.Info(log_msg)
+			return false
+		}
+	}
+
+	return true
+}
+
+func (r *HostReconciler) IsNetworkUpdateRequired(network_instance *starlingxv1.PlatformNetwork, system_network *networks.Network) (opts networks.NetworkOpts, result bool, uuid string) {
+	var delta strings.Builder
+
+	spec := network_instance.Spec
+
+	if system_network == nil || (network_instance.Name != system_network.Name) {
+		opts.Name = &network_instance.Name
+		delta.WriteString(fmt.Sprintf("\t+Name: %s\n", *opts.Name))
+		result = true
+	}
+
+	if system_network == nil || (spec.Type != system_network.Type) {
+		opts.Type = &spec.Type
+		delta.WriteString(fmt.Sprintf("\t+Type: %s\n", *opts.Type))
+		result = true
+	}
+
+	if system_network == nil || (spec.Dynamic != system_network.Dynamic) {
+		opts.Dynamic = &spec.Dynamic
+		delta.WriteString(fmt.Sprintf("\t+Dynamic: %v\n", *opts.Dynamic))
+		result = true
+	}
+
+	if system_network != nil {
+		uuid = system_network.UUID
+	}
+
+	deltaString := delta.String()
+	if deltaString != "" {
+		deltaString = "\n" + strings.TrimSuffix(deltaString, "\n")
+		logHost.Info(fmt.Sprintf("delta configuration:%s\n", deltaString))
+	}
+
+	network_instance.Status.Delta = deltaString
+	err := r.Client.Status().Update(context.TODO(), network_instance)
+	if err != nil {
+		logHost.Error(err, fmt.Sprintf("failed to update '%s' platform network delta", network_instance.Name))
+	}
+
+	return opts, result, uuid
+}
+
+func (r *HostReconciler) IsAddrPoolUpdateRequired(network_instance *starlingxv1.PlatformNetwork, addrpool_instance *starlingxv1.AddressPool, system_addrpool *addresspools.AddressPool) (opts addresspools.AddressPoolOpts, result bool, uuid string) {
+	var delta strings.Builder
+
+	if system_addrpool == nil || (addrpool_instance.Name != system_addrpool.Name) {
+		opts.Name = &addrpool_instance.Name
+		delta.WriteString(fmt.Sprintf("\t+Name: %s\n", *opts.Name))
+		result = true
+	}
+
+	spec := addrpool_instance.Spec
+
+	if system_addrpool == nil || !utils.IsIPAddressSame(spec.Subnet, system_addrpool.Network) {
+		opts.Network = &spec.Subnet
+		delta.WriteString(fmt.Sprintf("\t+Network: %s\n", *opts.Network))
+		result = true
+	}
+
+	if system_addrpool == nil || spec.Prefix != system_addrpool.Prefix {
+		opts.Prefix = &spec.Prefix
+		delta.WriteString(fmt.Sprintf("\t+Prefix: %d\n", *opts.Prefix))
+		result = true
+	}
+
+	if (system_addrpool == nil && spec.FloatingAddress != nil) ||
+		(spec.FloatingAddress != nil && !utils.IsIPAddressSame(*spec.FloatingAddress, system_addrpool.FloatingAddress)) {
+		opts.FloatingAddress = spec.FloatingAddress
+		delta.WriteString(fmt.Sprintf("\t+Floating Address: %s\n", *opts.FloatingAddress))
+		result = true
+	} else if spec.FloatingAddress == nil && system_addrpool != nil && system_addrpool.FloatingAddress != "" {
+		opts.FloatingAddress = spec.FloatingAddress
+		delta.WriteString(fmt.Sprintf("\t-Floating Address: %s\n", system_addrpool.FloatingAddress))
+		result = true
+	}
+
+	if (system_addrpool == nil && spec.Controller0Address != nil) ||
+		(spec.Controller0Address != nil && !utils.IsIPAddressSame(*spec.Controller0Address, system_addrpool.Controller0Address)) {
+		opts.Controller0Address = spec.Controller0Address
+		delta.WriteString(fmt.Sprintf("\t+Controller0 Address: %s\n", *opts.Controller0Address))
+		result = true
+	} else if spec.Controller0Address == nil && system_addrpool != nil && system_addrpool.Controller0Address != "" {
+		opts.Controller0Address = spec.Controller0Address
+		delta.WriteString(fmt.Sprintf("\t-Controller0 Address: %s\n", system_addrpool.Controller0Address))
+		result = true
+	}
+
+	if (system_addrpool == nil && spec.Controller1Address != nil) ||
+		(spec.Controller1Address != nil && !utils.IsIPAddressSame(*spec.Controller1Address, system_addrpool.Controller1Address)) {
+		opts.Controller1Address = spec.Controller1Address
+		delta.WriteString(fmt.Sprintf("\t+Controller1 Address: %s\n", *opts.Controller1Address))
+		result = true
+	} else if spec.Controller1Address == nil && system_addrpool != nil && system_addrpool.Controller1Address != "" {
+		opts.Controller1Address = spec.Controller1Address
+		delta.WriteString(fmt.Sprintf("\t-Controller1 Address: %s\n", system_addrpool.Controller1Address))
+		result = true
+	}
+
+	if network_instance.Spec.Type != networks.NetworkTypeOther {
+		// TODO(alegacy): There is a sysinv bug in how the gateway address
+		//  gets registered in the database.  It doesn't have a "name" and
+		//  so causes an exception when a related route is added.
+		if (system_addrpool == nil && spec.Gateway != nil) ||
+			(spec.Gateway != nil && system_addrpool.Gateway == nil) ||
+			(spec.Gateway != nil && !utils.IsIPAddressSame(*spec.Gateway, *system_addrpool.Gateway)) {
+			opts.Gateway = spec.Gateway
+			delta.WriteString(fmt.Sprintf("\t+Gateway: %s\n", *opts.Gateway))
+			result = true
+		} else if spec.Gateway == nil && system_addrpool != nil && system_addrpool.Gateway != nil {
+			opts.Gateway = spec.Gateway
+			delta.WriteString(fmt.Sprintf("\t-Gateway Address: %s\n", *system_addrpool.Gateway))
+			result = true
+		}
+	}
+
+	if system_addrpool == nil || (spec.Allocation.Order != nil && *spec.Allocation.Order != system_addrpool.Order) {
+		opts.Order = spec.Allocation.Order
+		delta.WriteString(fmt.Sprintf("\t+Order: %s\n", *opts.Order))
+		result = true
+	}
+
+	if len(spec.Allocation.Ranges) > 0 {
+		ranges := makeRangeArray(spec.Allocation.Ranges)
+		if system_addrpool == nil || !compareRangeArrays(ranges, system_addrpool.Ranges) {
+			opts.Ranges = &ranges
+			delta.WriteString(fmt.Sprintf("\t+Ranges: %s\n", *opts.Ranges))
+			result = true
+		}
+	}
+
+	if system_addrpool != nil {
+		uuid = system_addrpool.ID
+	}
+
+	deltaString := delta.String()
+	if deltaString != "" {
+		deltaString = "\n" + strings.TrimSuffix(deltaString, "\n")
+		logHost.Info(fmt.Sprintf("delta configuration:%s\n", deltaString))
+	}
+
+	addrpool_instance.Status.Delta = deltaString
+	err := r.Client.Status().Update(context.TODO(), addrpool_instance)
+	if err != nil {
+		logHost.Error(err, fmt.Sprintf("failed to update '%s' addresspool delta", addrpool_instance.Name))
+	}
+
+	return opts, result, uuid
+}
+
+func (r *HostReconciler) ReconcileAddrPoolResource(client *gophercloud.ServiceClient, network_instance *starlingxv1.PlatformNetwork, addrpool_instance *starlingxv1.AddressPool, system_info *cloudManager.SystemInfo) (error, *bool, *bool) {
+
+	system_addrpool, err := GetSystemAddrPool(client, addrpool_instance)
+	if err != nil {
+		return err, nil, nil
+	}
+
+	r.UpdateAddrPoolUUID(addrpool_instance, system_addrpool)
+
+	opts, update_required, uuid := r.IsAddrPoolUpdateRequired(network_instance, addrpool_instance, system_addrpool)
+
+	err, should_reconcile := r.ShouldReconcile(client, network_instance, addrpool_instance, update_required, uuid)
+	if err != nil {
+		return err, nil, nil
+	}
+
+	validation_result := r.ValidateAddressPool(network_instance, addrpool_instance, system_info)
+
+	if should_reconcile && validation_result && update_required {
+		err := r.CreateOrUpdateAddrPools(client, opts, uuid, addrpool_instance)
+		if err == nil {
+			// Make sure network UUID is synchronized
+			system_addrpool, err = GetSystemAddrPool(client, addrpool_instance)
+			if err != nil {
+				return err, nil, nil
+			}
+			r.UpdateAddrPoolUUID(addrpool_instance, system_addrpool)
+		}
+		return err, &should_reconcile, &validation_result
+	} else if !validation_result {
+		// These errors are to be corrected by the user.
+		// No use requeuing the request until user corrects it.
+
+		// Validation applies for addresspools to be created in the
+		// context of network but not for addresspool that already exists
+		// as per spec.
+		validation_result = validation_result || !update_required
+		return nil, &should_reconcile, &validation_result
+	} else if update_required {
+		msg := fmt.Sprintf(
+			"There is delta between applied spec and system for addresspool '%s'",
+			addrpool_instance.Name)
+		logHost.Info(msg)
+		err := perrors.New(msg)
+		return err, &should_reconcile, &validation_result
+	}
+
+	return nil, &should_reconcile, &validation_result
+
+}
+
+// Synchronize AddressPoolStatus.ID with correct UUID
+// of the addresspool as reported by the system.
+func (r *HostReconciler) UpdateAddrPoolUUID(addrpool_instance *starlingxv1.AddressPool, system_addrpool *addresspools.AddressPool) {
+	update_required := false
+	if system_addrpool != nil {
+		if addrpool_instance.Status.ID == nil {
+			update_required = true
+			addrpool_instance.Status.ID = &system_addrpool.ID
+		} else {
+			// Update stray UUID however this may have been caused.
+			if *addrpool_instance.Status.ID != system_addrpool.ID {
+				update_required = true
+				addrpool_instance.Status.ID = &system_addrpool.ID
+			}
+		}
+	}
+
+	if update_required {
+		err := r.Client.Status().Update(context.TODO(), addrpool_instance)
+		if err != nil {
+			// Logging the error should be enough, failure to update addrpool instance
+			// UUID should not block rest of the reconciliation since we
+			// always fallback to Name based addrpool instance lookup in case
+			// UUID is not updated / not valid.
+			logHost.Error(err, fmt.Sprintf("failed to update '%s' addresspool UUID", addrpool_instance.Name))
+		}
+	}
+}
+
+// Synchronize PlatformNetworkStatus.ID with correct UUID
+// of the network as reported by the system.
+func (r *HostReconciler) UpdateNetworkUUID(network_instance *starlingxv1.PlatformNetwork, system_network *networks.Network) {
+	update_required := false
+	if system_network != nil {
+		if network_instance.Status.ID == nil {
+			update_required = true
+			network_instance.Status.ID = &system_network.UUID
+		} else {
+			// Update stray UUID however this may have been caused.
+			if *network_instance.Status.ID != system_network.UUID {
+				update_required = true
+				network_instance.Status.ID = &system_network.UUID
+			}
+		}
+	}
+
+	if update_required {
+		err := r.Client.Status().Update(context.TODO(), network_instance)
+		if err != nil {
+			// Logging the error should be enough, failure to update network
+			// UUID should not block rest of the reconciliation since we
+			// always fallback to Name based platform network lookup in case
+			// UUID is not updated / not valid.
+			logHost.Error(err, fmt.Sprintf("failed to update '%s' platform network UUID", network_instance.Name))
+		}
+	}
+}
+
+func (r *HostReconciler) IsReconfiguration(client *gophercloud.ServiceClient, network_instance *starlingxv1.PlatformNetwork, addrpool_instance *starlingxv1.AddressPool) (error, bool) {
+	err, system_network, system_network_addrpools, addrpool_list := r.GetAllNetworkAddressPoolData(
+		client, network_instance)
+	if err != nil {
+		return err, false
+	}
+
+	if system_network != nil {
+		network_addrpool, associated_addrpool := GetAssociatedNetworkAddrPool(
+			system_network,
+			addrpool_instance,
+			system_network_addrpools,
+			addrpool_list)
+
+		if network_addrpool != nil && associated_addrpool != nil {
+			// There exists an associated addresspool from same IP family.
+			// This is an attempt to reconfigure the platform network.
+			return nil, true
+		}
+	}
+
+	return nil, false
+}
+
+// ShouldReconcile is a very important function that really controls the reconciliation
+// behaviour of network and associated addresspools. Note that parameters 'update_required'
+// and 'uuid' refers to address pool update_required and address pool uuid when called from
+// ReconcileAddrPoolResource function.
+func (r *HostReconciler) ShouldReconcile(client *gophercloud.ServiceClient, network_instance *starlingxv1.PlatformNetwork, addrpool_instance *starlingxv1.AddressPool, update_required bool, uuid string) (error, bool) {
+	if network_instance.Status.DeploymentScope == cloudManager.ScopeBootstrap {
+		switch network_instance.Spec.Type {
+		case cloudManager.OAMNetworkType,
+			cloudManager.MgmtNetworkType,
+			cloudManager.AdminNetworkType:
+			// Block both fresh configuration / reconfiguration of networks / addrpools
+			// such as oam / mgmt / admin in day-1.
+			return nil, false
+		default:
+			// Allow fresh configuration of networks / addrpools other than
+			// oam / mgmt / admin in day-1 but not reconfiguration.
+			if addrpool_instance != nil {
+				err, is_reconfig := r.IsReconfiguration(client, network_instance, addrpool_instance)
+				if err != nil {
+					return err, false
+				}
+				if !is_reconfig {
+					return nil, true
+				}
+			} else {
+				// for networks
+				if uuid == "" {
+					return nil, true
+				}
+			}
+
+		}
+	}
+
+	// Unless explicitly specified that reconciliation is allowed
+	// for given instances of platform network and address pools
+	// return false.
+	return nil, false
+}
+
+func (r *HostReconciler) CreateOrUpdateNetworks(client *gophercloud.ServiceClient, opts networks.NetworkOpts, uuid string, network_instance *starlingxv1.PlatformNetwork) error {
+	if uuid == "" {
+		_, err := networks.Create(client, opts).Extract()
+		if err != nil {
+			logHost.Error(err, fmt.Sprintf("failed to create platform network: %s", common.FormatStruct(opts)))
+			return err
+		}
+
+		r.ReconcilerEventLogger.NormalEvent(network_instance, common.ResourceCreated,
+			fmt.Sprintf("platform network '%s' has been created", *opts.Name))
+	} else {
+		_, err := networks.Update(client, uuid, opts).Extract()
+		if err != nil {
+			logHost.Error(err, fmt.Sprintf("failed to update platform network: %s", common.FormatStruct(opts)))
+			return err
+		}
+
+		r.ReconcilerEventLogger.NormalEvent(network_instance, common.ResourceUpdated,
+			fmt.Sprintf("platform network '%s' has been updated", *opts.Name))
+	}
+
+	return nil
+}
+
+func (r *HostReconciler) CreateOrUpdateAddrPools(client *gophercloud.ServiceClient, opts addresspools.AddressPoolOpts, uuid string, addrpool_instance *starlingxv1.AddressPool) error {
+	if uuid == "" {
+		_, err := addresspools.Create(client, opts).Extract()
+		if err != nil {
+			logHost.Error(err, fmt.Sprintf("failed to create addresspool: %s", common.FormatStruct(opts)))
+			return err
+		}
+
+		r.ReconcilerEventLogger.NormalEvent(addrpool_instance, common.ResourceCreated,
+			fmt.Sprintf("addresspool '%s' has been created", *opts.Name))
+	} else {
+		_, err := addresspools.Update(client, uuid, opts).Extract()
+		if err != nil {
+			logHost.Error(err, fmt.Sprintf("failed to update addresspool: %s", common.FormatStruct(opts)))
+			return err
+		}
+
+		r.ReconcilerEventLogger.NormalEvent(addrpool_instance, common.ResourceUpdated,
+			fmt.Sprintf("addresspool '%s' has been updated", *opts.Name))
+	}
+
+	return nil
+}
+
+func GetAssociatedNetworkAddrPool(
+	system_network *networks.Network,
+	addrpool_instance *starlingxv1.AddressPool,
+	system_network_addrpools []networkAddressPools.NetworkAddressPool,
+	addrpool_list []addresspools.AddressPool) (*networkAddressPools.NetworkAddressPool, *addresspools.AddressPool) {
+
+	for _, network_addrpool := range system_network_addrpools {
+		if network_addrpool.NetworkUUID == system_network.UUID {
+			addrpool := utils.GetSystemAddrPoolByUUID(addrpool_list, network_addrpool.AddressPoolUUID)
+			if addrpool != nil {
+				if utils.IsIPv4(addrpool.Network) == utils.IsIPv4(addrpool_instance.Spec.Subnet) {
+					// If the addresspool is from same network family
+					// return it as associated network-addresspool object.
+					// A network can have at most two network-addresspools,
+					// one from each network family ie. IPv4 & IPv6.
+					return &network_addrpool, addrpool
+				}
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func (r *HostReconciler) GetAllNetworkAddressPoolData(
+	client *gophercloud.ServiceClient,
+	network_instance *starlingxv1.PlatformNetwork) (
+	error,
+	*networks.Network,
+	[]networkAddressPools.NetworkAddressPool,
+	[]addresspools.AddressPool) {
+
+	system_network, err := GetSystemNetwork(client, network_instance)
+	if err != nil {
+		return err, nil, nil, nil
+	}
+
+	system_network_addrpools, err := networkAddressPools.ListNetworkAddressPools(client)
+	if err != nil {
+		logHost.Error(err, "failed to fetch network-addresspools from system")
+		return err, nil, nil, nil
+	}
+
+	addrpool_list, err := addresspools.ListAddressPools(client)
+	if err != nil {
+		logHost.Error(err, "failed to fetch addresspools from system")
+		return err, nil, nil, nil
+	}
+
+	return nil, system_network, system_network_addrpools, addrpool_list
+
+}
+
+func (r *HostReconciler) UpdateNetworkAddrPools(client *gophercloud.ServiceClient, network_instance *starlingxv1.PlatformNetwork, addrpool_instance *starlingxv1.AddressPool) error {
+
+	err, system_network, system_network_addrpools, addrpool_list := r.GetAllNetworkAddressPoolData(
+		client, network_instance)
+	if err != nil {
+		return err
+	}
+
+	if system_network == nil {
+		// No point in continuing if there is no network already
+		return nil
+	}
+
+	system_addrpool, err := GetSystemAddrPool(client, addrpool_instance)
+	if err != nil {
+		return err
+	} else if system_addrpool == nil {
+		// No point in continuing if there is no addresspool already
+		return nil
+	}
+
+	network_addrpool, associated_addrpool := GetAssociatedNetworkAddrPool(
+		system_network,
+		addrpool_instance,
+		system_network_addrpools,
+		addrpool_list)
+
+	if network_addrpool != nil && associated_addrpool != nil {
+		if associated_addrpool.ID != system_addrpool.ID {
+			// Delete the associated network addrpool since it's not
+			// linked to same address pool as the address pool spec.
+			err := networkAddressPools.Delete(client, network_addrpool.UUID).ExtractErr()
+			if err != nil {
+				logHost.Error(err, "failed to delete associated network-addresspool")
+				return err
+			} else {
+				log_msg := fmt.Sprintf(
+					"Deleted network-addresspool object %s - %s",
+					network_addrpool.NetworkName,
+					network_addrpool.AddressPoolName)
+
+				r.ReconcilerEventLogger.NormalEvent(network_instance, common.ResourceDeleted,
+					log_msg)
+			}
+		} else {
+			// No action required there is already network-addresspool
+			// association created for given network and addresspool
+			log_msg := fmt.Sprintf(
+				"Found network-addresspool with %s - %s. No need to delete/recreate network-addresspool association.",
+				network_addrpool.NetworkName,
+				network_addrpool.AddressPoolName)
+
+			logHost.V(2).Info(log_msg)
+
+			return nil
+		}
+	}
+
+	opts := networkAddressPools.NetworkAddressPoolOpts{}
+	opts.NetworkUUID = &system_network.UUID
+	opts.AddressPoolUUID = &system_addrpool.ID
+
+	_, err = networkAddressPools.Create(client, opts).Extract()
+
+	if err == nil {
+		msg := fmt.Sprintf("Created new network-addrpool association %s - %s", system_network.Name, system_addrpool.Name)
+
+		r.ReconcilerEventLogger.NormalEvent(network_instance, common.ResourceCreated,
+			msg)
+	} else {
+		logHost.Error(err, "there was an error creating new network-addresspool.")
+	}
+
+	return err
+
+}
+
+func (r *HostReconciler) UpdateNetworkReconciliationStatus(
+	network_instance *starlingxv1.PlatformNetwork,
+	is_reconciled bool,
+	should_reconcile bool) error {
+
+	oldInSync := network_instance.Status.InSync
+
+	if network_instance.Status.DeploymentScope == cloudManager.ScopeBootstrap {
+		if !should_reconcile {
+			// Prevents raising alarm if configuration of given network type
+			// is unsupported in day-1 and system is out-of-sync.
+			// Insync will serve as reconciliation indicator in this case.
+			network_instance.Status.Reconciled = true
+		} else {
+			network_instance.Status.Reconciled = is_reconciled
+		}
+		network_instance.Status.InSync = is_reconciled
+	}
+
+	err := r.Client.Status().Update(context.TODO(), network_instance)
+	if err != nil {
+		logHost.Error(err, fmt.Sprintf("failed to update '%s' platform network status", network_instance.Name))
+		return err
+	}
+
+	if oldInSync != network_instance.Status.InSync {
+		r.ReconcilerEventLogger.NormalEvent(network_instance, common.ResourceUpdated,
+			"%s network's synchronization has changed to: %t", network_instance.Name, network_instance.Status.InSync)
+	}
+
+	return nil
+}
+
+func (r *HostReconciler) UpdateAddrPoolReconciliationStatus(
+	network_instance *starlingxv1.PlatformNetwork,
+	addrpool_instance *starlingxv1.AddressPool,
+	is_reconciled bool,
+	should_reconcile bool) error {
+
+	oldInSync := addrpool_instance.Status.InSync
+
+	// AddressPool doesn't have deploymentScope by design.
+	// It inherits deploymentScope of associated network.
+	if network_instance.Status.DeploymentScope == cloudManager.ScopeBootstrap {
+		if !should_reconcile {
+			// Prevents raising alarm if configuration of given network type
+			// is unsupported in day-1 and system is out-of-sync.
+			// Insync will serve as reconciliation indicator in this case.
+			addrpool_instance.Status.Reconciled = true
+		} else {
+			addrpool_instance.Status.Reconciled = is_reconciled
+		}
+		addrpool_instance.Status.InSync = is_reconciled
+	}
+
+	err := r.Client.Status().Update(context.TODO(), addrpool_instance)
+	if err != nil {
+		logHost.Error(err, fmt.Sprintf("failed to update '%s' addresspool status", addrpool_instance.Name))
+		return err
+	}
+
+	if oldInSync != addrpool_instance.Status.InSync {
+		r.ReconcilerEventLogger.NormalEvent(addrpool_instance, common.ResourceUpdated,
+			"%s addresspool's synchronization has changed to: %t", addrpool_instance.Name, addrpool_instance.Status.InSync)
+	}
+
+	return nil
+}
+
+func (r *HostReconciler) ReconcileNetworkResource(client *gophercloud.ServiceClient, network_instance *starlingxv1.PlatformNetwork) (error, *bool) {
+
+	system_network, err := GetSystemNetwork(client, network_instance)
+	if err != nil {
+		return err, nil
+	}
+
+	r.UpdateNetworkUUID(network_instance, system_network)
+
+	opts, update_required, uuid := r.IsNetworkUpdateRequired(network_instance, system_network)
+
+	err, should_reconcile := r.ShouldReconcile(client, network_instance, nil, update_required, uuid)
+	if err != nil {
+		return err, nil
+	}
+
+	if should_reconcile && update_required {
+		err := r.CreateOrUpdateNetworks(client, opts, uuid, network_instance)
+		if err == nil {
+			// Make sure network UUID is synchronized
+			system_network, err = GetSystemNetwork(client, network_instance)
+			if err != nil {
+				return err, nil
+			}
+			r.UpdateNetworkUUID(network_instance, system_network)
+		}
+		return err, &should_reconcile
+	} else if update_required {
+		err_msg := fmt.Sprintf(
+			"There is delta between applied spec and system for platform network '%s'",
+			network_instance.Name)
+		err := perrors.New(err_msg)
+		return err, &should_reconcile
+	}
+
+	return nil, &should_reconcile
+
+}
+
+func (r *HostReconciler) ReconcileNetworkAndAddressPools(
+	client *gophercloud.ServiceClient,
+	network_instance *starlingxv1.PlatformNetwork,
+	addrpool_instance *starlingxv1.AddressPool,
+	system_info *cloudManager.SystemInfo) error {
+
+	err, should_reconcile := r.ReconcileNetworkResource(client, network_instance)
+	if err != nil && should_reconcile == nil {
+		// Some other error occured not related to reconciliation.
+		// Eg. error listing networks by querying the system.
+		// Request will be requeued.
+		return err
+	}
+
+	is_reconciled := err == nil
+	err_status := r.UpdateNetworkReconciliationStatus(
+		network_instance,
+		is_reconciled,
+		*should_reconcile)
+
+	if *should_reconcile && err != nil {
+		//Reconciliation request will be requeued
+		return err
+	} else if err_status != nil {
+		//Reconciliation request will be requeued
+		return err_status
+	}
+
+	err, should_reconcile, validation_result := r.ReconcileAddrPoolResource(client, network_instance, addrpool_instance, system_info)
+	if err != nil && should_reconcile == nil {
+		// Some other error occured not related to reconciliation.
+		// Eg. error listing networks by querying the system.
+		// Request will be requeued.
+		return err
+	}
+
+	is_reconciled = err == nil && *validation_result
+
+	err_status = r.UpdateAddrPoolReconciliationStatus(
+		network_instance,
+		addrpool_instance,
+		is_reconciled,
+		*should_reconcile)
+
+	// Update network-addresspool only if addresspool has been reconciled.
+	if *should_reconcile && is_reconciled {
+		logHost.V(2).Info(
+			fmt.Sprintf("Updating network-addresspool association for network '%s' and addrpool '%s'",
+				network_instance.Name, addrpool_instance.Name))
+		update_err := r.UpdateNetworkAddrPools(client, network_instance, addrpool_instance)
+		if update_err != nil {
+			return update_err
+		}
+	}
+
+	if *should_reconcile && err != nil {
+		//Reconciliation request will be requeued
+		return err
+	} else if err_status != nil {
+		//Reconciliation request will be requeued
+		return err_status
+	}
+
+	return nil
+}
+
+func (r *HostReconciler) ReconcilePlatformNetworkBootstrap(
+	client *gophercloud.ServiceClient,
+	host_instance *starlingxv1.Host,
+	network_instance *starlingxv1.PlatformNetwork,
+	addrpool_instance *starlingxv1.AddressPool,
+	system_info *cloudManager.SystemInfo) error {
+
+	err := r.ReconcileNetworkAndAddressPools(client, network_instance, addrpool_instance, system_info)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func (r *HostReconciler) ReconcilePlatformNetworkAndAddrPoolResource(
+	client *gophercloud.ServiceClient,
+	host_instance *starlingxv1.Host,
+	network_instance *starlingxv1.PlatformNetwork,
+	addrpool_instance *starlingxv1.AddressPool,
+	system_info *cloudManager.SystemInfo) error {
+
+	if network_instance.Status.DeploymentScope == cloudManager.ScopeBootstrap {
+		return r.ReconcilePlatformNetworkBootstrap(client, host_instance, network_instance, addrpool_instance, system_info)
+	}
+	return nil
+
+}
+
+func (r *HostReconciler) ReconcilePlatformNetworks(client *gophercloud.ServiceClient, instance *starlingxv1.Host, profile *starlingxv1.HostProfileSpec, host *v1info.HostInfo, system_info *cloudManager.SystemInfo) []error {
+	var errs []error
 	if !utils.IsReconcilerEnabled(utils.HostPlatformNetwork) {
 		return nil
 	}
 
-	addrpools := &starlingxv1.AddressPoolList{}
-	platform_networks := &starlingxv1.PlatformNetworkList{}
 	opts := kubeclient.ListOptions{}
 	opts.Namespace = instance.Namespace
-	err := r.List(context.TODO(), addrpools, &opts)
-	if err != nil {
-		err = perrors.Wrap(err, "failed to list address pools")
-		return err
-	}
-
-	err = r.List(context.TODO(), platform_networks, &opts)
+	platform_networks := &starlingxv1.PlatformNetworkList{}
+	err := r.List(context.TODO(), platform_networks, &opts)
 	if err != nil {
 		err = perrors.Wrap(err, "failed to list platform networks")
-		return err
+		errs = append(errs, err)
 	}
 
-	// TODO(sriram-gn): Remove this after implementing actual reconciliation workflows.
-	for _, addrpool := range addrpools.Items {
-		addrpool_instance := &starlingxv1.AddressPool{}
-		addrpool_namespace := types.NamespacedName{Namespace: addrpool.ObjectMeta.Namespace, Name: addrpool.ObjectMeta.Name}
-		err := r.Client.Get(context.TODO(), addrpool_namespace, addrpool_instance)
-		if err != nil {
-			logHost.Error(err, "Failed to get addrpool resource from namespace")
-		}
-		addrpool_instance.Status.InSync = true
-		addrpool_instance.Status.Reconciled = true
-		err = r.Client.Status().Update(context.TODO(), addrpool_instance)
-		if err != nil {
-			logHost.Error(err, "Failed to update addrpool status")
-			return err
-		}
-	}
-
-	// TODO(sriram-gn): Remove this after implementing actual reconciliation workflows.
 	for _, platform_network := range platform_networks.Items {
 		platform_network_instance := &starlingxv1.PlatformNetwork{}
 		platform_network_namespace := types.NamespacedName{Namespace: platform_network.ObjectMeta.Namespace, Name: platform_network.ObjectMeta.Name}
 		err := r.Client.Get(context.TODO(), platform_network_namespace, platform_network_instance)
 		if err != nil {
 			logHost.Error(err, "Failed to get platform network resource from namespace")
+			errs = append(errs, err)
 		}
-		platform_network_instance.Status.InSync = true
-		platform_network_instance.Status.Reconciled = true
-		err = r.Client.Status().Update(context.TODO(), platform_network_instance)
-		if err != nil {
-			logHost.Error(err, "Failed to update platform_network_instance status")
-			return err
+
+		for _, addrpool_name := range platform_network_instance.Spec.AssociatedAddressPools {
+			addrpool_instance := &starlingxv1.AddressPool{}
+			addrpool_namespace := types.NamespacedName{
+				Namespace: platform_network.ObjectMeta.Namespace,
+				Name:      addrpool_name}
+			err := r.Client.Get(context.TODO(), addrpool_namespace, addrpool_instance)
+			if err != nil {
+				logHost.Error(err, "Failed to get addrpool resource from namespace")
+				errs = append(errs, err)
+			} else {
+				err = r.ReconcilePlatformNetworkAndAddrPoolResource(client, instance, platform_network_instance, addrpool_instance, system_info)
+				if err != nil {
+					errs = append(errs, err)
+				}
+			}
 		}
 	}
 
-	return nil
+	return errs
 }

--- a/controllers/manager/manager.go
+++ b/controllers/manager/manager.go
@@ -9,8 +9,10 @@ import (
 	"strconv"
 	"sync"
 
+	"fmt"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/hosts"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/system"
 	"github.com/gophercloud/gophercloud/starlingx/nfv/v1/systemconfigupdate"
 	perrors "github.com/pkg/errors"
 	v1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
@@ -22,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"strings"
 )
 
 var log = logf.Log.WithName("manager")
@@ -53,10 +56,12 @@ const (
 // Note that the AdminNetworkType is being referenced from host controller as well
 // as platform network controller.
 const (
-	OAMNetworkType   = "oam"
-	MgmtNetworkType  = "mgmt"
-	AdminNetworkType = "admin"
-	MgmtAddrPoolName = "management"
+	OAMNetworkType         = "oam"
+	MgmtNetworkType        = "mgmt"
+	AdminNetworkType       = "admin"
+	MgmtAddrPoolName       = "management"
+	PXEBootNetworkType     = "pxeboot"
+	ClusterHostNetworkType = "cluster-host"
 )
 
 const (
@@ -98,6 +103,8 @@ type CloudManager interface {
 	GetSystemType(namespace string) SystemType
 	StartMonitor(monitor *Monitor, message string) error
 	CancelMonitor(object client.Object)
+	GetActiveHost(namespace string, client *gophercloud.ServiceClient) (*v1.Host, error)
+	GetSystemInfo(namespace string, client *gophercloud.ServiceClient) (*SystemInfo, error)
 
 	// Strategy related methods
 	SetResourceInfo(resourcetype string, personality string, resourcename string, reconciled bool, required string)
@@ -118,6 +125,8 @@ type CloudManager interface {
 	GetStrategyRetryCount() (int, error)
 	IsPlatformNetworkReconciling() bool
 	SetPlatformNetworkReconciling(status bool)
+	IsNotifyingActiveHost() bool
+	SetNotifyingActiveHost(status bool)
 
 	// gophercloud
 	GcShow(c *gophercloud.ServiceClient) (*systemconfigupdate.SystemConfigUpdate, error)
@@ -146,6 +155,11 @@ type SystemNamespace struct {
 	client     *gophercloud.ServiceClient
 	ready      bool
 	systemType SystemType
+}
+
+type SystemInfo struct {
+	SystemType SystemType
+	SystemMode SystemMode
 }
 
 // Strategy related consts and defines
@@ -195,6 +209,7 @@ type PlatformManager struct {
 	strategyStatus                  *StrategyStatus
 	vimClient                       *gophercloud.ServiceClient
 	PlatformNetworkReconcilerStatus bool
+	NotifyActiveHostStatus          bool
 	GetPlatformClientImpl           func(namespace string) *gophercloud.ServiceClient
 }
 
@@ -343,6 +358,9 @@ var systemDependencies = []schema.GroupVersionKind{
 		Kind:    v1.KindPlatformNetwork},
 	{Group: v1.Group,
 		Version: v1.Version,
+		Kind:    v1.KindAddressPool},
+	{Group: v1.Group,
+		Version: v1.Version,
 		Kind:    v1.KindDataNetwork},
 	{Group: v1.Group,
 		Version: v1.Version,
@@ -369,7 +387,7 @@ func (m *PlatformManager) notifyControllers(namespace string, gvkList []schema.G
 
 		for _, obj := range objects.Items {
 			switch obj.GetKind() {
-			case v1.KindHost, v1.KindHostProfile, v1.KindPlatformNetwork, v1.KindDataNetwork, v1.KindPTPInstance, v1.KindPTPInterface:
+			case v1.KindHost, v1.KindHostProfile, v1.KindPlatformNetwork, v1.KindAddressPool, v1.KindDataNetwork, v1.KindPTPInstance, v1.KindPTPInterface:
 				annotations := obj.GetAnnotations()
 				if annotations == nil {
 					annotations = make(map[string]string)
@@ -591,6 +609,61 @@ func (m *PlatformManager) CancelMonitor(object client.Object) {
 		monitor.Stop()
 		delete(m.monitors, key)
 	}
+}
+
+func (m *PlatformManager) GetSystemInfo(namespace string, client *gophercloud.ServiceClient) (*SystemInfo, error) {
+	system_info := &SystemInfo{}
+
+	default_system, err := system.GetDefaultSystem(client)
+	if err != nil {
+		log.Error(err, "failed to query host list")
+		return system_info, err
+	}
+
+	if default_system.SystemMode == "" || default_system.SystemType == "" {
+		err_msg := "Expected values for both 'system_mode' and 'system_type' from system API"
+		err = perrors.New(err_msg)
+		log.Error(err, "unexpected API response")
+		return system_info, err
+	}
+
+	system_info.SystemMode = SystemMode(strings.ToLower(default_system.SystemMode))
+	system_info.SystemType = SystemType(strings.ToLower(default_system.SystemType))
+
+	return system_info, nil
+
+}
+
+func (m *PlatformManager) GetActiveHost(namespace string, client *gophercloud.ServiceClient) (*v1.Host, error) {
+	host_instance := &v1.Host{}
+
+	host_list, err := hosts.ListHosts(client)
+	if err != nil {
+		log.Error(err, "failed to query host list")
+		return host_instance, err
+	}
+
+	for _, host := range host_list {
+		if host.Capabilities.Personality != nil {
+			if *host.Capabilities.Personality == "Controller-Active" {
+				host_namespace := types.NamespacedName{Namespace: namespace, Name: host.Hostname}
+				err = m.GetClient().Get(context.TODO(), host_namespace, host_instance)
+				if err != nil {
+					log.Error(err, fmt.Sprintf("failed to fetch host instance: %s", host.Hostname))
+					return host_instance, err
+				}
+				break
+			}
+		}
+	}
+
+	if host_instance.Name == "" {
+		err = perrors.New("None of the controllers are active at this point")
+		return host_instance, err
+	}
+
+	return host_instance, nil
+
 }
 
 func (m *PlatformManager) StartStrategyMonitor() {
@@ -816,6 +889,18 @@ func (m *PlatformManager) SetPlatformNetworkReconciling(status bool) {
 	m.lock.Lock()
 	defer func() { m.lock.Unlock() }()
 	m.PlatformNetworkReconcilerStatus = status
+}
+
+func (m *PlatformManager) IsNotifyingActiveHost() bool {
+	m.lock.Lock()
+	defer func() { m.lock.Unlock() }()
+	return m.NotifyActiveHostStatus
+}
+
+func (m *PlatformManager) SetNotifyingActiveHost(status bool) {
+	m.lock.Lock()
+	defer func() { m.lock.Unlock() }()
+	m.NotifyActiveHostStatus = status
 }
 
 // GcCreate is wrapper function for systemconfigupdate Create

--- a/controllers/manager/monitor_test.go
+++ b/controllers/manager/monitor_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gophercloud/gophercloud/starlingx/nfv/v1/systemconfigupdate"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	v1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -351,6 +352,12 @@ func (m *Dummymanager) StartMonitor(monitor *Monitor, message string) error {
 func (m *Dummymanager) CancelMonitor(object client.Object) {
 
 }
+func (m *Dummymanager) GetActiveHost(namespace string, client *gophercloud.ServiceClient) (*v1.Host, error) {
+	return nil, nil
+}
+func (m *Dummymanager) GetSystemInfo(namespace string, client *gophercloud.ServiceClient) (*SystemInfo, error) {
+	return nil, nil
+}
 func (m *Dummymanager) SetResourceInfo(resourcetype string, personality string, resourcename string, reconciled bool, required string) {
 
 }
@@ -408,6 +415,12 @@ func (m *Dummymanager) IsPlatformNetworkReconciling() bool {
 	return false
 }
 func (m *Dummymanager) SetPlatformNetworkReconciling(status bool) {
+
+}
+func (m *Dummymanager) IsNotifyingActiveHost() bool {
+	return false
+}
+func (m *Dummymanager) SetNotifyingActiveHost(status bool) {
 
 }
 func (m *Dummymanager) GcShow(c *gophercloud.ServiceClient) (*systemconfigupdate.SystemConfigUpdate, error) {

--- a/go.mod
+++ b/go.mod
@@ -92,4 +92,4 @@ require (
 )
 
 // replace github.com/gophercloud/gophercloud => ./external/gophercloud
-replace github.com/gophercloud/gophercloud => github.com/Wind-River/gophercloud v0.0.0-20240327184120-524e1aa02d32
+replace github.com/gophercloud/gophercloud => github.com/Wind-River/gophercloud v0.0.0-20240506170703-89c22d948e40

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMo
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/Wind-River/gophercloud v0.0.0-20240327184120-524e1aa02d32 h1:ilWhLGRtkk/H0gjEoMCfjX8If65hVdw42RLHhCiacCI=
-github.com/Wind-River/gophercloud v0.0.0-20240327184120-524e1aa02d32/go.mod h1:vVDhU9TrWNFfORJV7Tvx7UXsu/ImDlVeHhQCdrbzLEA=
+github.com/Wind-River/gophercloud v0.0.0-20240506170703-89c22d948e40 h1:lzfnWPZG2KHJOACRUHkUrbmAEDckGvUi9KhdD2/dWcI=
+github.com/Wind-River/gophercloud v0.0.0-20240506170703-89c22d948e40/go.mod h1:vVDhU9TrWNFfORJV7Tvx7UXsu/ImDlVeHhQCdrbzLEA=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=


### PR DESCRIPTION
This commit enables all of Day-1 workflows related to platform network reconciliation.
Apart from that, there are certain mechanisms built in to handle notifying host controller whenever an instance of platform network resource and address pool resource is created or updated in a non-blocking way while taking care of potential issues due to concurrent operations.

Test Cases:
 1. PASS - Verify successful unlock of AIO-SX in Day-1 without platformnetwork / addresspool instances.
 2. PASS - Verify successful Day-2 operation on AIO-SX host without platformnetwork / addresspool instances.
 3. PASS - Verify reconfiguration is blocked for all networks in Day-1.
 4. PASS - Verify fresh configuration (even partial ie. single new stack) is successful for all networks other than oam / admin / mgmt.
 5. PASS - Verify fresh configuration (even partial) is blocked for networks such as oam / admin / mgmt.
 6. PASS - Verify IPv6 addresspool associated with pxeboot fails to reconcile without requeuing the request despite fresh configuration.
 7. PASS - Verify oam fails to reconcile if either 'floatingAddress' or 'gateway' is missing from the addresspool spec on AIO-SX.
 8. PASS - Verify mgmt / cluster-host / pxeboot fails to reconcile if any of 'floatingAddress', controller0Address' or 'controller1Address' are missing from the addresspool spec.
 9. PASS - Verify addresspool resource instances can be deleted with no impact on the system.
10. PASS - Verify platformnetwork resource instances can be deleted with no impact on the system.