### PR TITLE
Disable route compare when reconfig

### DIFF
--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -1054,7 +1054,7 @@ func (r *HostReconciler) CompareDisabledAttributes(in *starlingxv1.HostProfileSp
 			}
 		}
 
-		if utils.IsReconcilerEnabled(utils.Route) {
+		if !reconfig && utils.IsReconcilerEnabled(utils.Route) {
 			if !in.Routes.DeepEqual(&other.Routes) {
 				return false
 			}


### PR DESCRIPTION
This commit disables the route comparison when it is a reconfiguration scenario, avoids triggering the lock request in the day-2 operation.

After this change, the route can still be compared during initial deployment or on a enabled host when reconfiguring the host.

Test plan:
1. Initial deployment of AIOSX subcloud with admin network.
2. Reconfigure the admin network(multi-netting), verified the routes update not causing reboot.