### PR TITLE
DM does not reconcile due to the runtime installed certs

### DIFF
--- a/controllers/system/system_controller_test.go
+++ b/controllers/system/system_controller_test.go
@@ -163,4 +163,57 @@ var _ = Describe("System controller", func() {
 			Expect(k8sClient.Create(ctx, created)).To(Succeed())
 		})
 	})
+	Context("For the FixCertsToManage func when current has runtimeCerts", func() {
+		It("Should remove the rutime certs and return the remaining", func() {
+			specCerts := &starlingxv1.CertificateList{
+				{
+					Type:      "ssl_ca",
+					Secret:    "ssl-ca-secret-1",
+					Signature: "",
+				},
+				{
+					Type:      "ssl_ca",
+					Secret:    "ssl-ca-secret-2",
+					Signature: "",
+				},
+				{
+					Type:      "ssl_ca",
+					Secret:    "ssl-ca-secret-3",
+					Signature: "",
+				},
+			}
+			currentCerts := &starlingxv1.CertificateList{
+				{
+					Type:      "ssl_ca",
+					Secret:    "ssl-ca-secret-1",
+					Signature: "ssl_ca_0011",
+				},
+				{
+					Type:      "ssl_ca",
+					Secret:    "ssl-ca-secret-2",
+					Signature: "ssl_ca_0012",
+				},
+				{
+					Type:      "ssl_ca",
+					Secret:    "ssl-ca-secret-0",
+					Signature: "ssl_ca_0013",
+				},
+			}
+
+			expRes := starlingxv1.CertificateList{
+				{
+					Type:      "ssl_ca",
+					Secret:    "ssl-ca-secret-1",
+					Signature: "ssl_ca_0011",
+				},
+				{
+					Type:      "ssl_ca",
+					Secret:    "ssl-ca-secret-2",
+					Signature: "ssl_ca_0012",
+				},
+			}
+			res := FixCertsToManage(specCerts, currentCerts)
+			Expect(res).To(Equal(expRes))
+		})
+	})
 })


### PR DESCRIPTION
DM should ignore the ssl_ca certificates that gets installed in the system at the runtime

Test Plan:
PASS: The AIO-SX VM should not show delta with certs and host insync should be true when day2 operation is attempted on the host