### PR TITLE
Restart the DM pod during enrollment after applying configuration

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM golang:1.22.3-bullseye
+FROM golang:1.23.0-bullseye
 
 # Install our required version of Kustomize to generate the examples
 RUN wget https://github.com/kubernetes-sigs/kustomize/releases/download/v1.0.11/kustomize_1.0.11_linux_amd64 -q -O /usr/local/bin/kustomize && chmod 755 /usr/local/bin/kustomize

--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -1,3 +1,4 @@
+---
 # SPDX-License-Identifier: Apache-2.0
 # Copyright(c) 2021-2024 Wind River Systems, Inc.
 - name: Deployment Manager Playbook
@@ -383,6 +384,14 @@
             deploy_config: "/home/{{ ansible_ssh_user }}/deployment-config.yaml"
           when: inventory_hostname != 'localhost'
 
+        - name: Check for the presence of the subcloud enrollment completed
+          stat:
+            path: /var/run/.subcloud_enrollment_completed
+          register: subcloud_enrollment_status
+
+        - set_fact:
+            subcloud_enrollment: "{{ subcloud_enrollment_status.stat.exists }}"
+
         - name: Configure required region value if not systemcontroller
           block:
           - name: Get region name from environment
@@ -420,19 +429,48 @@
           failed_when: false
           register: scope_principal
 
+        - name: Fail if system subcloud enrollment finalized but have principal in scope
+          fail:
+            msg:
+              "Cannot apply principal scope on enrolled subcloud before unlock."
+          when:
+            - scope_principal.stdout_lines | length > 0
+            - subcloud_enrollment
+
         # Check if there is any strategy-related alarm
         - name: Check if a VIM strategy is in progress
           shell: |
             source /etc/platform/openrc; fm alarm-list | grep 900.
           failed_when: false
           register: strategy_alarms
+          when: scope_principal.stdout_lines | length > 0
 
         - name: Fail if there is a strategy in progress during a Day-2 operation
           fail:
             msg:
               - "VIM Strategy in progress."
               - "Wait until all the strategies are cleared before applying the system configuration update."
-          when: ( scope_principal.stdout_lines | length > 0 and strategy_alarms.stdout != "")
+          when:
+            - scope_principal.stdout_lines | length > 0
+            - strategy_alarms.stdout != ""
+
+        - name: Append config map for subcloud enrollment
+          blockinfile:
+            path: "{{ deploy_config }}"
+            block: |
+
+              ---
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: factory-install
+                namespace: deployment
+              data:
+                factory-installed: "true"
+                factory-config-finalized: "false"
+            marker: ""
+            insertafter: EOF
+          when: subcloud_enrollment
 
         - name: Apply Deployment Configuration File
           shell: KUBECONFIG=/etc/kubernetes/admin.conf /bin/kubectl apply -f {{ deploy_config }}
@@ -455,6 +493,13 @@
         - wait_for:
             timeout: 5
             msg: Waiting after apply DM config
+
+        - name: Restart the deployment manager if subcloud enrollment
+          command: >-
+            kubectl -n platform-deployment-manager delete pods --selector control-plane=controller-manager
+          environment:
+            KUBECONFIG: "/etc/kubernetes/admin.conf"
+          when: subcloud_enrollment
 
         # Check the current administrativestate
         - name: Get current administrativeState


### PR DESCRIPTION
During the subcloud enrollment, as the deployment config may not change
anything, the system controller and host controller may stop their reconcile
process right after applying the configuration with the configMap. The next
round of reconciliation is 10 hrs later, resulting in the host not get unlocked
immediately.

This commit checks the flag of subcloud_enrollment_completed which will not be
persistent post a reboot. Once the flag is there, append the configMap for
factory-install automatically and delete the DM pod post applying the
deployment-config.yaml, ensures another reconciliation post applying the
deployment configurations.

TODO: we may hit his problem again in the day-2 operation. Simple condition
can be added in that case, but it is out of the scope of this commit, and I
don't want to add it now as no failure reported for this reason.

Test plan:
1. Passed - deploy an AIOSX subcloud.
2. Passed - enroll a subcloud, and the subcloud gets unlocked automatically post the
enrollment.
3. Passed - update the MTU of an interface on the newly enrolled subcloud,
verify the day-2 operation w/o error.

Signed-off-by: Yuxing Jiang <Yuxing.Jiang@windriver.com>