### PR TITLE
Support Day-2 Platform Network Reconfig Workflows in Multinode Systems

### DIFF
--- a/controllers/addresspool_controller.go
+++ b/controllers/addresspool_controller.go
@@ -75,7 +75,7 @@ func (r *AddressPoolReconciler) ReconcileResource(client *gophercloud.ServiceCli
 				}
 			}
 
-			host_instance, err := r.CloudManager.GetActiveHost(request_namespace, client)
+			host_instance, _, err := r.CloudManager.GetHostByPersonality(request_namespace, client, cloudManager.PersonalityActiveController)
 			if err != nil {
 				msg := "failed to get active host"
 				return common.NewUserDataError(msg)

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019-2023 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2024 Wind River Systems, Inc. */
 
 package common
 
@@ -286,7 +286,7 @@ func (h *ErrorHandler) HandleReconcilerError(request reconcile.Request, in error
 		result = RetryTransientError
 		err = nil
 
-		h.Info("waiting for dependency status", "request", request)
+		h.Info(fmt.Sprintf("%s", in), "request", request)
 	case HostNotifyError:
 		resetClient = false
 		result = RetryImmediate

--- a/controllers/common/common_test.go
+++ b/controllers/common/common_test.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2023 Wind River Systems, Inc. */
+/* Copyright(c) 2024 Wind River Systems, Inc. */
 
 package common
 
@@ -40,7 +40,7 @@ var _ = Describe("Common utils", func() {
 				Expect(result).To(Equal(RetryTransientError))
 				Expect(sink.infoCalled).To(BeTrue())
 				Expect(sink.errorCalled).To(BeFalse())
-				Expect(sink.message).To(Equal("waiting for dependency status"))
+				Expect(sink.message).To(Equal("Test for status dependency"))
 			})
 		})
 		Context("when error is ErrResourceConfigurationDependency", func() {

--- a/controllers/manager/dummy_manager.go
+++ b/controllers/manager/dummy_manager.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/hosts"
 	"github.com/gophercloud/gophercloud/starlingx/nfv/v1/systemconfigupdate"
 	"github.com/pkg/errors"
 	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
@@ -53,6 +54,9 @@ func (m *Dummymanager) BuildPlatformClient(namespace string, endpointName string
 	return c, nil
 }
 func (m *Dummymanager) NotifySystemDependencies(namespace string) error {
+	return nil
+}
+func (m *Dummymanager) NotifyController(object client.Object, annotationKey string, deleteKey bool) error {
 	return nil
 }
 func (m *Dummymanager) NotifyResource(object client.Object) error {
@@ -103,13 +107,13 @@ func (m *Dummymanager) GetMonitorVersion() int {
 func (m *Dummymanager) SetMonitorVersion(i int) {
 
 }
-func (m *Dummymanager) StrageySent() {
+func (m *Dummymanager) StrategySent() {
 	m.strategySent = true
 }
-func (m *Dummymanager) GetStrageySent() bool {
+func (m *Dummymanager) GetStrategySent() bool {
 	return m.strategySent
 }
-func (m *Dummymanager) ClearStragey() {
+func (m *Dummymanager) ClearStrategy() {
 
 }
 func (m *Dummymanager) GetNamespace() string {
@@ -146,6 +150,9 @@ func (m *Dummymanager) IsNotifyingActiveHost() bool {
 }
 func (m *Dummymanager) SetNotifyingActiveHost(status bool) {
 
+}
+func (m *Dummymanager) GetHostByPersonality(namespace string, client *gophercloud.ServiceClient, personality string) (*starlingxv1.Host, *hosts.Host, error) {
+	return nil, nil, nil
 }
 func (m *Dummymanager) GcShow(c *gophercloud.ServiceClient) (*systemconfigupdate.SystemConfigUpdate, error) {
 	if len(m.gcShow) == 0 {

--- a/controllers/manager/manager.go
+++ b/controllers/manager/manager.go
@@ -43,9 +43,10 @@ const SystemEndpointSecretName = "system-endpoint"
 
 const (
 	// Defines annotation keys for resources.
-	NotificationCountKey = "deployment-manager/notifications"
-	ReconcileAfterInSync = "deployment-manager/reconcile-after-insync"
-	RestoreInProgress    = "deployment-manager/restore-in-progress"
+	NotificationCountKey    = "deployment-manager/notifications"
+	ReconcileAfterInSync    = "deployment-manager/reconcile-after-insync"
+	RestoreInProgress       = "deployment-manager/restore-in-progress"
+	LockAndUnlockController = "deployment-manager/lock-and-unlock-controller"
 )
 
 const (
@@ -67,6 +68,11 @@ const (
 	// It's serves as an indicator to DM that only addresspool
 	// needs to be reconciled and not network / network-addrpools.
 	OtherNetworkType = "other"
+)
+
+const (
+	PersonalityActiveController  = "Controller-Active"
+	PersonalityStandbyController = "Controller-Standby"
 )
 
 const (
@@ -102,13 +108,14 @@ type CloudManager interface {
 	BuildPlatformClient(namespace string, endpointName string, endpointType string) (*gophercloud.ServiceClient, error)
 	NotifySystemDependencies(namespace string) error
 	NotifyResource(object client.Object) error
+	NotifyController(object client.Object, annotationKey string, deleteKey bool) error
 	SetSystemReady(namespace string, value bool)
 	GetSystemReady(namespace string) bool
 	SetSystemType(namespace string, value SystemType)
 	GetSystemType(namespace string) SystemType
 	StartMonitor(monitor *Monitor, message string) error
 	CancelMonitor(object client.Object)
-	GetActiveHost(namespace string, client *gophercloud.ServiceClient) (*v1.Host, error)
+	GetHostByPersonality(namespace string, client *gophercloud.ServiceClient, personality string) (*v1.Host, *hosts.Host, error)
 	GetSystemInfo(namespace string, client *gophercloud.ServiceClient) (*SystemInfo, error)
 
 	// Strategy related methods
@@ -119,9 +126,9 @@ type CloudManager interface {
 	GetConfigVersion() int
 	GetMonitorVersion() int
 	SetMonitorVersion(i int)
-	StrageySent()
-	GetStrageySent() bool
-	ClearStragey()
+	StrategySent()
+	GetStrategySent() bool
+	ClearStrategy()
 	GetNamespace() string
 	GetVimClient() *gophercloud.ServiceClient
 	SetStrategyAppliedSent(namespace string, applied bool) error
@@ -425,7 +432,7 @@ func (m *PlatformManager) notifyControllers(namespace string, gvkList []schema.G
 
 // notifyController updates an annotation on a single controller to force it
 // to re-run its reconcile loop.
-func (m *PlatformManager) notifyController(object client.Object, annotationKey string, deleteKey bool) error {
+func (m *PlatformManager) NotifyController(object client.Object, annotationKey string, deleteKey bool) error {
 	key := client.ObjectKeyFromObject(object)
 
 	result := object.DeepCopyObject().(client.Object)
@@ -476,7 +483,7 @@ func (m *PlatformManager) NotifySystemDependencies(namespace string) error {
 }
 
 func (m *PlatformManager) NotifyResource(object client.Object) error {
-	return m.notifyController(object, NotificationCountKey, false)
+	return m.NotifyController(object, NotificationCountKey, false)
 }
 
 // GetKubernetesClient returns a reference to the Kubernetes client
@@ -645,23 +652,25 @@ func (m *PlatformManager) GetSystemInfo(namespace string, client *gophercloud.Se
 
 }
 
-func (m *PlatformManager) GetActiveHost(namespace string, client *gophercloud.ServiceClient) (*v1.Host, error) {
+func (m *PlatformManager) GetHostByPersonality(namespace string, client *gophercloud.ServiceClient, personality string) (*v1.Host, *hosts.Host, error) {
 	host_instance := &v1.Host{}
+	var host_obj *hosts.Host
 
 	host_list, err := hosts.ListHosts(client)
 	if err != nil {
 		log.Error(err, "failed to query host list")
-		return host_instance, err
+		return host_instance, host_obj, err
 	}
 
 	for _, host := range host_list {
 		if host.Capabilities.Personality != nil {
-			if *host.Capabilities.Personality == "Controller-Active" {
+			if *host.Capabilities.Personality == personality {
 				host_namespace := types.NamespacedName{Namespace: namespace, Name: host.Hostname}
+				host_obj = &host
 				err = m.GetClient().Get(context.TODO(), host_namespace, host_instance)
 				if err != nil {
 					log.Error(err, fmt.Sprintf("failed to fetch host instance: %s", host.Hostname))
-					return host_instance, err
+					return host_instance, host_obj, err
 				}
 				break
 			}
@@ -669,12 +678,11 @@ func (m *PlatformManager) GetActiveHost(namespace string, client *gophercloud.Se
 	}
 
 	if host_instance.Name == "" {
-		err = perrors.New("None of the controllers are active at this point")
-		return host_instance, err
+		err = perrors.New(fmt.Sprintf("None of the hosts are %s at this point", personality))
+		return host_instance, host_obj, err
 	}
 
-	return host_instance, nil
-
+	return host_instance, host_obj, nil
 }
 
 func (m *PlatformManager) StartStrategyMonitor() {
@@ -771,16 +779,16 @@ func (m *PlatformManager) SetMonitorVersion(i int) {
 	m.strategyStatus.MonitorVersion = i
 }
 
-// StrageySent to update strategy sent with true
-func (m *PlatformManager) StrageySent() {
+// StrategySent to update strategy sent with true
+func (m *PlatformManager) StrategySent() {
 	m.lock.Lock()
 	defer func() { m.lock.Unlock() }()
 
 	m.strategyStatus.StrategySent = true
 }
 
-// GetStrageySent to return the current strategy sent value
-func (m *PlatformManager) GetStrageySent() bool {
+// GetStrategySent to return the current strategy sent value
+func (m *PlatformManager) GetStrategySent() bool {
 	m.lock.Lock()
 	defer func() { m.lock.Unlock() }()
 
@@ -848,8 +856,8 @@ func (m *PlatformManager) SetStrategyRetryCount(c int) error {
 	return nil
 }
 
-// ClearStragey to clear strategy status
-func (m *PlatformManager) ClearStragey() {
+// ClearStrategy to clear strategy status
+func (m *PlatformManager) ClearStrategy() {
 	// Clear applied status in System instance
 	err := m.SetStrategyAppliedSent(m.strategyStatus.Namespace, false)
 	if err != nil {

--- a/controllers/platformnetwork_controller.go
+++ b/controllers/platformnetwork_controller.go
@@ -75,7 +75,7 @@ func (r *PlatformNetworkReconciler) ReconcileResource(client *gophercloud.Servic
 	if instance.DeletionTimestamp.IsZero() {
 		if instance.Status.ObservedGeneration != instance.ObjectMeta.Generation ||
 			scope_updated {
-			host_instance, err := r.CloudManager.GetActiveHost(reqNs, client)
+			host_instance, _, err := r.CloudManager.GetHostByPersonality(reqNs, client, cloudManager.PersonalityActiveController)
 			if err != nil {
 				msg := "failed to get active host"
 				logPlatformNetwork.Error(err, msg)

--- a/controllers/system/system_controller.go
+++ b/controllers/system/system_controller.go
@@ -1657,7 +1657,7 @@ func (r *SystemReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 	// If strategy is applied, start strategy monitor
 	if instance.Status.StrategyApplied {
 		logSystem.Info("Strategy applied, start strategy monitor")
-		r.CloudManager.StrageySent()
+		r.CloudManager.StrategySent()
 		r.CloudManager.StartStrategyMonitor()
 	} else {
 		logSystem.V(2).Info("Strategy not applied")

--- a/go.mod
+++ b/go.mod
@@ -92,4 +92,4 @@ require (
 )
 
 // replace github.com/gophercloud/gophercloud => ./external/gophercloud
-replace github.com/gophercloud/gophercloud => github.com/Wind-River/gophercloud v0.0.0-20240613135955-990ba2998293
+replace github.com/gophercloud/gophercloud => github.com/Wind-River/gophercloud v0.0.0-20240625143930-1d6b313577a4

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMo
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/Wind-River/gophercloud v0.0.0-20240613135955-990ba2998293 h1:oNTZaEcMYACgZ/uwIKNEj+fmC5KyOlvf0PiR5b7Eni0=
-github.com/Wind-River/gophercloud v0.0.0-20240613135955-990ba2998293/go.mod h1:vVDhU9TrWNFfORJV7Tvx7UXsu/ImDlVeHhQCdrbzLEA=
+github.com/Wind-River/gophercloud v0.0.0-20240625143930-1d6b313577a4 h1:nmhNtNzi6j84s2V+7ObUn0cLL+P94iJPrkjNxhoH004=
+github.com/Wind-River/gophercloud v0.0.0-20240625143930-1d6b313577a4/go.mod h1:vVDhU9TrWNFfORJV7Tvx7UXsu/ImDlVeHhQCdrbzLEA=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=


### PR DESCRIPTION
In this commit we are enabling reconfiguration of platform networks such as OAM and admin networks.

Reconfiguration of management network is blocked in multinode system and OAM network reconfiguration involves lock and unlock of both the controllers orchestrated by DM through VIM APIs.

The go.mod has also been updated to fix modification of range of the addresspool during reconfiguration.

Test Cases:
1. PASS - Verify that range of the addresspool can be updated successfully for reconfigurable networks.
2. PASS - Verify that OAM, admin network reconfiguration is successful.
3. PASS - Verify that management network reconfiguration is blocked.