### PR TITLE
Update factory install config workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,10 @@ expected to be applied once again to finalize the configuration of the system.
 The Deployment Manager can read/update a configmap and orchestrate the
 configuration process accordingly.
 
+Note: only one host is expected to deployed before updating again, and the host
+is expected to be locked. Otherwise, the configMap will be set as finalized
+to block the further operation.
+
 ```yaml
 apiVersion: v1
 kind: ConfigMap
@@ -546,7 +550,10 @@ data:
 Once the factory-installed data is set to true, the Deployment Manager will
 recollect the default resource configuration(which is expected to be set up
 before the Deployment Manager and should not be updated by the Deployment
-Manager), and force a strategy required orchestration only once until finalized.
+Manager), and force update the reconciled status as false until finalized.
+
+The factory-config-finalized value is expected to be set as true once a host
+is unlocked.
 
 Once the factory-config-finalized is set to true, or the configmap is deleted
 from the namespace, this operation will not be triggered.

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -568,11 +568,17 @@ func UpdateDefaultsRequired(
 	name string,
 	factory bool,
 ) (bool, error) {
+	// TODO(yuxing) currently the UpdateDefaultsRequired only works on factory
+	// installed scenario, consider remove this restriction for generic usage
 	if !factory {
 		return false, nil
 	}
 
-	defaultUpdated, err := manager.GetResourceDefaultUpdated(namespace, name)
+	defaultUpdated, err := manager.GetFactoryResourceDataUpdated(
+		namespace,
+		name,
+		"default",
+	)
 
 	if err != nil {
 		// Failed to get the info, force to update it again

--- a/controllers/common/common_test.go
+++ b/controllers/common/common_test.go
@@ -288,7 +288,12 @@ func TestUpdateDefaultsRequired(t *testing.T) {
 			}
 
 			// Test setting resource default updated
-			err := manager.SetResourceDefaultUpdated("deployment", "system-abcd", tt.expectedDefaultUpdated)
+			err := manager.SetFactoryResourceDataUpdated(
+				"deployment",
+				"system-abcd",
+				"default",
+				tt.expectedDefaultUpdated,
+			)
 			if err != nil && tt.expectedError == nil {
 				t.Fatalf("expected no error, got %v", err)
 			}
@@ -297,7 +302,11 @@ func TestUpdateDefaultsRequired(t *testing.T) {
 			}
 
 			// Test getting resource default updated
-			result, err := manager.GetResourceDefaultUpdated("deployment", "system-abcd")
+			result, err := manager.GetFactoryResourceDataUpdated(
+				"deployment",
+				"system-abcd",
+				"default",
+			)
 			if err != nil && tt.expectedError == nil {
 				t.Fatalf("expected no error, got %v", err)
 			}

--- a/controllers/datanetwork_controller.go
+++ b/controllers/datanetwork_controller.go
@@ -367,16 +367,11 @@ func (r *DataNetworkReconciler) StopAfterInSync() bool {
 // Update ReconcileAfterInSync in instance
 // ReconcileAfterInSync value will be:
 // "true"  if deploymentScope is "principal" because it is day 2 operation (update configuration)
-// "true"  if the factory install is not finalized
 // "false" if deploymentScope is "bootstrap"
 // Then reflect these values to cluster object
 // It is expected that instance.Status.Deployment scope is already updated by
 // UpdateDeploymentScope at this point.
 func (r *DataNetworkReconciler) UpdateConfigStatus(instance *starlingxv1.DataNetwork, ns string) (err error) {
-	factory, err := r.CloudManager.GetFactoryInstall(ns)
-	if err != nil {
-		return err
-	}
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		err := r.Client.Get(context.TODO(), types.NamespacedName{
 			Name:      instance.Name,
@@ -388,10 +383,9 @@ func (r *DataNetworkReconciler) UpdateConfigStatus(instance *starlingxv1.DataNet
 
 		// Put ReconcileAfterInSync values depends on scope
 		// "true"  if scope is "principal" because it is day 2 operation (update configuration)
-		// "true"  if the factory install is not finalized
 		// "false" if scope is "bootstrap" or None
 		afterInSync, ok := instance.Annotations[cloudManager.ReconcileAfterInSync]
-		if instance.Status.DeploymentScope == cloudManager.ScopePrincipal || factory {
+		if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
 			if !ok || afterInSync != "true" {
 				instance.Annotations[cloudManager.ReconcileAfterInSync] = "true"
 			}
@@ -429,9 +423,9 @@ func (r *DataNetworkReconciler) UpdateConfigStatus(instance *starlingxv1.DataNet
 				// Case: DM upgrade in reconciled node
 				instance.Status.ConfigurationUpdated = false
 			} else {
-				// Case: Fresh/factory install or Day-2 operation
+				// Case: Fresh install or Day-2 operation
 				instance.Status.ConfigurationUpdated = true
-				if instance.Status.DeploymentScope == cloudManager.ScopePrincipal || factory {
+				if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
 					instance.Status.Reconciled = false
 					// Update strategy required status for strategy monitor
 					r.CloudManager.UpdateConfigVersion()
@@ -452,6 +446,47 @@ func (r *DataNetworkReconciler) UpdateConfigStatus(instance *starlingxv1.DataNet
 		return err
 	}
 
+	return nil
+}
+
+// During factory install, the reconciled status is expected to be updated to
+// false to unblock the configuration as the day 1 configuration.
+// UpdateStatusForFactoryInstall updates the status by checking the factory
+// install data.
+func (r *DataNetworkReconciler) UpdateStatusForFactoryInstall(
+	ns string,
+	instance *starlingxv1.DataNetwork,
+) error {
+	reconciledUpdated, err := r.CloudManager.GetFactoryResourceDataUpdated(
+		ns,
+		instance.Name,
+		"reconciled",
+	)
+	if err != nil {
+		return err
+	}
+
+	if !reconciledUpdated {
+		instance.Status.Reconciled = false
+		err = r.Client.Status().Update(context.TODO(), instance)
+		if err != nil {
+			return err
+		}
+		err = r.CloudManager.SetFactoryResourceDataUpdated(
+			ns,
+			instance.Name,
+			"reconciled",
+			true,
+		)
+		if err != nil {
+			return err
+		}
+		r.ReconcilerEventLogger.NormalEvent(
+			instance,
+			common.ResourceUpdated,
+			"Set Reconciled false for factory install",
+		)
+	}
 	return nil
 }
 
@@ -498,14 +533,20 @@ func (r *DataNetworkReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 		return reconcile.Result{}, err
 	}
 
-	// The status reaches its desired status post reconciled
-	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation &&
-		instance.Status.Reconciled {
-
-		factory, err := r.GetFactoryInstall(request.Namespace)
+	factory, err := r.CloudManager.GetFactoryInstall(request.Namespace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if factory {
+		err := r.UpdateStatusForFactoryInstall(request.Namespace, instance)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
+	}
+
+	// The status reaches its desired status post reconciled
+	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation &&
+		instance.Status.Reconciled {
 
 		if !scope_updated && !factory {
 			logDataNetwork.V(2).Info("reconcile finished, desired state reached after reconciled.")

--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -1054,7 +1054,7 @@ func (r *HostReconciler) CompareDisabledAttributes(in *starlingxv1.HostProfileSp
 			}
 		}
 
-		if utils.IsReconcilerEnabled(utils.Route) {
+		if !reconfig && utils.IsReconcilerEnabled(utils.Route) {
 			if !in.Routes.DeepEqual(&other.Routes) {
 				return false
 			}

--- a/controllers/manager/manager.go
+++ b/controllers/manager/manager.go
@@ -148,8 +148,8 @@ type CloudManager interface {
 	// factory install related methods
 	GetFactoryInstall(namespace string) (bool, error)
 	SetFactoryConfigFinalized(namespace string, value bool) error
-	SetResourceDefaultUpdated(namespace string, name string, value bool) error
-	GetResourceDefaultUpdated(namespace string, name string) (bool, error)
+	SetFactoryResourceDataUpdated(namespace string, name string, data string, value bool) error
+	GetFactoryResourceDataUpdated(namespace string, name string, data string) (bool, error)
 
 	// gophercloud
 	GcShow(c *gophercloud.ServiceClient) (*systemconfigupdate.SystemConfigUpdate, error)

--- a/controllers/manager/monitor.go
+++ b/controllers/manager/monitor.go
@@ -6,6 +6,8 @@ package manager
 import (
 	"fmt"
 
+	"time"
+
 	"github.com/go-logr/logr"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/starlingx/nfv/v1/systemconfigupdate"
@@ -13,7 +15,6 @@ import (
 	errors2 "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 // Monitor defines the interface which must be implemented by all concrete
@@ -327,15 +328,6 @@ func monitorStrategyState(management CloudManager) bool {
 	case StrategyApplied:
 		log.Info("Strategy applied. Finish strategy monitor.")
 		deleteStrategy(management, client)
-		ns := management.GetNamespace()
-		if ns == "" {
-			log.Info("System namespace does not exist. Skip")
-		} else {
-			err := management.SetFactoryConfigFinalized(ns, true)
-			if err != nil {
-				log.Error(err, "Failed to set factory config finalized")
-			}
-		}
 		return true
 	}
 	return false

--- a/controllers/platformnetwork_controller.go
+++ b/controllers/platformnetwork_controller.go
@@ -141,16 +141,11 @@ func (r *PlatformNetworkReconciler) UpdateDeploymentScope(instance *starlingxv1.
 // Update ReconcileAfterInSync in instance
 // ReconcileAfterInSync value will be:
 // "true"  if deploymentScope is "principal" because it is day 2 operation (update configuration)
-// "true"  if the factory install is not finalized
 // "false" if deploymentScope is "bootstrap"
 // Then reflect these values to cluster object
 // It is expected that instance.Status.Deployment scope is already updated by
 // UpdateDeploymentScope at this point.
 func (r *PlatformNetworkReconciler) UpdateConfigStatus(instance *starlingxv1.PlatformNetwork, ns string) (err error) {
-	factory, err := r.CloudManager.GetFactoryInstall(ns)
-	if err != nil {
-		return err
-	}
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		err := r.Client.Get(context.TODO(), types.NamespacedName{
 			Name:      instance.Name,
@@ -162,10 +157,9 @@ func (r *PlatformNetworkReconciler) UpdateConfigStatus(instance *starlingxv1.Pla
 
 		// Put ReconcileAfterInSync values depends on scope
 		// "true"  if scope is "principal" because it is day 2 operation (update configuration)
-		// "true"  if the factory install is not finalized
 		// "false" if scope is "bootstrap" or None
 		afterInSync, ok := instance.Annotations[cloudManager.ReconcileAfterInSync]
-		if instance.Status.DeploymentScope == cloudManager.ScopePrincipal || factory {
+		if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
 			if !ok || afterInSync != "true" {
 				instance.Annotations[cloudManager.ReconcileAfterInSync] = "true"
 			}
@@ -210,6 +204,47 @@ func (r *PlatformNetworkReconciler) UpdateConfigStatus(instance *starlingxv1.Pla
 		return err
 	}
 
+	return nil
+}
+
+// During factory install, the reconciled status is expected to be updated to
+// false to unblock the configuration as the day 1 configuration.
+// UpdateStatusForFactoryInstall updates the status by checking the factory
+// install data.
+func (r *PlatformNetworkReconciler) UpdateStatusForFactoryInstall(
+	ns string,
+	instance *starlingxv1.PlatformNetwork,
+) error {
+	reconciledUpdated, err := r.CloudManager.GetFactoryResourceDataUpdated(
+		ns,
+		instance.Name,
+		"reconciled",
+	)
+	if err != nil {
+		return err
+	}
+
+	if !reconciledUpdated {
+		instance.Status.Reconciled = false
+		err = r.Client.Status().Update(context.TODO(), instance)
+		if err != nil {
+			return err
+		}
+		err = r.CloudManager.SetFactoryResourceDataUpdated(
+			ns,
+			instance.Name,
+			"reconciled",
+			true,
+		)
+		if err != nil {
+			return err
+		}
+		r.ReconcilerEventLogger.NormalEvent(
+			instance,
+			common.ResourceUpdated,
+			"Set Reconciled false for factory install",
+		)
+	}
 	return nil
 }
 
@@ -261,14 +296,20 @@ func (r *PlatformNetworkReconciler) Reconcile(ctx context.Context, request ctrl.
 		return reconcile.Result{}, err
 	}
 
-	// The status reaches its desired status post reconciled
-	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation &&
-		instance.Status.Reconciled {
-
-		factory, err := r.GetFactoryInstall(request.Namespace)
+	factory, err := r.CloudManager.GetFactoryInstall(request.Namespace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if factory {
+		err := r.UpdateStatusForFactoryInstall(request.Namespace, instance)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
+	}
+
+	// The status reaches its desired status post reconciled
+	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation &&
+		instance.Status.Reconciled {
 
 		if !scope_updated && !factory {
 			logPlatformNetwork.V(2).Info("reconcile finished, desired state reached after reconciled.")

--- a/controllers/ptpinterface_controller.go
+++ b/controllers/ptpinterface_controller.go
@@ -447,16 +447,11 @@ func (r *PtpInterfaceReconciler) StopAfterInSync() bool {
 // Update ReconcileAfterInSync in instance
 // ReconcileAfterInSync value will be:
 // "true"  if deploymentScope is "principal" because it is day 2 operation (update configuration)
-// "true" if factory install is not finalized
 // "false" if deploymentScope is "bootstrap"
 // Then reflect these values to cluster object
 // It is expected that instance.Status.Deployment scope is already updated by
 // UpdateDeploymentScope at this point.
 func (r *PtpInterfaceReconciler) UpdateConfigStatus(instance *starlingxv1.PtpInterface, ns string) (err error) {
-	factory, err := r.CloudManager.GetFactoryInstall(ns)
-	if err != nil {
-		return err
-	}
 
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		err := r.Client.Get(context.TODO(), types.NamespacedName{
@@ -469,10 +464,9 @@ func (r *PtpInterfaceReconciler) UpdateConfigStatus(instance *starlingxv1.PtpInt
 
 		// Put ReconcileAfterInSync values depends on scope
 		// "true"  if scope is "principal" because it is day 2 operation (update configuration)
-		// "true"  if the factory install is not finalized
 		// "false" if scope is "bootstrap" or None
 		afterInSync, ok := instance.Annotations[cloudManager.ReconcileAfterInSync]
-		if instance.Status.DeploymentScope == cloudManager.ScopePrincipal || factory {
+		if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
 			if !ok || afterInSync != "true" {
 				instance.Annotations[cloudManager.ReconcileAfterInSync] = "true"
 			}
@@ -509,9 +503,9 @@ func (r *PtpInterfaceReconciler) UpdateConfigStatus(instance *starlingxv1.PtpInt
 				// Case: DM upgrade in reconciled node
 				instance.Status.ConfigurationUpdated = false
 			} else {
-				// Case: Fresh/factory install or Day-2 operation
+				// Case: Fresh install or Day-2 operation
 				instance.Status.ConfigurationUpdated = true
-				if instance.Status.DeploymentScope == cloudManager.ScopePrincipal || factory {
+				if instance.Status.DeploymentScope == cloudManager.ScopePrincipal {
 					instance.Status.Reconciled = false
 					// Update strategy required status for strategy monitor
 					r.CloudManager.UpdateConfigVersion()
@@ -532,6 +526,47 @@ func (r *PtpInterfaceReconciler) UpdateConfigStatus(instance *starlingxv1.PtpInt
 		return err
 	}
 
+	return nil
+}
+
+// During factory install, the reconciled status is expected to be updated to
+// false to unblock the configuration as the day 1 configuration.
+// UpdateStatusForFactoryInstall updates the status by checking the factory
+// install data.
+func (r *PtpInterfaceReconciler) UpdateStatusForFactoryInstall(
+	ns string,
+	instance *starlingxv1.PtpInterface,
+) error {
+	reconciledUpdated, err := r.CloudManager.GetFactoryResourceDataUpdated(
+		ns,
+		instance.Name,
+		"reconciled",
+	)
+	if err != nil {
+		return err
+	}
+
+	if !reconciledUpdated {
+		instance.Status.Reconciled = false
+		err = r.Client.Status().Update(context.TODO(), instance)
+		if err != nil {
+			return err
+		}
+		err = r.CloudManager.SetFactoryResourceDataUpdated(
+			ns,
+			instance.Name,
+			"reconciled",
+			true,
+		)
+		if err != nil {
+			return err
+		}
+		r.ReconcilerEventLogger.NormalEvent(
+			instance,
+			common.ResourceUpdated,
+			"Set Reconciled false for factory install",
+		)
+	}
 	return nil
 }
 
@@ -581,13 +616,19 @@ func (r *PtpInterfaceReconciler) Reconcile(ctx context.Context, request ctrl.Req
 		return reconcile.Result{}, err
 	}
 
-	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation &&
-		instance.Status.Reconciled {
-
-		factory, err := r.GetFactoryInstall(request.Namespace)
+	factory, err := r.CloudManager.GetFactoryInstall(request.Namespace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if factory {
+		err := r.UpdateStatusForFactoryInstall(request.Namespace, instance)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
+	}
+
+	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation &&
+		instance.Status.Reconciled {
 
 		if !scope_updated && !factory {
 			logPtpInterface.V(2).Info("reconcile finished, desired state reached after reconciled.")


### PR DESCRIPTION
Update factory install config workflow
As the factory install workflow changes: starting from fully deployed
system to only the active controller was deployed. This commit updates
the configuration workflow to align with the starting point: using the
day-1 operation rather than day-2 operation to config the system.

This commit:
1. Removes the strategy-related code for configuration post-factory
install.
2. Update all the resources' reconciled status to "false" once to
unblock the reconciliation.
3. Set the configuration post factory install finalized post the
unlock of the active controller.

With this change, the configuration post-factory install should no
longer trigger a vim strategy to orchestrate the lock/unlock of the
hosts.

Additional requests:
1 the host should be locked before applying the configMap to start the
configuration.
2 the administrative status should be set to "unlock" to trigger the
unlock of the host.

Test plan:
1. Deploy an active controller of a DX system, and lock the controller.
2. Apply the configMap to trigger the configuration.
3. Verify the host can be reconfigured and unlocked by DM.
4. Verify the host can be reconciled post-unlock.

Signed-off-by: Yuxing Jiang <Yuxing.Jiang@windriver.com>
