### PR TITLE
Support DeploymentScope Update When Generation equals ObservedGeneration

### DIFF
--- a/controllers/ptpinstance_controller.go
+++ b/controllers/ptpinstance_controller.go
@@ -458,11 +458,13 @@ func (r *PtpInstanceReconciler) GetScopeConfig(instance *starlingxv1.PtpInstance
 	return deploymentScope, nil
 }
 
-// Update deploymentScope and ReconcileAfterInSync in instance
+// Update ReconcileAfterInSync in instance
 // ReconcileAfterInSync value will be:
 // "true"  if deploymentScope is "principal" because it is day 2 operation (update configuration)
 // "false" if deploymentScope is "bootstrap"
 // Then reflect these values to cluster object
+// It is expected that instance.Status.Deployment scope is already updated by
+// UpdateDeploymentScope at this point.
 func (r *PtpInstanceReconciler) UpdateConfigStatus(instance *starlingxv1.PtpInstance) (err error) {
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		err := r.Client.Get(context.TODO(), types.NamespacedName{
@@ -472,17 +474,12 @@ func (r *PtpInstanceReconciler) UpdateConfigStatus(instance *starlingxv1.PtpInst
 		if err != nil {
 			return err
 		}
-		deploymentScope, err := r.GetScopeConfig(instance)
-		if err != nil {
-			return err
-		}
-		logPtpInstance.V(2).Info("deploymentScope in configuration", "deploymentScope", deploymentScope)
 
 		// Put ReconcileAfterInSync values depends on scope
 		// "true"  if scope is "principal" because it is day 2 operation (update configuration)
 		// "false" if scope is "bootstrap" or None
 		afterInSync, ok := instance.Annotations[cloudManager.ReconcileAfterInSync]
-		if deploymentScope == cloudManager.ScopePrincipal {
+		if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
 			if !ok || afterInSync != "true" {
 				instance.Annotations[cloudManager.ReconcileAfterInSync] = "true"
 			}
@@ -506,14 +503,6 @@ func (r *PtpInstanceReconciler) UpdateConfigStatus(instance *starlingxv1.PtpInst
 		if err != nil {
 			return err
 		}
-
-		// Update scope status
-		deploymentScope, err := r.GetScopeConfig(instance)
-		if err != nil {
-			return err
-		}
-		logPtpInstance.V(2).Info("deploymentScope in configuration", "deploymentScope", deploymentScope)
-		instance.Status.DeploymentScope = deploymentScope
 
 		// Set default value for StrategyRequired
 		if instance.Status.StrategyRequired == "" {
@@ -594,16 +583,23 @@ func (r *PtpInstanceReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 		return ctrl.Result{}, nil
 	}
 
-	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation &&
-		instance.Status.Reconciled {
-		return ctrl.Result{}, nil
+	err, scope_updated := r.UpdateDeploymentScope(instance)
+	if err != nil {
+		return reconcile.Result{}, err
 	}
 
-	// Update scope from configuration
+	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation &&
+		instance.Status.Reconciled {
+		if !scope_updated {
+			return ctrl.Result{}, nil
+		}
+	}
+
+	// Update ReconciledAfterInSync and ObservedGeneration.
 	logPtpInstance.V(2).Info("before UpdateConfigStatus", "instance", instance)
 	err = r.UpdateConfigStatus(instance)
 	if err != nil {
-		logPtpInstance.Error(err, "unable to update scope")
+		logPtpInstance.Error(err, "unable to update ReconciledAfterInSync or ObservedGeneration.")
 		return reconcile.Result{}, err
 	}
 	logPtpInstance.V(2).Info("after UpdateConfigStatus", "instance", instance)
@@ -649,6 +645,32 @@ func (r *PtpInstanceReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// UpdateDeploymentScope function is used to update the deployment.
+func (r *PtpInstanceReconciler) UpdateDeploymentScope(instance *starlingxv1.PtpInstance) (error, bool) {
+	scope, err := r.GetScopeConfig(instance)
+	if err != nil {
+		logPtpInstance.Error(err, "failed to fetch deploymentScope")
+		return err, false
+	}
+
+	// Set default value for StrategyRequired otherwise status update will fail.
+	if instance.Status.StrategyRequired == "" {
+		instance.Status.StrategyRequired = cloudManager.StrategyNotRequired
+	}
+
+	if instance.Status.DeploymentScope != scope {
+		instance.Status.DeploymentScope = scope
+		err := r.Client.Status().Update(context.TODO(), instance)
+		if err != nil {
+			logPtpInstance.Error(err, "failed to update deploymentScope")
+			return err, false
+		}
+		return nil, true
+	}
+
+	return nil, false
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
This commit fixes the bug where the user could not update deploymentScope without updating the spec of resource kinds such as Hosts, System, DataNetwork, PTPInterface and PTPInstance.

Test Cases:
1. PASS - Deploy AIO-SX system successfully with existing Day-1 configuration.
2. PASS - Verify that Day-2 operations are successful on AIO-SX.
3. PASS - Verify that deploymentScope of resource kinds such as Hosts, System, DataNetwork, PTPInterface and PTPInstance can be updated back and forth between "bootstrap" and "principal" without changin the spec.