### PR TITLE
Add logs on host reconcile path

### DIFF
--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -2334,6 +2334,7 @@ func (r *HostReconciler) Reconcile(ctx context.Context, request ctrl.Request) (r
 	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation &&
 		instance.Status.Reconciled &&
 		instance.Status.DeploymentScope == "bootstrap" &&
+		*instance.Status.AvailabilityStatus == "available" &&
 		instance.Status.StrategyRequired == cloudManager.StrategyNotRequired &&
 		!platformnetwork_update_required {
 

--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -1564,9 +1564,12 @@ func (r *HostReconciler) StopAfterInSync() bool {
 // ReconcileExistingHost is responsible for dealing with the provisioning of an
 // existing host.
 func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient, instance *starlingxv1.Host, profile *starlingxv1.HostProfileSpec, host *hosts.Host, reqNs string) error {
+	logHost.Info("Starting to configure on existing host", "host", host.ID)
+
 	var defaults *starlingxv1.HostProfileSpec
 	var current *starlingxv1.HostProfileSpec
 	var platform_network_subreconciler_errs []error
+
 	if !host.Stable() {
 		msg := "waiting for a stable state for existing host"
 		m := NewStableHostMonitor(instance, host.ID)
@@ -1575,6 +1578,7 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 
 	// Gather all host attributes so that they can be reused by various
 	// functions without needing to be re-queried each time.
+	logHost.V(2).Info("gathering host information", "host", host.ID)
 	hostInfo := v1info.HostInfo{}
 	err := hostInfo.PopulateHostInfo(client, host.ID)
 	if err != nil {
@@ -1583,27 +1587,31 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 
 	// Fetch default attributes so that they can be used to back sparse host
 	// profile configurations.
+	logHost.V(2).Info("fetching default host attributes", "host", host.ID)
 	defaults, err = r.GetHostDefaults(instance)
 	if err != nil {
 		return err
 	}
 
-	// Check facotry install config map
+	// Check factory install config map
+	logHost.V(2).Info("checking factory install config map", "namespace", reqNs)
 	factory, err := r.CloudManager.GetFactoryInstall(reqNs)
 	if err != nil {
-		return err
+		return perrors.Wrap(err, "failed to get factory install config map")
 	}
 
 	if factory && host.IsUnlockedEnabled() {
 		// finalize factory install if host already unlocked
-		logHost.Info("finalizing factory install")
+		logHost.Info("finalizing factory install", "host", host.ID)
 		err = r.SetFactoryConfigFinalized(instance.Namespace, true)
 		if err != nil {
-			return err
+			return perrors.Wrap(err, "failed to finalize factory config")
 		}
 		factory = false
 	}
 
+	// Determine if we need to update the default configuration
+	logHost.V(2).Info("checking if update to defaults is required", "host", host.ID)
 	updatedRequired, err := common.UpdateDefaultsRequired(
 		r.CloudManager,
 		reqNs,
@@ -1611,10 +1619,11 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 		factory,
 	)
 	if err != nil {
-		return err
+		return perrors.Wrap(err, "failed to check if update to defaults is required")
 	}
 
 	if defaults == nil || updatedRequired {
+		logHost.Info("defaults are nil or update required", "host", host.ID)
 		if !host.Stable() || host.AvailabilityStatus == hosts.AvailOffline {
 			// Ideally we would only ever collect the defaults when the host is
 			// in the locked/disabled/online state.  This is the best approach
@@ -1632,8 +1641,7 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 			return r.CloudManager.StartMonitor(m, msg)
 		}
 
-		logHost.Info("collecting default values")
-
+		logHost.Info("collecting default values for host", "host", host.ID)
 		defaults, err = r.BuildHostDefaults(instance, hostInfo)
 		if err != nil {
 			return err
@@ -1643,6 +1651,7 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 			"defaults collected and stored")
 
 		if factory {
+			logHost.V(2).Info("setting factory resource data updated", "namespace", reqNs, "host", host.ID)
 			err := r.CloudManager.SetFactoryResourceDataUpdated(
 				reqNs,
 				instance.Name,
@@ -1650,21 +1659,19 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 				true,
 			)
 			if err != nil {
-				return err
+				return perrors.Wrap(err, "failed to set factory resource data updated")
 			}
 		}
 
 		current = defaults.DeepCopy()
-
 	} else {
 		// Otherwise, the defaults already existed so build a new profile with
 		// the current host configuration so that we can compare it to the
 		// desired state.
-		logHost.V(2).Info("building current profile from current config")
-
+		logHost.V(2).Info("building current profile from current config", "host", host.ID)
 		current, err = starlingxv1.NewHostProfileSpec(hostInfo)
 		if err != nil {
-			return err
+			return perrors.Wrap(err, "failed to build current profile")
 		}
 	}
 
@@ -1684,16 +1691,17 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 	// Create a new composite profile that is backed by the host's default
 	// configuration.  This will ensure that if a user deletes an optional
 	// attribute that we will know how to restore the original value.
+	logHost.Info("merging profiles", "host", host.ID)
 	profile, err = MergeProfiles(defaults, profile)
 	if err != nil {
-		return err
+		return perrors.Wrap(err, "failed to merge profiles")
 	}
 
 	// Fix attributes in profiles to a uniformed format
-	// As the Merge Profiles will overwrite some formate in the default profile
+	// As the Merge Profiles will overwrite some format in the default profile
 	// parsed in the constructor, move this process after it.
+	logHost.V(2).Info("fixing profile attributes", "host", host.ID)
 	FixProfileAttributes(defaults, profile, current, &hostInfo)
-
 	FillEmptyUuidbyName(defaults, current)
 
 	// TODO(alegacy): Need to move ProvisioningMode out of the profile or
@@ -1703,7 +1711,7 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 
 	// N3000 interface name change apply
 	if host.IsUnlockedEnabled() {
-		logHost.Info("Sync interface name")
+		logHost.Info("syncing interface name", "host", host.ID)
 		SyncIFNameByUuid(profile, current)
 	}
 
@@ -1713,10 +1721,10 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 	}
 
 	if is_active_host {
+		logHost.Info("host is active, reconciling platform networks", "host", host.ID)
 		system_info, err := r.CloudManager.GetSystemInfo(reqNs, client)
 		if err != nil {
-			msg := "failed to get active host"
-			return common.NewUserDataError(msg)
+			return common.NewUserDataError("failed to get system info")
 		}
 
 		// Only reconcile platform networks in active controller reconciliation
@@ -1725,12 +1733,12 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 		// if IsPlatformNetworkReconciling.
 		if !r.CloudManager.IsPlatformNetworkReconciling() {
 			r.CloudManager.SetPlatformNetworkReconciling(true)
-
 			// Do not allow notifying active host until ReconcilePlatformNetworks
 			// is completed, this is to prevent unnecessary status update conflicts
 			// in addrpools and platform network resources.
 			r.CloudManager.SetNotifyingActiveHost(true)
 
+			logHost.Info("starting platform network reconciliation", "host", host.ID)
 			platform_network_subreconciler_errs = r.ReconcilePlatformNetworks(client, instance, profile, &hostInfo, system_info)
 
 			r.CloudManager.SetPlatformNetworkReconciling(false)
@@ -1751,25 +1759,27 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 				err_msg := "there were errors during platform network reconciliation"
 				return common.NewPlatformNetworkReconciliationError(err_msg)
 			}
-
 		} else {
 			err_msg := "waiting for platform network reconciled."
 			return common.NewPlatformNetworkReconciliationError(err_msg)
 		}
 	}
 
+	// Fetch system information for further comparison
+	logHost.V(2).Info("fetching system info for attribute comparison", "namespace", reqNs)
 	system_info, err := r.CloudManager.GetSystemInfo(reqNs, client)
 	if err != nil {
 		msg := "failed to get system info"
 		return common.NewUserDataError(msg)
 	}
+
+	logHost.Info("comparing profile attributes", "host", host.ID)
 	inSync := r.CompareAttributes(profile, current, instance, host.Personality, system_info)
 
 	// Continue the following steps even inSync:
 	// strategy not finished
-	if inSync &&
-		(instance.Status.StrategyRequired == cloudManager.StrategyNotRequired) {
-		logHost.V(2).Info("no changes between composite profile and current configuration")
+	if inSync && (instance.Status.StrategyRequired == cloudManager.StrategyNotRequired) {
+		logHost.V(2).Info("no changes between composite profile and current config", "host", host.ID)
 		instance.Status.Delta = ""
 		return nil
 	}
@@ -1815,12 +1825,13 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 		}
 	}
 
+	logHost.Info("reconciling host by state", "host", host.ID)
 	err = r.ReconcileHostByState(client, instance, current, profile, &hostInfo, system_info)
 	if err != nil {
 		return err
 	}
 
-	logHost.V(2).Info("final configuration is:", "profile", current)
+	logHost.V(2).Info("final configuration is set", "profile", current)
 
 	return nil
 }

--- a/controllers/host/host_info.go
+++ b/controllers/host/host_info.go
@@ -16,10 +16,15 @@ import (
 // fake host profile that can be used as a reference for the current settings
 // applied to the host.  The default settings are saved on the host status.
 func (r *HostReconciler) BuildHostDefaults(instance *starlingxv1.Host, host v1info.HostInfo) (*starlingxv1.HostProfileSpec, error) {
+	logHost.Info("building host defaults", "host", host.ID)
+
 	defaults, err := starlingxv1.NewHostProfileSpec(host)
 	if defaults == nil || err != nil {
+		err = perrors.Wrap(err, "failed to create host profile spec")
 		return nil, err
 	}
+
+	logHost.V(2).Info("host profile spec created", "defaults", defaults)
 
 	buffer, err := json.Marshal(defaults)
 	if err != nil {
@@ -35,6 +40,8 @@ func (r *HostReconciler) BuildHostDefaults(instance *starlingxv1.Host, host v1in
 		err = perrors.Wrap(err, "failed to update host defaults")
 		return nil, err
 	}
+
+	logHost.Info("host defaults successfully built and updated", "host", host.ID)
 
 	return defaults, nil
 }


### PR DESCRIPTION
This commits aims to add more logs in the host reconcile path since it was seen situations in which the reconciler is blocked and current logs can not give the enough information to debug it.