### PR TITLE
kubectl delete <crd> command failed by timed out error

### DIFF
--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -1868,6 +1868,12 @@ func (r *HostReconciler) ReconcileResource(
 		host, err = hosts.Get(client, *id).Extract()
 		if err != nil {
 			if _, ok := err.(gophercloud.ErrDefault404); !ok {
+				if !instance.DeletionTimestamp.IsZero() {
+					if utils.ContainsString(instance.ObjectMeta.Finalizers, HostFinalizerName) {
+						// Remove the finalizer
+						r.removeHostFinalizer(instance)
+					}
+				}
 				err = perrors.Wrapf(err, "failed to get: %s", *id)
 				return err
 			}


### PR DESCRIPTION
When kubectl delete crd is executed its getting timed out
The CRD finalizer is removed to make sure no the command is not timed out

Test Cases:
PASS- kubectl delete <CRD> should not timeout