### PR TITLE
Enable playbook task for ignoring unreachable servers

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -643,7 +643,7 @@
                 wait_for:
                   timeout: 300
                 register: waiting_after_failures
-                ignore_errors: true
+                ignore_unreachable: true
 
               - name: Get post unlock state
                 shell: >-
@@ -684,7 +684,7 @@
             wait_for:
               timeout: "{{ boot_wait_time }}"
             register: waiting_after_reboot
-            ignore_errors: true
+            ignore_unreachable: true
 
           # Retry block: sometimes system reboots twice
           # It will take some extra time.


### PR DESCRIPTION
DM playbook fails when the task status is set to unreachable instead of failed. Seems the clause 'ignore_errors: true' is treated different than just a task failure. From ansible 2.7, it is possible to use ignore_unreachable.

Test Cases:
1. PASS: Run dcmanager add from system controller. Deployment config is applied successfully on controller-0. 'deploy status' shall be 'complete' for the subcloud.
2. PASS: Deploy AIO-SX successfully.