### PR TITLE
Enhancement to avoid instant fatal errors

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -712,7 +712,7 @@
               get_unrecon_status_post.stderr == "")
             retries: "{{ host_reconcile_retries }}"
             delay: 30
-            ignore_errors: yes
+            failed_when: false
 
           - name: Fail if fail to get resource reconciled status
             fail:


### PR DESCRIPTION
AIO-SX Subcloud DM failure during scale deployment while evaluating the conditional check for get unreconciled status. This task is the 1st task after the host reboot after unlock, it may be a timing issue as some of the system service not was started at that time. Adding an enhancement to avoid instant fatal errors using proper "failed_when" to replace "ignore_errors: true". So the "retry" in this task can be respected.

Test Cases:
  1. PASS? Deploy 500 AIO-SX subclouds in parallel.