### PR TITLE
Enforce Dual-Stack OAM For Configuring Secondary Cluster Networks

### DIFF
--- a/common/utilities.go
+++ b/common/utilities.go
@@ -218,3 +218,12 @@ func GetSystemNetworkByName(network_list []networks.Network, network_name string
 	}
 	return nil
 }
+
+func GetSystemNetworkByType(network_list []networks.Network, network_type string) *networks.Network {
+	for _, network := range network_list {
+		if network.Type == network_type {
+			return &network
+		}
+	}
+	return nil
+}

--- a/common/utilities_test.go
+++ b/common/utilities_test.go
@@ -4,10 +4,11 @@
 package common
 
 import (
-	"reflect"
-
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/networks"
+	net_test "github.com/gophercloud/gophercloud/starlingx/inventory/v1/networks/testing"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"reflect"
 )
 
 var _ = Describe("Common utils", func() {
@@ -391,6 +392,16 @@ var _ = Describe("Common utils", func() {
 					gotResult := DedupeSlice(tt.given)
 					Expect(reflect.DeepEqual(gotResult, tt.wantResult)).To(BeTrue())
 				}
+			})
+		})
+	})
+
+	Describe("GetSystemNetworkByType utility", func() {
+		Context("with network list and network type", func() {
+			It("should return network object associated with network type", func() {
+				network_list := []networks.Network{net_test.NetworkHerp, net_test.NetworkDerp}
+				got := GetSystemNetworkByType(network_list, "oam")
+				Expect(reflect.DeepEqual(*got, net_test.NetworkDerp)).To(BeTrue())
 			})
 		})
 	})

--- a/controllers/host/host_controller_fixtures.go
+++ b/controllers/host/host_controller_fixtures.go
@@ -312,6 +312,20 @@ const NetworkAddressPoolClusterHostReconcile = `
 			"address_pool_uuid": "28f8fabb-43df-4458-a256-d9195e2b6667",
 			"network_name": "cluster-host",
 			"address_pool_name": "cluster-host"
+		},
+		{
+			"uuid": "33333333-a6e5-425e-9317-995da88d6694",
+			"network_uuid": "32665423-d48b-486e-8151-7dcecd3779df",
+			"address_pool_uuid": "384c6eb3-d48b-486e-8151-7dcecd377666",
+			"network_name": "oam",
+			"address_pool_name": "oam-ipv6"
+		},
+		{
+			"uuid": "33333333-2222-425e-9317-995da88d6694",
+			"network_uuid": "32665423-d48b-486e-8151-7dcecd3779df",
+			"address_pool_uuid": "384c6eb3-d48b-486e-8151-7dcecd3779df",
+			"network_name": "oam",
+			"address_pool_name": "oam"
 		}
 	]
 }
@@ -369,8 +383,47 @@ const NetworkListClusterHostReconcile = `
 			"type": "cluster-host",
 			"uuid": "0bebc4ef-e8e4-1248-b9d5-8694a79f58ce",
 			"primary_pool_family": "ipv4"
+		},
+		{
+			"dynamic": false,
+			"id": 3,
+			"name": "oam",
+			"pool_uuid": "384c6eb3-d48b-486e-8151-7dcecd377666",
+			"type": "oam",
+			"uuid": "32665423-d48b-486e-8151-7dcecd3779df",
+			"primary_pool_family": "ipv6"
 		}
     ]
+}
+`
+
+const NetworkListWithoutDualStackOAM = `
+{
+    "networks": [
+		{
+			"dynamic": true,
+			"id": 4,
+			"name": "cluster-host",
+			"pool_uuid": "28f8fabb-43df-4458-a256-d9195e2b6667",
+			"type": "cluster-host",
+			"uuid": "0bebc4ef-e8e4-1248-b9d5-8694a79f58ce",
+			"primary_pool_family": "ipv4"
+		}
+    ]
+}
+`
+
+const NetworkAddrPoolListWithoutDualStackOAM = `
+{
+    "network_addresspools": [
+		{
+			"uuid": "55555555-a6e5-425e-9317-995da88d6695",
+			"network_uuid": "0bebc4ef-e8e4-1248-b9d5-8694a79f58ce",
+			"address_pool_uuid": "28f8fabb-43df-4458-a256-d9195e2b6667",
+			"network_name": "cluster-host",
+			"address_pool_name": "cluster-host"
+		}
+	]
 }
 `
 

--- a/controllers/manager/manager.go
+++ b/controllers/manager/manager.go
@@ -57,12 +57,14 @@ const (
 // Note that the AdminNetworkType is being referenced from host controller as well
 // as platform network controller.
 const (
-	OAMNetworkType         = "oam"
-	MgmtNetworkType        = "mgmt"
-	AdminNetworkType       = "admin"
-	MgmtAddrPoolName       = "management"
-	PXEBootNetworkType     = "pxeboot"
-	ClusterHostNetworkType = "cluster-host"
+	OAMNetworkType            = "oam"
+	MgmtNetworkType           = "mgmt"
+	AdminNetworkType          = "admin"
+	MgmtAddrPoolName          = "management"
+	PXEBootNetworkType        = "pxeboot"
+	ClusterHostNetworkType    = "cluster-host"
+	ClusterPodNetworkType     = "cluster-pod"
+	ClusterServiceNetworkType = "cluster-service"
 	// The network type "other" does not exist in real sense.
 	// It's serves as an indicator to DM that only addresspool
 	// needs to be reconciled and not network / network-addrpools.


### PR DESCRIPTION
In this commit we are enforcing dual-stack to be configured for OAM network before configuring secondary stacks of cluster-host / cluster-pod / cluster-service networks.

Test Cases:
1. PASS - Verify that cluster-host / cluster-pod / cluster-service sercondary stacks are not configured until OAM secondary stack is configured.
2. PASS - Verify that all the UT related to this scenario is successfully executed.