### PR TITLE
Fix host availability update post reconciled

### DIFF
--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -2334,6 +2334,7 @@ func (r *HostReconciler) Reconcile(ctx context.Context, request ctrl.Request) (r
 	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation &&
 		instance.Status.Reconciled &&
 		instance.Status.DeploymentScope == "bootstrap" &&
+		*instance.Status.AvailabilityStatus == "available" &&
 		instance.Status.StrategyRequired == cloudManager.StrategyNotRequired &&
 		!platformnetwork_update_required {
 


### PR DESCRIPTION
In cases where the host is already insync and reconciled, if it was degraded before the unlock, the availability status was not being updated.

This commit adds a check in the Reconcile method to ensure that the availability status it's updated if the host is already reconciled but not available.

Test Plan:
PASS: Build image and deploy a AIO-DX where the issue was seen. Verify that the 'degraded' status it's updated to 'available' after unlock.