### PR TITLE
Fix Incorrect Delta Indicators

### DIFF
--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -422,7 +422,7 @@ func GetDeltaString(spec interface{}, current interface{}, parameters map[string
 		return "", err
 	}
 
-	diff := cmp.Diff(specData, currentData)
+	diff := cmp.Diff(currentData, specData)
 	deltaString := collectDiffValues(diff, parameters)
 	deltaString = strings.TrimSuffix(deltaString, "\n")
 	return deltaString, nil


### PR DESCRIPTION
The delta indicators "+" and "-" are shown in reverse for "host" and "system" instances.
This order of arguments provided to "cmd.Diff" function has been corrected to fix the issue.

Test Cases:
1. PASS - Verify delta is accurately shown for "host" and "system" in Day-1 operation.
2. PASS - Verify delta is accurately shown for "host" and "system" in Day-2 operation.