### PR TITLE
Remove status.delta when controller is insync

### DIFF
--- a/api/v1/constructors.go
+++ b/api/v1/constructors.go
@@ -6,6 +6,7 @@ package v1
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -201,6 +202,10 @@ func parseProcessorInfo(profile *HostProfileSpec, host v1info.HostInfo) error {
 			}
 			node.Functions = append(node.Functions, data)
 		}
+
+		slices.SortFunc(node.Functions, func(a, b ProcessorFunctionInfo) int {
+			return strings.Compare(a.Function, b.Function)
+		})
 
 		result = append(result, node)
 	}

--- a/api/v1/host_types.go
+++ b/api/v1/host_types.go
@@ -155,6 +155,18 @@ type HostStatus struct {
 	Delta string `json:"delta"`
 }
 
+func (h *Host) SetStatusDelta(delta string) {
+	h.Status.Delta = delta
+}
+
+func (h *Host) GetStatusDelta() string {
+	return h.Status.Delta
+}
+
+func (h *Host) GetInsync() bool {
+	return h.Status.InSync
+}
+
 func (h *Host) GetStrategyRequired() string {
 	return h.Status.StrategyRequired
 }

--- a/api/v1/system_types.go
+++ b/api/v1/system_types.go
@@ -538,6 +538,18 @@ type System struct {
 	Status SystemStatus `json:"status,omitempty"`
 }
 
+func (s *System) SetStatusDelta(delta string) {
+	s.Status.Delta = delta
+}
+
+func (s *System) GetStatusDelta() string {
+	return s.Status.Delta
+}
+
+func (s *System) GetInsync() bool {
+	return s.Status.InSync
+}
+
 // +kubebuilder:object:root=true
 // SystemList contains a list of System
 // +deepequal-gen=false

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/google/go-cmp/cmp"
 	"github.com/gophercloud/gophercloud"
 	perrors "github.com/pkg/errors"
 	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
@@ -91,6 +90,14 @@ var (
 	// RetryNever is used when the reconciler will be triggered by a separate
 	// mechanism and no retry is necessary.
 	RetryNever = reconcile.Result{Requeue: false}
+
+	// Properties contained on DataNetwork resouce
+	DataNetworkPropers = map[string]interface{}{
+		"type":        nil,
+		"description": nil,
+		"mtu":         nil,
+		"vxlan":       []string{"multicastgroup", "udpPortNumber", "ttl", "endpointMode"},
+	}
 
 	// Properties contained on System resource
 	SystemProperties = map[string]interface{}{
@@ -395,37 +402,6 @@ func (in *EventLogger) WarningEvent(object runtime.Object, reason string, messag
 	// logLevel is set to the debug level (1) because WarningEvent should be
 	// accompanied by a reconciler error which has its own log generated.
 	in.event(object, v1.EventTypeWarning, 1, reason, messageFmt, args...)
-}
-
-func GetDeltaString(spec interface{}, current interface{}, parameters map[string]interface{}) (string, error) {
-
-	specBytes, err := json.Marshal(spec)
-	if err != nil {
-		return "", err
-	}
-
-	currentBytes, err := json.Marshal(current)
-	if err != nil {
-		return "", err
-	}
-
-	var specData map[string]interface{}
-	var currentData map[string]interface{}
-
-	err = json.Unmarshal([]byte(specBytes), &specData)
-	if err != nil {
-		return "", err
-	}
-
-	err = json.Unmarshal([]byte(currentBytes), &currentData)
-	if err != nil {
-		return "", err
-	}
-
-	diff := cmp.Diff(currentData, specData)
-	deltaString := collectDiffValues(diff, parameters)
-	deltaString = strings.TrimSuffix(deltaString, "\n")
-	return deltaString, nil
 }
 
 /*

--- a/controllers/common/delta.go
+++ b/controllers/common/delta.go
@@ -1,0 +1,76 @@
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type instance interface {
+	client.Object
+
+	SetStatusDelta(string)
+	GetStatusDelta() string
+	GetInsync() bool
+}
+
+func GetDeltaString(spec interface{}, current interface{}, parameters map[string]interface{}) (string, error) {
+
+	specBytes, err := json.Marshal(spec)
+	if err != nil {
+		return "", err
+	}
+
+	currentBytes, err := json.Marshal(current)
+	if err != nil {
+		return "", err
+	}
+
+	var specData map[string]interface{}
+	var currentData map[string]interface{}
+
+	err = json.Unmarshal([]byte(specBytes), &specData)
+	if err != nil {
+		return "", err
+	}
+
+	err = json.Unmarshal([]byte(currentBytes), &currentData)
+	if err != nil {
+		return "", err
+	}
+
+	diff := cmp.Diff(currentData, specData)
+	deltaString := collectDiffValues(diff, parameters)
+	deltaString = strings.TrimSuffix(deltaString, "\n")
+	return deltaString, nil
+}
+
+func SetInstanceDelta(
+	inst instance, spec, current interface{},
+	parameters map[string]interface{},
+	status client.StatusWriter, log logr.Logger,
+) {
+	kind := inst.GetObjectKind().GroupVersionKind().Kind
+	log.Info(fmt.Sprintf("Updating delta for kind %s", kind))
+
+	oldDelta := inst.GetStatusDelta()
+	if inst.GetInsync() {
+		inst.SetStatusDelta("")
+	} else if delta, err := GetDeltaString(spec, current, parameters); err == nil {
+		inst.SetStatusDelta(delta)
+	} else {
+		log.Info(fmt.Sprintf("Failed to get Delta string for kind %s: %s\n", kind, err))
+	}
+
+	if oldDelta != inst.GetStatusDelta() {
+		err := status.Update(context.TODO(), inst)
+		if err != nil {
+			log.Info(fmt.Sprintf("Failed to update the status for kind %s: %s", kind, err))
+		}
+	}
+}


### PR DESCRIPTION
DM must not have status.delta when controllers are insync. This commit
ensures no delta always controllers are in sync after a day-2 update.

Test Case:
PASS - perform day-2 updates, changing parameters in the deployment
configuration and ensure no delta after insync true