### PR TITLE
Fix nil pointer error in AvailabilityStatus check

### DIFF
--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -2345,7 +2345,7 @@ func (r *HostReconciler) Reconcile(ctx context.Context, request ctrl.Request) (r
 	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation &&
 		instance.Status.Reconciled &&
 		instance.Status.DeploymentScope == "bootstrap" &&
-		*instance.Status.AvailabilityStatus == "available" &&
+		instance.Status.AvailabilityStatus != nil && *instance.Status.AvailabilityStatus == "available" &&
 		instance.Status.StrategyRequired == cloudManager.StrategyNotRequired &&
 		!platformnetwork_update_required {
 


### PR DESCRIPTION
In case the availability status is not set yet, the check for availability status in the Reconcile function will produce a nil pointer dereference, and a subsequent crash on the pod.

This commit adds a nil check before dereferencing AvailabilityStatus in the Host Reconcile function.