### PR TITLE
Fix delta when some of processor functions spec are out of order

### DIFF
--- a/api/v1/constructors.go
+++ b/api/v1/constructors.go
@@ -6,6 +6,7 @@ package v1
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -201,6 +202,10 @@ func parseProcessorInfo(profile *HostProfileSpec, host v1info.HostInfo) error {
 			}
 			node.Functions = append(node.Functions, data)
 		}
+
+		slices.SortFunc(node.Functions, func(a, b ProcessorFunctionInfo) int {
+			return strings.Compare(a.Function, b.Function)
+		})
 
 		result = append(result, node)
 	}


### PR DESCRIPTION
This fix ensures no delta when the processors functions are the same but one of the slices are out of order. For exemple:

final profile: [{"function":"platform","count":2},{"function":"vswitch","count":0}]}]
current profile: [{"function":"vswitch","count":0},{"function":"platform","count":2}]}]

Test Plan:
- day-2 operations, ensure no delta in processors