### PR TITLE
Update deployctl to export configuration for multiple ip pools and host platform network

### DIFF
--- a/api/v1/constructors.go
+++ b/api/v1/constructors.go
@@ -1432,16 +1432,17 @@ func NewPTPInterface(name string, namespace string, PTPint ptpinterfaces.PTPInte
 	return &ptpInterface, nil
 }
 
-func NewPlatformNetworkSpec(pool addresspools.AddressPool, network networks.Network) (*PlatformNetworkSpec, error) {
+func NewPlatformNetworkSpec(associatedAddressPools []string, network networks.Network) (*PlatformNetworkSpec, error) {
 	spec := PlatformNetworkSpec{
-		Type:    network.Type,
-		Dynamic: network.Dynamic,
+		Type:                   network.Type,
+		Dynamic:                network.Dynamic,
+		AssociatedAddressPools: associatedAddressPools,
 	}
 
 	return &spec, nil
 }
 
-func NewPlatformNetwork(namespace string, pool addresspools.AddressPool, network networks.Network) (*PlatformNetwork, error) {
+func NewPlatformNetwork(namespace string, associatedAddressPools []string, network networks.Network) (*PlatformNetwork, error) {
 	platformNetwork := PlatformNetwork{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: APIVersion,
@@ -1456,7 +1457,7 @@ func NewPlatformNetwork(namespace string, pool addresspools.AddressPool, network
 		},
 	}
 
-	spec, err := NewPlatformNetworkSpec(pool, network)
+	spec, err := NewPlatformNetworkSpec(associatedAddressPools, network)
 	if err != nil {
 		return nil, err
 	}

--- a/api/v1/constructors_test.go
+++ b/api/v1/constructors_test.go
@@ -395,42 +395,22 @@ var _ = Describe("Constructor utils for kind", func() {
 	Describe("Test NewPlatformNetworkSpec", func() {
 		Context("When network dynamic is false", func() {
 			It("should give allocation type as AllocationOrderStatic", func() {
-				gateway := "gateway"
-				ranges := make([]AllocationRange, 0)
-				obj := AllocationRange{
-					Start: "192.168.1.100",
-					End:   "192.168.1.200",
+				associatedAddressPool := []string{
+					"192.168.1.0/24",
+					"192.168.1.255",
+					"192.168.1.1",
+					"192.168.1.2",
 				}
-				ranges = append(ranges, obj)
-				obj = AllocationRange{
-					Start: "10.0.0.1",
-					End:   "10.0.0.255",
-				}
-				ranges = append(ranges, obj)
-				poolRanges := make([][]string, 2)
-				poolRanges[0] = []string{"192.168.1.100", "192.168.1.200"}
-				poolRanges[1] = []string{"10.0.0.1", "10.0.0.255"}
-
-				pool := addresspools.AddressPool{
-					Network:            "192.168.1.0/24",
-					FloatingAddress:    "192.168.1.255",
-					Controller0Address: "192.168.1.1",
-					Controller1Address: "192.168.1.2",
-					Prefix:             24,
-					Gateway:            &gateway,
-					Order:              "random",
-					Ranges:             poolRanges,
-				}
-
 				network := networks.Network{
 					Dynamic: false,
 					Type:    "mgmt",
 				}
 				expSpec := PlatformNetworkSpec{
-					Type:    "mgmt",
-					Dynamic: false,
+					Type:                   "mgmt",
+					Dynamic:                false,
+					AssociatedAddressPools: associatedAddressPool,
 				}
-				pnSpec, err := NewPlatformNetworkSpec(pool, network)
+				pnSpec, err := NewPlatformNetworkSpec(associatedAddressPool, network)
 				Expect(err).To(BeNil())
 				Expect(*pnSpec).To(Equal(expSpec))
 			})
@@ -441,41 +421,21 @@ var _ = Describe("Constructor utils for kind", func() {
 		Context("When network dynamic is false", func() {
 			It("should give allocation type as AllocationOrderStatic", func() {
 				namespace := "NameSpace"
-				gateway := "192.168.1.1"
-				ranges := make([]AllocationRange, 0)
-				obj := AllocationRange{
-					Start: "192.168.1.100",
-					End:   "192.168.1.200",
+				associatedAddressPool := []string{
+					"192.168.1.0/24",
+					"192.168.1.255",
+					"192.168.1.1",
+					"192.168.1.2",
 				}
-				ranges = append(ranges, obj)
-				obj = AllocationRange{
-					Start: "10.0.0.1",
-					End:   "10.0.0.255",
-				}
-				ranges = append(ranges, obj)
-				poolRanges := make([][]string, 2)
-				poolRanges[0] = []string{"192.168.1.100", "192.168.1.200"}
-				poolRanges[1] = []string{"10.0.0.1", "10.0.0.255"}
-
-				pool := addresspools.AddressPool{
-					Network:            "192.168.1.0/24",
-					FloatingAddress:    "192.168.1.255",
-					Controller0Address: "192.168.1.1",
-					Controller1Address: "192.168.1.2",
-					Prefix:             24,
-					Gateway:            &gateway,
-					Order:              "random",
-					Ranges:             poolRanges,
-				}
-
 				network := networks.Network{
 					Name:    "NetworkName",
 					Dynamic: false,
 					Type:    "mgmt",
 				}
 				expSpec := PlatformNetworkSpec{
-					Type:    "mgmt",
-					Dynamic: false,
+					Type:                   "mgmt",
+					Dynamic:                false,
+					AssociatedAddressPools: associatedAddressPool,
 				}
 				expPn := PlatformNetwork{
 					TypeMeta: metav1.TypeMeta{
@@ -491,7 +451,7 @@ var _ = Describe("Constructor utils for kind", func() {
 					},
 					Spec: expSpec,
 				}
-				pn, err := NewPlatformNetwork(namespace, pool, network)
+				pn, err := NewPlatformNetwork(namespace, associatedAddressPool, network)
 				Expect(err).To(BeNil())
 				Expect(*pn).To(Equal(expPn))
 			})

--- a/build/build.go
+++ b/build/build.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/datanetworks"
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/hosts"
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/licenses"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/networkAddressPools"
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/networks"
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/ptpinstances"
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/ptpinterfaces"
@@ -146,6 +147,7 @@ type Deployment struct {
 	Hosts             []*starlingxv1.Host
 	PtpInstances      []*starlingxv1.PtpInstance
 	PtpInterfaces     []*starlingxv1.PtpInterface
+	AddressPools      []*starlingxv1.AddressPool
 }
 
 // progressUpdate is a utility method to write a progress log to the provided
@@ -226,7 +228,7 @@ func (db *DeploymentBuilder) Build() (*Deployment, error) {
 		return nil, err
 	}
 
-	db.progressUpdate("building platform network configurations\n")
+	db.progressUpdate("building platform network and address pool configurations\n")
 
 	err = db.buildPlatformNetworks(&deployment)
 	if err != nil {
@@ -342,6 +344,17 @@ func (d *Deployment) ToYAML() (string, error) {
 		buf, err := yaml.Marshal(n)
 		if err != nil {
 			err = perrors.Wrap(err, "failed to render platform network to YAML")
+			return "", err
+		}
+
+		b.Write(buf)
+		b.Write([]byte(yamlSeparator))
+	}
+
+	for _, n := range d.AddressPools {
+		buf, err := yaml.Marshal(n)
+		if err != nil {
+			err = perrors.Wrap(err, "failed to render address pools to YAML")
 			return "", err
 		}
 
@@ -554,7 +567,22 @@ func (db *DeploymentBuilder) buildDataNetworks(d *Deployment) error {
 	return nil
 }
 
+func (db *DeploymentBuilder) GetAssociatedAddressPools(networkName string, networkAddressPools []networkAddressPools.NetworkAddressPool, addressPools []addresspools.AddressPool) []addresspools.AddressPool {
+	var associated_address_pools []addresspools.AddressPool
+	for _, networkAddressPool := range networkAddressPools {
+		if networkAddressPool.NetworkName == networkName {
+			addressPool := utils.GetSystemAddrPoolByName(addressPools, networkAddressPool.AddressPoolName)
+			associated_address_pools = append(associated_address_pools, *addressPool)
+
+		}
+	}
+	return associated_address_pools
+}
+
 func (db *DeploymentBuilder) buildPlatformNetworks(d *Deployment) error {
+	var associated_address_pools []addresspools.AddressPool
+	var associated_pools_name []string
+	var addressPool *starlingxv1.AddressPool
 	results, err := networks.ListNetworks(db.client)
 	if err != nil {
 		err = perrors.Wrap(err, "failed to list platform networks")
@@ -567,36 +595,30 @@ func (db *DeploymentBuilder) buildPlatformNetworks(d *Deployment) error {
 		return err
 	}
 
+	networkAddrPools, err := networkAddressPools.ListNetworkAddressPools(db.client)
+	if err != nil {
+		err = perrors.Wrap(err, "failed to list network address pools")
+		return err
+	}
+
 	d.PlatformNetworks = make([]*starlingxv1.PlatformNetwork, 0)
 	always_generate_networks := []string{"storage", "mgmt", "oam", "admin"}
 	sort.Strings(always_generate_networks)
-	for _, p := range pools {
-		skip := false
-		network := networks.Network{}
-		for _, n := range results {
-			if n.PoolUUID == p.ID {
-				// TODO(alegacy): for now we only support networks used for data
-				//  interfaces which are realized in the system as a standalone
-				//  pool without a network so if we find a matching network then
-				//  skip it.
-				//
-				// sdinescu: we special case storage network type, since this is
-				// a user configurable network type with an attached address pool
-				// and we should always create this network.
-				// Since go doesn't seem to have an easy way to determine if an
-				// element is part of a slice, we sort it and then use
-				// sort.SearchStrings to look for the element.
-				index := sort.SearchStrings(always_generate_networks, n.Type)
-				if index >= len(always_generate_networks) || always_generate_networks[index] != n.Type {
-					skip = true
+	for _, n := range results {
+		associated_pools_name = []string{}
+		index := sort.SearchStrings(always_generate_networks, n.Type)
+		if index < len(always_generate_networks) && always_generate_networks[index] == n.Type {
+			// With "--minimal-config", Exports platform networks / address pools belonging to only storage network
+			// Without "--minimal-config", Exports all address pools and platform networks belongs to any of storage, admin, mgm , oam networks
+			associated_address_pools = db.GetAssociatedAddressPools(n.Name, networkAddrPools, pools)
+			for _, pools := range associated_address_pools {
+				associated_pools_name = append(associated_pools_name, pools.Name)
+				addressPool, err = starlingxv1.NewAddressPool(db.namespace, pools)
+				if err != nil {
+					return err
 				}
-				network = n
-				break
 			}
-		}
-
-		if !skip {
-			net, err := starlingxv1.NewPlatformNetwork(db.namespace, p, network)
+			net, err := starlingxv1.NewPlatformNetwork(db.namespace, associated_pools_name, n)
 			if err != nil {
 				return err
 			}
@@ -605,13 +627,13 @@ func (db *DeploymentBuilder) buildPlatformNetworks(d *Deployment) error {
 			// We are passing pointer to PlatformNetwork resource (net), hence, calling filterPlatformNetworks
 			// before or after append wouldn't make any difference and either way it would work.
 			d.PlatformNetworks = append(d.PlatformNetworks, net)
+			d.AddressPools = append(d.AddressPools, addressPool)
 			err = db.filterPlatformNetworks(net, d)
 			if err != nil {
 				return err
 			}
 		}
 	}
-
 	return nil
 }
 

--- a/build/filter.go
+++ b/build/filter.go
@@ -740,15 +740,24 @@ func NewCoreNetworkFilter() *CoreNetworkFilter {
 
 func (in *CoreNetworkFilter) Filter(platform_network *v1.PlatformNetwork, deployment *Deployment) error {
 	filtered_platform_networks := []*v1.PlatformNetwork{}
+	filtered_address_pools := []*v1.AddressPool{}
 	for _, pn := range deployment.PlatformNetworks {
 		if !(pn.Spec.Type == oamNetwork ||
 			pn.Spec.Type == mgmtNetwork ||
 			pn.Spec.Type == adminNetwork) {
 			filtered_platform_networks = append(filtered_platform_networks, pn)
+			for _, name := range pn.Spec.AssociatedAddressPools {
+				for _, pool := range deployment.AddressPools {
+					if name == pool.Name {
+						filtered_address_pools = append(filtered_address_pools, pool)
+					}
+				}
+			}
 		}
 	}
 
 	deployment.PlatformNetworks = filtered_platform_networks
+	deployment.AddressPools = filtered_address_pools
 	return nil
 }
 


### PR DESCRIPTION
After the change of PlatformNetwork and HostProfile CRDs, respective constructors are modified to adopt the change. Updates the platform network with its associated addresspool. 

Test plan:
- 'Make tool' generates deployctl successfully
- 'Make test' runs successfully
- With"--minimal-config" generates platformnetworks / address pools belonging to "storage" network type only
- Without "--minimal-config", it generates platformnetworks / address pools belonging to one of "storage / admin / mgmt. / oam" network types