### PR TITLE
Implement RestoreInProgress in AddressPool reconciler

### DIFF
--- a/controllers/addresspool_controller.go
+++ b/controllers/addresspool_controller.go
@@ -5,6 +5,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -147,6 +148,22 @@ func (r *AddressPoolReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 		return reconcile.Result{}, err
 	}
 
+	// Restore the address pool status
+	if r.isRestoreInProgress(instance) {
+		r.ReconcilerEventLogger.NormalEvent(instance, common.ResourceUpdated, "Restoring '%s' Addresspool resource status without doing actual reconciliation", instance.Name)
+		if err := r.RestoreAddressPoolStatus(instance); err != nil {
+			return reconcile.Result{}, err
+		}
+		if err := r.ClearRestoreInProgress(instance); err != nil {
+			return reconcile.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation && instance.Status.Reconciled {
+		return ctrl.Result{}, nil
+	}
+
 	if instance.DeletionTimestamp.IsZero() {
 		// Ensure that the object has a finalizer setup as a pre-delete hook so
 		// that we can delete any system resources that we previously added.
@@ -212,4 +229,58 @@ func (r *AddressPoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&starlingxv1.AddressPool{}).
 		Complete(r)
+}
+
+// Verify whether we have annotation restore-in-progress
+func (r *AddressPoolReconciler) isRestoreInProgress(instance *starlingxv1.AddressPool) bool {
+	restoreInProgress, ok := instance.Annotations[cloudManager.RestoreInProgress]
+	if ok && restoreInProgress != "" {
+		return true
+	}
+	return false
+}
+
+// Updates the AddressPool status while restoring
+func (r *AddressPoolReconciler) RestoreAddressPoolStatus(instance *starlingxv1.AddressPool) error {
+	annotation := instance.GetObjectMeta().GetAnnotations()
+	config, ok := annotation[cloudManager.RestoreInProgress]
+	if ok {
+		restoreStatus := &cloudManager.RestoreStatus{}
+		err := json.Unmarshal([]byte(config), &restoreStatus)
+		if err != nil {
+			logAddressPool.Error(err, "failed to unmarshal  restore status")
+			return nil
+		} else {
+			instance.Status.InSync = true
+			instance.Status.Reconciled = true
+			instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
+
+			err = r.Client.Status().Update(context.TODO(), instance)
+			if err != nil {
+				log_err_msg := fmt.Sprintf(
+					"Failed to update AddressPool status while restoring '%s' resource. Error: %s",
+					instance.Name,
+					err)
+				return common.NewResourceStatusDependency(log_err_msg)
+			}
+			StatusUpdate := fmt.Sprintf("Status updated for AddressPool resource '%s' during restore with following values: Reconciled=%t InSync=%t",
+				instance.Name, instance.Status.Reconciled, instance.Status.InSync)
+			r.ReconcilerEventLogger.NormalEvent(instance, common.ResourceUpdated, StatusUpdate)
+		}
+	}
+	return nil
+}
+
+// Clear annotation RestoreInProgress
+func (r *AddressPoolReconciler) ClearRestoreInProgress(instance *starlingxv1.AddressPool) error {
+	delete(instance.Annotations, cloudManager.RestoreInProgress)
+	if !utils.ContainsString(instance.ObjectMeta.Finalizers, AddressPoolFinalizerName) {
+		instance.ObjectMeta.Finalizers = append(instance.ObjectMeta.Finalizers, AddressPoolFinalizerName)
+	}
+	err := r.Client.Update(context.TODO(), instance)
+	if err != nil {
+		return common.NewResourceStatusDependency(fmt.Sprintf("Failed to update '%s' addresspool resource after removing '%s' annotation during restoration.",
+			instance.Name, cloudManager.RestoreInProgress))
+	}
+	return nil
 }

--- a/controllers/platformnetwork_controller.go
+++ b/controllers/platformnetwork_controller.go
@@ -369,9 +369,7 @@ func (r *PlatformNetworkReconciler) RestorePlatformNetworkStatus(instance *starl
 		restoreStatus := &cloudManager.RestoreStatus{}
 		err := json.Unmarshal([]byte(config), &restoreStatus)
 		if err == nil {
-			if restoreStatus.InSync != nil {
-				instance.Status.InSync = *restoreStatus.InSync
-			}
+			instance.Status.InSync = true
 			instance.Status.Reconciled = true
 			instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
 			instance.Status.DeploymentScope = "bootstrap"


### PR DESCRIPTION
Implement RestoreInProgress in AddressPool reconciler

The new function "RestoreInProgress" in all the controllers to support migration of CRDs from 22.12 MR2+ / MR3 to 24.09 during upgrade.

The AddressPool reconciler did not exist back then.

This functionality should be implemented and tested in AddressPool reconciler as well.

Please note that both "Reconciler" and "InSync" should be set to true in case of PlatformNetworks / AddressPools.

Otherwise, when the host controller is notified "PlatformNetworkUpdateRequired" returns true and reconciliation will be allowed which would be problematic during the upgrade.

Test plan:
- Install helm based DM with platform network in config file
- Helm based DM should be running
- Check all the crds, insync and reconciled should be true
- Set garbage values to annoatation deployment-manager/restore-in-
progress, reconcilation should not trigger
- PASS - Day-1 and Day-2 operation after successful restore
- PASS - addresspool with "deploymentscope: principal"
