### PR TITLE
Add N-1 Support for Subcloud Configuration

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -29,6 +29,9 @@
     - set_fact:
         manager_app_chart: "{{ manager_app_chart | default('/usr/local/share/applications/helm/deployment-manager-*.tgz') }}"
 
+    - set_fact:
+        dm_monitor_playbook: "{{ dm_monitor_playbook | default('/usr/local/share/applications/playbooks/dm-monitor-book.yaml') }}"
+
     - block:
       # Information to be used at final DM checks.
         - name: Get host name
@@ -43,11 +46,18 @@
             awk '$2 ~ /^distributed_cloud_role/ {print $4}'
           register: get_distributed_cloud_role
 
+        - name: Get software version
+          shell: >-
+            source /etc/platform/openrc; system show |
+            awk '$2 ~ /^software_version/ {print $4}'
+          register: get_software_version
+
         - name: Show dc_role and hostname
           debug:
             msg:
             - "hostname: {{get_host_name.stdout}}"
             - "dc_role: {{ get_distributed_cloud_role.stdout }}"
+            - "software_version: {{ get_software_version.stdout }}"
 
     - block:
       # Copy required files up to the target host if this playbook is being
@@ -178,72 +188,135 @@
           msg: "{{ deployment_manager_pod_name.stdout }}"
       when: reconfig_flag
 
-    - name: Check deployment-manager app status
-      shell: source /etc/platform/openrc; system application-list --nowrap | grep deployment-manager | awk '{ print $10 }'
-      register: dm_app_status
-
-    - name: Fail if the deployment manager application staus is not ready to apply
-      fail:
-        msg: >
-          Deployment manager application is not in expected status:
-          {{ dm_app_status.stdout }}
-      when:
-        - dm_app_status.stdout_lines |length > 0
-        - dm_app_status.stdout != 'applied'
-        - dm_app_status.stdout != 'uploaded'
-        - dm_app_status.stdout != 'applying'
-
-    - name: Upload deployment manager
-      block:
-      - name: Find deployment-manager app helm-chart in application directory
-        find:
-          paths: "{{ manager_app_chart | dirname }}"
-          patterns: 'deployment-manager*.tgz'
-        register: app_helm_chart
-
-      - name: Fail deployment-manager app helm-chart does not exists
-        fail:
-          msg: "Deployment manger helm-chart does not exists in application directory"
-        when: (app_helm_chart.files[0].path | length == 0)
-
-      - name: Upload deployment-manager app Helm Chart
-        shell: source /etc/platform/openrc; system application-upload {{ app_helm_chart.files[0].path }}
-
-      - name: Wait deployment-manager app to become uploaded
+    - block:
+      # Install Deployment-Manager as System Application
+      - name: Check deployment-manager app status
         shell: source /etc/platform/openrc; system application-list --nowrap | grep deployment-manager | awk '{ print $10 }'
-        register: app_upload_status
-        retries: 10
-        delay: 6
-        until: ("uploaded" in app_upload_status.stdout)
+        register: dm_app_status
+
+      - name: Fail if the deployment manager application staus is not ready to apply
+        fail:
+          msg: >
+            Deployment manager application is not in expected status:
+            {{ dm_app_status.stdout }}
+        when:
+          - dm_app_status.stdout_lines |length > 0
+          - dm_app_status.stdout != 'applied'
+          - dm_app_status.stdout != 'uploaded'
+          - dm_app_status.stdout != 'applying'
+
+      - name: Upload deployment manager
+        block:
+        - name: Find deployment-manager app helm-chart in application directory
+          find:
+            paths: "{{ manager_app_chart | dirname }}"
+            patterns: 'deployment-manager*.tgz'
+          register: app_helm_chart
+
+        - name: Fail deployment-manager app helm-chart does not exists
+          fail:
+            msg: "Deployment manger helm-chart does not exists in application directory"
+          when: (app_helm_chart.files[0].path | length == 0)
+
+        - name: Upload deployment-manager app Helm Chart
+          shell: source /etc/platform/openrc; system application-upload {{ app_helm_chart.files[0].path }}
+
+        - name: Wait deployment-manager app to become uploaded
+          shell: source /etc/platform/openrc; system application-list --nowrap | grep deployment-manager | awk '{ print $10 }'
+          register: app_upload_status
+          retries: 10
+          delay: 6
+          until: ("uploaded" in app_upload_status.stdout)
+          ignore_errors: yes
+
+        - name: Fail if deployment-manager app upload fails
+          fail:
+            msg: "The upload of deployment-manager system app has failed.
+                  Expected 'uploaded' state but the app is in
+                  '{{ app_upload_status.stdout }}' state "
+          when: not ("uploaded" in app_upload_status.stdout)
+
+        when: dm_app_status.stdout_lines|length == 0
+
+      - name: Apply deployment-manager app
+        shell: source /etc/platform/openrc; system application-apply deployment-manager
+        when: dm_app_status.stdout != 'applied' and dm_app_status.stdout != 'applying'
+
+      - name: Wait deployment-manager app to become applied
+        shell: source /etc/platform/openrc; system application-list --nowrap | grep deployment-manager | awk '{ print $10 }'
+        register: app_apply_status
+        retries: 30
+        delay: 10
+        until: ("applied" in app_apply_status.stdout)
         ignore_errors: yes
 
-      - name: Fail if deployment-manager app upload fails
+      - name: Fail if deployment-manager app apply fails
         fail:
-          msg: "The upload of deployment-manager system app has failed.
-                Expected 'uploaded' state but the app is in
-                '{{ app_upload_status.stdout }}' state "
-        when: not ("uploaded" in app_upload_status.stdout)
+          msg: "The apply of DM system app has failed.
+                Expected 'applied' state but the app is in
+                '{{ app_apply_status.stdout }}' state."
+        when: not ("applied" in app_apply_status.stdout)
 
-      when: dm_app_status.stdout_lines|length == 0
+      when: get_software_version.stdout >= "24.09"
 
-    - name: Apply deployment-manager app
-      shell: source /etc/platform/openrc; system application-apply deployment-manager
-      when: dm_app_status.stdout != 'applied' and dm_app_status.stdout != 'applying'
+    - block:
+      # Remove webhook and webhook service
+      - name: Search webhook configurations for v1
+        shell: |
+          kubectl get ValidatingWebhookConfigurations validating-webhook-configuration --no-headers | awk 'NR == 1 { print $1 }'
+        environment:
+          KUBECONFIG: "/etc/kubernetes/admin.conf"
+        ignore_errors: yes
+        register: validation_webhook
 
-    - name: Wait deployment-manager app to become applied
-      shell: source /etc/platform/openrc; system application-list --nowrap | grep deployment-manager | awk '{ print $10 }'
-      register: app_apply_status
-      retries: 30
-      delay: 10
-      until: ("applied" in app_apply_status.stdout)
-      ignore_errors: yes
+      - name: Query for validating webhook configuration
+        shell: |
+          grep -iq 'validating-webhook-configuration' <<< {{ validation_webhook.stdout_lines }}
+        ignore_errors: yes
+        register: webhook_config_exists
 
-    - name: Fail if deployment-manager app apply fails
-      fail:
-        msg: "The apply of DM system app has failed.
-              Expected 'applied' state but the app is in
-              '{{ app_apply_status.stdout }}' state."
-      when: not ("applied" in app_apply_status.stdout)
+      - name: Delete validating webhook configuration
+        shell: |
+          kubectl delete ValidatingWebhookConfigurations validating-webhook-configuration
+        environment:
+          KUBECONFIG: "/etc/kubernetes/admin.conf"
+        when: webhook_config_exists.rc == 0
+
+      - name: Search webhook service for v1
+        shell: |
+          kubectl get svc webhook-server-service -n platform-deployment-manager --no-headers | awk 'NR == 1 { print $1 }'
+        environment:
+          KUBECONFIG: "/etc/kubernetes/admin.conf"
+        register: webhook_service
+
+      - name: Query for webhook-server-service
+        shell: |
+          grep -iq 'webhook-server-service' <<< {{ webhook_service.stdout_lines }}
+        ignore_errors: yes
+        register: webhook_service_exists
+
+      - name: Delete webhook-server-service
+        shell: |
+          kubectl delete svc webhook-server-service -n platform-deployment-manager
+        environment:
+          KUBECONFIG: "/etc/kubernetes/admin.conf"
+        when: webhook_service_exists.rc == 0
+
+      # Install Helm Based Deployment Manager
+      - name: Install Helm Based Deployment Manager
+        shell: KUBECONFIG=/etc/kubernetes/admin.conf /usr/sbin/helm upgrade --install deployment-manager {% if helm_chart_overrides is defined %}--values {{ helm_chart_overrides }}{% endif %} {{ manager_chart }}
+
+      # Install or Upgrade DM-Monitor
+      - name: "Install or Upgrade Helm Based DM-monitor"
+        shell: "ansible-playbook {{ dm_monitor_playbook }}"
+        become: yes
+        ignore_errors: yes
+        when: dm_monitor_playbook
+
+      when:
+        - get_software_version.stdout < "24.09"
+        - "'subcloud' in get_distributed_cloud_role.stdout"
+        - user_uploaded_artifacts is false
 
     # Delete old Deployment Manager pod if it was reinstalled,
     # the pod to delete may already be terminated by helm
@@ -699,9 +772,14 @@
 
           # After reboot, wait for resource reconciliation. This ensures the
           # playbook doesn't fail if resources are properly reconciled.
+          - name: Define resource list based on version
+            set_fact:
+              resources: "{{ 'systems,datanetworks,platformnetworks,ptpinstances,ptpinterfaces' if get_software_version.stdout < '24.09'
+                        else 'systems,datanetworks,platformnetworks,ptpinstances,ptpinterfaces,addresspools' }}"
+
           - name: Get not reconciled resource
             shell: >
-              (kubectl get systems,datanetworks,platformnetworks,addresspools,ptpinstances,ptpinterfaces
+              (kubectl get "{{ resources }}"
               -o custom-columns='NAME:.metadata.name,RECONCILED:.status.reconciled'
               -n deployment;
               kubectl -n deployment get hosts "{{ get_host_name.stdout }}" -o


### PR DESCRIPTION
Due to USM, the load-import functionality has been replaced with software upload. In the software upload
process for N-1 loads, deployment-manager files are no longer present in /opt/platform/software_version.

We are checking for the presence of DM deploy files in the /opt/platform/deploy/<sw_version> directory.
If these files are found, the DM files (playbook, overrides, helm-chart) will be updated in the payload.

If the files are not found in the specified directory, the process will then search for them in an alternative
location at /usr/local/share/applications/ on the system controller. If located there, these files will
update the DM files in the payload, and the user_uploaded_artifacts flag will be set to false, indicating that the files were not manually uploaded by the user.

Since the system controller playbook is updated in the payload rather than the subcloud, this means the system controller
playbook (version 24.09) will be executed within the subcloud configuration version 22.12. 

To address this, the playbook now verifies whether the host version is less than 24.09, if the subcloud and user has not
uploaded DM artifacts then helm based Deployment-manager is install.

Test-Plan:
A) PASS: Deploy AIO-SX successfully.

B) Set-up
DC-libvirt 24.09 system controller 22.12 subcloud

1. Uploaded 22.12 DM artifacts using
   dcmanager subcloud deploy upload DM-chart, overrides,
   playbook.
2. Added a 22.12 subcloud using dcmanager subcloud add.
   Validated the uploaded artifacts are picked up for
   configuration.
3. Helm based DM and DM monitor is running.
4. Deleted the DM artifacts present on the subcloud in
   /usr/local/share/applications/
5. Recong a subcloud using dcmanager subcloud deploy config,
   validated the uploaded artifacts are picked up for
   configuration.
6. Helm based DM and DM monitor is running.

1. Not uploaded 22.12 DM artifacts using
2. Added a 22.12 subcloud using dcmanager subcloud add.
   Validated the DM helm-chart and overrides are picked from
   sublcoud for configuration, and playbook from system controller.
3. Helm based DM and DM monitor is running.
4. Recong a subcloud using dcmanager subcloud deploy config,
   Validated the DM helm-chart and overrides are picked from
   sublcoud for configuration, and playbook from system controller.
5. Helm based DM and DM monitor is running.

C) Set-up
DC-libvirt 24.09 system controller 24.09 subcloud

1. Not uploaded 24.09 DM artifacts using
   dcmanager subcloud deploy upload DM-chart, overrides,
   playbook.
2. Added a 24.09 subcloud using dcmanager subcloud add.
3. System application based DM and DM monitor is running.
4. Recong a subcloud using dcmanager subcloud deploy config.
5. System application based DM and DM monitor is running.