### PR TITLE
Enable playbook task for ignoring unreachable servers

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -614,7 +614,7 @@
             wait_for:
               timeout: "{{ boot_wait_time }}"
             register: waiting_after_reboot
-            ignore_errors: true
+            ignore_unreachable: true
 
           # Retry block: sometimes system reboots twice
           # It will take some extra time.


### PR DESCRIPTION
    Enable playbook task for ignoring unreachable servers

    DM playbook failed due to second reboot on standard subcloud.
    Playbook has block for when system reboot twice but it was not
    getting triggered. When server is unreachable, task status is
    set to unreachable instead of failed. From ansible 2.7, it is
    possible to use ignore_unreachable.

    Test Cases:
    1. PASS: Run dcmanager add from system controller. Deployment
       config is applied successfully on controller-0 with server
       rebooting twice. 'deploy status' shall be 'complete' for the
       subcloud.
    2. PASS: Deploy AIO-SX successfully.