### PR TITLE
Delta is removed when config is updated in dc system

### DIFF
--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -382,6 +382,24 @@ func (in *EventLogger) WarningEvent(object runtime.Object, reason string, messag
 	in.event(object, v1.EventTypeWarning, 1, reason, messageFmt, args...)
 }
 
+// removes unnecessary certs
+func FilterCertsFromSpec(spec *starlingxv1.SystemSpec) {
+	result := make([]starlingxv1.CertificateInfo, 0)
+	for _, c := range *spec.Certificates {
+		if c.Type == starlingxv1.PlatformCertificate || c.Type == starlingxv1.OpenstackCACertificate ||
+			c.Type == starlingxv1.DockerCertificate || c.Type == starlingxv1.OpenLDAPCertificate {
+			continue
+		}
+		result = append(result, c)
+	}
+	if len(result) > 0 {
+		list := starlingxv1.CertificateList(result)
+		spec.Certificates = &list
+	} else {
+		spec.Certificates = nil
+	}
+}
+
 func GetDeltaString(spec interface{}, current interface{}, parameters map[string]interface{}) (string, error) {
 
 	specBytes, err := json.Marshal(spec)

--- a/controllers/system/system_controller.go
+++ b/controllers/system/system_controller.go
@@ -1033,6 +1033,9 @@ func (r *SystemReconciler) ReconcileRequired(instance *starlingxv1.System, spec 
 
 	logSystem.Info("current is:", "values", current)
 
+	//filters certs except ssl_ca from spec
+	common.FilterCertsFromSpec(spec)
+
 	deltaString, err := common.GetDeltaString(current, spec, common.SystemProperties)
 	if err != nil {
 		logSystem.Info(fmt.Sprintf("failed to get Delta status:  %s\n", err))


### PR DESCRIPTION
When we update the config as per the below config we are getting a delta in ssl certificate.

Config updated:
{'kind': 'System', 'metadata':

{'name': 'dc-subcloud3'}
, 'spec': {'description': 'Description test'}}

Run the below command to check the status:
kubectl get system -n=deployment -o=custom-columns=Type:.kind,Name:.metadata.name,Description:.spec.description,INSYNC:.status.inSync,Scope:.status.deploymentScope,Reconciled:.status.reconciled,StrategyRequired:.status.strategyRequired,DELTA:.status.delta

output:
[2024-03-14 11:17:11,800] 349  DEBUG MainThread ssh.send    :: Send 'kubectl get system -n=deployment -o=custom-columns=Type:.kind,Name:.metadata.name,De     scription:.spec.description,INSYNC:.status.inSync,Scope:.status.deploymentScope,Reconciled:.status.reconciled,StrategyRequired:.status.strategyRequired,D     ELTA:.status.delta'
1539 [2024-03-14 11:17:11,851] 551  DEBUG MainThread ssh.exec_cmd:: Expecting .controller-[01][:| ].\$  in prompt
1540 [2024-03-14 11:17:11,903] 471  DEBUG MainThread ssh.expect  :: Output:
1541 Type     Name           Description        INSYNC   Scope       Reconciled   StrategyRequired   DELTA
1542 System   dc-subcloud3   Description test   false    bootstrap   true         not_required
1543 certificates:
1544 -                       map[string]any{"secret":            "ssl-cert-secret-2",                "type":                  "ssl"},
1545 -                       "secret":                           "docker-registry-cert-secret-3",
1546 +                       "secret":                           "system-registry-local-certificate-old",
1547 -                       map[string]any{"secret":            "ssl-ca-cert-secret-4",                              "type":                  "ssl_ca"},
1548 +                       map[string]any{"secret":            "system-restapi-gui-certificate-old",                "type":                  "ssl"},
1549 -                       "secret":                           "ssl-ca-cert-secret-5",
1550 +                       "secret":                           "stepca-root-secret",
1551
1552 storage:
1553          "backends":
1554 -                       "replicationFactor":       