### PR TITLE
Report error for 'deploy resume' when issue is unresolved

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -154,10 +154,15 @@
         path: /etc/platform/.unlock_ready
       register: is_unlock_ready
 
+    - name: Check if host is provisioned
+      shell: |
+        source /etc/platform/openrc;
+        system host-show "{{ get_host_name.stdout}}" | awk '$2 ~ /^invprovision/ {print $4}'
+      register: get_host_invprovision
+
     - name: Set reconfiguration fact
       set_fact:
-        reconfig_flag: "{{ true if (is_unlock_ready.stat.exists == True)
-                        else false }}"
+        reconfig_flag: "{{ reconfig_flag | default(true if is_unlock_ready.stat.exists else false) }}"
 
     - name: Mark the bootstrap as finalized
       file:


### PR DESCRIPTION
Below blocks are skipped when reconfig_flag is true: 1) Search administrativeState into host resource
2) Wait until unlock task triggered

Thereby, playbook doesn't attempt to apply the config during 'deploy resume' and henceforth any unresolved errors persist but it reports deploy status as 'complete' which is incorrect.

Test Cases:
1. PASS: Run subcloud add with deploy-config. Make sure there is an error condition that will cause DM playbook to fail. Run deploy resume, it should report error.
2. PASS: Run subcloud add with deploy-config. Make sure there is no error condition and DM playbook shall pass. Run deploy resume, it should skip above mentioned tasks.
3. PASS: Day-2 operation tested with controller-0 unlocked for 'system' resource.
4. PASS: Day-2 operation tested with controller-0 locked for 'host' resource.