### PR TITLE
Support Day-2 Platform Network Reconfig Workflows in Multinode Systems

### DIFF
--- a/controllers/addresspool_controller.go
+++ b/controllers/addresspool_controller.go
@@ -76,7 +76,7 @@ func (r *AddressPoolReconciler) ReconcileResource(client *gophercloud.ServiceCli
 				}
 			}
 
-			host_instance, err := r.CloudManager.GetActiveHost(request_namespace, client)
+			host_instance, _, err := r.CloudManager.GetHostByPersonality(request_namespace, client, cloudManager.ActiveController)
 			if err != nil {
 				msg := "failed to get active host"
 				return common.NewUserDataError(msg)

--- a/controllers/datanetwork_controller_test.go
+++ b/controllers/datanetwork_controller_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("Datanetwork controller", func() {
 
 	const (
-		timeout  = time.Second * 10
+		timeout  = time.Second * 20
 		interval = time.Millisecond * 250
 	)
 

--- a/controllers/manager/dummy_manager.go
+++ b/controllers/manager/dummy_manager.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/hosts"
 	"github.com/gophercloud/gophercloud/starlingx/nfv/v1/systemconfigupdate"
 	"github.com/pkg/errors"
 	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
@@ -103,13 +104,13 @@ func (m *Dummymanager) GetMonitorVersion() int {
 func (m *Dummymanager) SetMonitorVersion(i int) {
 
 }
-func (m *Dummymanager) StrageySent() {
+func (m *Dummymanager) StrategySent() {
 	m.strategySent = true
 }
-func (m *Dummymanager) GetStrageySent() bool {
+func (m *Dummymanager) GetStrategySent() bool {
 	return m.strategySent
 }
-func (m *Dummymanager) ClearStragey() {
+func (m *Dummymanager) ClearStrategy() {
 
 }
 func (m *Dummymanager) GetNamespace() string {
@@ -147,16 +148,29 @@ func (m *Dummymanager) IsNotifyingActiveHost() bool {
 func (m *Dummymanager) SetNotifyingActiveHost(status bool) {
 
 }
+func (m *Dummymanager) SetStrategyExpectedByOtherReconcilers(status bool) {
+
+}
+func (m *Dummymanager) GetStrategyExpectedByOtherReconcilers() bool {
+	return false
+}
+func (m *Dummymanager) GetHostByPersonality(namespace string, client *gophercloud.ServiceClient, personality string) (*starlingxv1.Host, *hosts.Host, error) {
+	return nil, nil, nil
+}
 func (m *Dummymanager) GcShow(c *gophercloud.ServiceClient) (*systemconfigupdate.SystemConfigUpdate, error) {
-	if len(m.gcShow) == 0 {
-		err := errors.New("test: no info available")
-		return nil, err
-	} else {
+	if len(m.gcShow) != 0 {
 		s := &systemconfigupdate.SystemConfigUpdate{
 			State: m.gcShow,
+			ID:    "abc-def",
 		}
 		return s, nil
 	}
+
+	// VIM API sends json response {"strategy": null} when there are no
+	// strategies on the system and not error responses such as 404.
+	// Hence we are returning nil, nil without error.
+
+	return nil, nil
 }
 func (m *Dummymanager) GcActionStrategy(c *gophercloud.ServiceClient, opts systemconfigupdate.StrategyActionOpts) (*systemconfigupdate.SystemConfigUpdate, error) {
 	m.strategyActionSend = true

--- a/controllers/platformnetwork_controller.go
+++ b/controllers/platformnetwork_controller.go
@@ -75,7 +75,7 @@ func (r *PlatformNetworkReconciler) ReconcileResource(client *gophercloud.Servic
 	if instance.DeletionTimestamp.IsZero() {
 		if instance.Status.ObservedGeneration != instance.ObjectMeta.Generation ||
 			scope_updated {
-			host_instance, err := r.CloudManager.GetActiveHost(reqNs, client)
+			host_instance, _, err := r.CloudManager.GetHostByPersonality(reqNs, client, cloudManager.ActiveController)
 			if err != nil {
 				msg := "failed to get active host"
 				logPlatformNetwork.Error(err, msg)

--- a/controllers/platformnetwork_controller_test.go
+++ b/controllers/platformnetwork_controller_test.go
@@ -16,7 +16,7 @@ import (
 
 var _ = Describe("Platformnetwork controller", func() {
 	const (
-		timeout  = time.Second * 10
+		timeout  = time.Second * 20
 		interval = time.Millisecond * 250
 	)
 

--- a/controllers/ptpinstance_controller_test.go
+++ b/controllers/ptpinstance_controller_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("PtpInstance controller", func() {
 
 	const (
-		timeout  = time.Second * 10
+		timeout  = time.Second * 20
 		interval = time.Millisecond * 250
 	)
 

--- a/controllers/ptpinterface_controller_test.go
+++ b/controllers/ptpinterface_controller_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("PtpInterface controller", func() {
 
 	const (
-		timeout  = time.Second * 10
+		timeout  = time.Second * 20
 		interval = time.Millisecond * 250
 	)
 

--- a/controllers/system/system_controller.go
+++ b/controllers/system/system_controller.go
@@ -1736,7 +1736,7 @@ func (r *SystemReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 	// If strategy is applied, start strategy monitor
 	if instance.Status.StrategyApplied {
 		logSystem.Info("Strategy applied, start strategy monitor")
-		r.CloudManager.StrageySent()
+		r.CloudManager.StrategySent()
 		r.CloudManager.StartStrategyMonitor()
 	} else {
 		logSystem.V(2).Info("Strategy not applied")


### PR DESCRIPTION
Support Day-2 Platform Network Reconfig Workflows in Multinode Systems

In this commit we are enabling reconfiguration of platform networks such
as OAM and admin networks.

Reconfiguration of management network is blocked in multinode system and
OAM network reconfiguration involves lock and unlock of both the
controllers orchestrated by DM through VIM APIs.

The go.mod has also been updated to fix modification of range of the
addresspool during reconfiguration.

Test Cases:
1. PASS - Verify that range of the addresspool can be updated
          successfully for reconfigurable networks.
2. PASS - Verify that OAM, admin network reconfiguration is successful.
3. PASS - Verify that management network reconfiguration is blocked.
4. PASS - Verify that management network configuration is successful
          ie. the secondary stack.
