### PR TITLE
Fix syntax error in playbook

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -540,7 +540,7 @@
                   host={{ ansible_host }}
                   timeout={{ wait_for_timeout }}
                   delay=5
-                  state: stopped
+                  state=stopped
 
             - name: Waiting for SSH port to become open
               local_action:


### PR DESCRIPTION
This change the syntax of `state: stopped` to `state=stopped`