### PR TITLE
Fix DM Crash When Allocation Order is Nil

### DIFF
--- a/controllers/host/platformnetworks.go
+++ b/controllers/host/platformnetworks.go
@@ -281,7 +281,8 @@ func (r *HostReconciler) IsAddrPoolUpdateRequired(network_instance *starlingxv1.
 		}
 	}
 
-	if current_addrpool == nil || (spec.Allocation.Order != nil && *spec.Allocation.Order != current_addrpool.Order) {
+	if (current_addrpool == nil && spec.Allocation.Order != nil) ||
+		(current_addrpool != nil && spec.Allocation.Order != nil && *spec.Allocation.Order != current_addrpool.Order) {
 		opts.Order = spec.Allocation.Order
 		delta.WriteString(fmt.Sprintf("\t+Order: %s\n", *opts.Order))
 		result = true


### PR DESCRIPTION
This commit fixes nil pointer exception caused when allocation order is not supplied as part of the spec during AddressPool creation.

Test Cases:
1. PASS - Verify that address pool is created successfully when allocation order is not specified in the spec.