### PR TITLE
Fix IPv6 static mode support

### DIFF
--- a/controllers/host/networking.go
+++ b/controllers/host/networking.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2024 Wind River Systems, Inc. */
 
 package host
 
@@ -648,7 +648,7 @@ func hasIPv4StaticAddresses(info starlingxv1.CommonInterfaceInfo, profile *starl
 // has any configured static addresses.
 func hasIPv6StaticAddresses(info starlingxv1.CommonInterfaceInfo, profile *starlingxv1.HostProfileSpec) bool {
 	for _, addrInfo := range profile.Addresses {
-		if utils.IsIPv4(addrInfo.Address) {
+		if utils.IsIPv6(addrInfo.Address) {
 			if addrInfo.Interface == info.Name {
 				return true
 			}


### PR DESCRIPTION
This commit updates the hasIPv6StaticAddresses in order to fix the ipv6 static interface setup.

Test Plan:
PASS: Execute a Day1 operation creating a IPv6 static interface. Verify the interface is created correctly.