### PR TITLE
Deployctl exports incorrect OAM IPV6 IP

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -71,16 +71,21 @@ var defaultHostFilters = []HostFilter{
 	NewHostKernelFilter(),
 }
 
+var defaultPlatformNetworkFilters = []PlatformNetworkFilter{
+	NewAddressPoolFilter(),
+}
+
 // NewDeploymentBuilder returns an instantiation of a deployment builder
 // structure.
 func NewDeploymentBuilder(client *gophercloud.ServiceClient, namespace string, name string, progressWriter io.Writer) *DeploymentBuilder {
 	return &DeploymentBuilder{
-		client:         client,
-		namespace:      namespace,
-		name:           name,
-		progressWriter: progressWriter,
-		systemFilters:  defaultSystemFilters,
-		hostFilters:    defaultHostFilters}
+		client:                 client,
+		namespace:              namespace,
+		name:                   name,
+		progressWriter:         progressWriter,
+		systemFilters:          defaultSystemFilters,
+		platformNetworkFilters: defaultPlatformNetworkFilters,
+		hostFilters:            defaultHostFilters}
 }
 
 // parseIncompleteSecret is a convenience unitilty function to parse an incompleteSecret

--- a/build/build_suite_test.go
+++ b/build/build_suite_test.go
@@ -267,7 +267,9 @@ var _ = Describe("Test Build utilities:", func() {
 		Expect(reflect.DeepEqual(
 			got.hostFilters, expectHostFilter)).To(BeTrue())
 
-		var expectPlatformNetworkFilters []PlatformNetworkFilter
+		expectPlatformNetworkFilters := []PlatformNetworkFilter{
+			NewAddressPoolFilter(),
+		}
 		Expect(reflect.DeepEqual(
 			got.platformNetworkFilters, expectPlatformNetworkFilters)).To(BeTrue())
 	})

--- a/build/filter.go
+++ b/build/filter.go
@@ -761,6 +761,30 @@ func (in *CoreNetworkFilter) Filter(platform_network *v1.PlatformNetwork, deploy
 	return nil
 }
 
+// Interface removes the empty controllerAddress attributes from the addresspool
+type AddressPoolFilter struct {
+}
+
+func NewAddressPoolFilter() *AddressPoolFilter {
+	return &AddressPoolFilter{}
+}
+
+func (in *AddressPoolFilter) Filter(platform_network *v1.PlatformNetwork, deployment *Deployment) error {
+	if deployment.AddressPools != nil {
+		for _, addrPool := range deployment.AddressPools {
+			// Check if Controller0Address is not nil and if it's an empty string
+			if addrPool.Spec.Controller0Address != nil && *addrPool.Spec.Controller0Address == "" {
+				addrPool.Spec.Controller0Address = nil
+			}
+			// Check if Controller1Address is not nil and if it's an empty string
+			if addrPool.Spec.Controller1Address != nil && *addrPool.Spec.Controller1Address == "" {
+				addrPool.Spec.Controller1Address = nil
+			}
+		}
+	}
+	return nil
+}
+
 // Filter all filesystem types except backup and database
 type FileSystemFilter struct {
 }

--- a/build/filter_test.go
+++ b/build/filter_test.go
@@ -1559,4 +1559,46 @@ var _ = Describe("Test filters utilities:", func() {
 			})
 		})
 	})
+	Describe("Test AddressPoolFilter filter func", func() {
+		Context("When addresspool has controllerAddress as empty", func() {
+			It("Updated the controllerAddresses to nil", func() {
+				emptyString := ""
+				addr0 := "192.168.192.01"
+				addr1 := "192.168.192.02"
+				in := &AddressPoolFilter{}
+				platform_network := &v1.PlatformNetwork{}
+				deployment := &Deployment{
+					AddressPools: []*v1.AddressPool{
+						{
+							Spec: v1.AddressPoolSpec{
+								Controller0Address: &emptyString,
+								Controller1Address: &emptyString,
+							},
+						},
+						{
+							Spec: v1.AddressPoolSpec{
+								Controller0Address: &addr0,
+								Controller1Address: &addr1,
+							},
+						},
+					},
+				}
+				expAddrPools := []*v1.AddressPool{
+					{
+						Spec: v1.AddressPoolSpec{},
+					},
+					{
+						Spec: v1.AddressPoolSpec{
+							Controller0Address: &addr0,
+							Controller1Address: &addr1,
+						},
+					},
+				}
+				// Call the filter method
+				err := in.Filter(platform_network, deployment)
+				Expect(err).To(BeNil())
+				Expect(deployment.AddressPools).To(Equal(expAddrPools))
+			})
+		})
+	})
 })


### PR DESCRIPTION
deployctl build -s "lab_name" -o "deploy_file_name" exports
incorrect OAM IP under AddressPool.

Test Cases:
PASS- Generated deploy config using deployctl should be successfull with  day2 operation