### PR TITLE
Restrict Filesystem Removal

### DIFF
--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -70,6 +70,7 @@ var CephPrimaryGroup []string
 
 // Only the listed file systems are allow to create and delete
 var FileSystemCreationAllowed = []string{"instances", "image-conversion", "ceph"}
+var FileSystemDeletionAllowed = []string{"instances", "image-conversion"}
 
 var _ reconcile.Reconciler = &HostReconciler{}
 
@@ -886,7 +887,7 @@ func (r *HostReconciler) CompareFileSystemTypes(in *starlingxv1.HostProfileSpec,
 		// Find difference of file system types to add or remove
 		added, removed, _ := utils.ListDelta(current, configured)
 		_, _, fs_to_add := utils.ListDelta(added, FileSystemCreationAllowed)
-		_, _, fs_to_remove := utils.ListDelta(removed, FileSystemCreationAllowed)
+		_, _, fs_to_remove := utils.ListDelta(removed, FileSystemDeletionAllowed)
 
 		if len(fs_to_remove) > 0 || len(fs_to_add) > 0 {
 			return false

--- a/controllers/host/host_controller_test.go
+++ b/controllers/host/host_controller_test.go
@@ -659,7 +659,7 @@ var _ = Describe("Host controller", func() {
 						Size: 2,
 					},
 					{
-						Name: "ceph",
+						Name: "image-conversion",
 						Size: 1,
 					},
 				}},
@@ -676,6 +676,40 @@ var _ = Describe("Host controller", func() {
 
 			got := r.CompareFileSystemTypes(in, other)
 			Expect(got).To(BeFalse())
+		})
+		It("Should return true when in and other storage are not equal, since ceph fs does not support removal", func() {
+			in := &starlingxv1.HostProfileSpec{
+				Storage: &starlingxv1.ProfileStorageInfo{Monitor: nil, OSDs: nil, VolumeGroups: nil, FileSystems: &starlingxv1.FileSystemList{
+					{
+						Name: "instances",
+						Size: 5,
+					},
+				}},
+			}
+			other := &starlingxv1.HostProfileSpec{
+				Storage: &starlingxv1.ProfileStorageInfo{Monitor: nil, OSDs: nil, VolumeGroups: nil, FileSystems: &starlingxv1.FileSystemList{
+					{
+						Name: "instances",
+						Size: 2,
+					},
+					{
+						Name: "ceph",
+						Size: 1,
+					},
+				}},
+			}
+
+			var k8sManager, _ = ctrl.NewManager(cfg, ctrl.Options{
+				Scheme:             scheme.Scheme,
+				MetricsBindAddress: "0",
+			})
+			r := &HostReconciler{
+				Client: k8sManager.GetClient(),
+				Scheme: k8sManager.GetScheme(),
+			}
+
+			got := r.CompareFileSystemTypes(in, other)
+			Expect(got).To(BeTrue())
 		})
 	})
 

--- a/controllers/host/storage.go
+++ b/controllers/host/storage.go
@@ -727,7 +727,7 @@ func (r *HostReconciler) ReconcileFileSystemTypes(client *gophercloud.ServiceCli
 	// Find difference of file system types to add or remove
 	added, removed, _ := common.ListDelta(current, configured)
 	_, _, fs_to_add := common.ListDelta(added, FileSystemCreationAllowed)
-	_, _, fs_to_remove := common.ListDelta(removed, FileSystemCreationAllowed)
+	_, _, fs_to_remove := common.ListDelta(removed, FileSystemDeletionAllowed)
 
 	if len(fs_to_remove) > 0 {
 		updated, err := r.DeleteFileSystems(client, fs_to_remove, host)


### PR DESCRIPTION
Although the ceph host filesystem is optional and allowed to be created, its removal is only supported in specific situations and should not be addressed by the Deployment Manager.

This commit also resolves a reconcile error due to the automatic creation of the ceph host filesystem using Ceph bare metal.

Includes:
- Creates the FileSystemDeletionAllowed list excluding ceph.
- Updates the "Should return false when in and other storage is not equal and have allowed filesystem types" feature test to use the image-conversion instead of ceph.
- Creates a new feature test expecting the reconciliation to be true when the extra filesystem is ceph.