### PR TITLE
Cherry pick fixes for stable/24.09

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ COPY --from=builder /workspace/manager .
 ENTRYPOINT ["/manager"]
 
 # Copy the delve debugger into a debug image
-FROM ubuntu:23.10 as debug
+FROM ubuntu:noble as debug
 WORKDIR /
 RUN apt-get update && apt-get install -y tcpdump net-tools iputils-ping iproute2
 COPY --from=dlvbuilder /go/bin/dlv /

--- a/api/v1/constructors.go
+++ b/api/v1/constructors.go
@@ -6,7 +6,6 @@ package v1
 import (
 	"fmt"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -202,10 +201,6 @@ func parseProcessorInfo(profile *HostProfileSpec, host v1info.HostInfo) error {
 			}
 			node.Functions = append(node.Functions, data)
 		}
-
-		slices.SortFunc(node.Functions, func(a, b ProcessorFunctionInfo) int {
-			return strings.Compare(a.Function, b.Function)
-		})
 
 		result = append(result, node)
 	}

--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -2334,7 +2334,7 @@ func (r *HostReconciler) Reconcile(ctx context.Context, request ctrl.Request) (r
 	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation &&
 		instance.Status.Reconciled &&
 		instance.Status.DeploymentScope == "bootstrap" &&
-		*instance.Status.AvailabilityStatus == "available" &&
+		instance.Status.AvailabilityStatus != nil && *instance.Status.AvailabilityStatus == "available" &&
 		instance.Status.StrategyRequired == cloudManager.StrategyNotRequired &&
 		!platformnetwork_update_required {
 


### PR DESCRIPTION
* Cherry-picks latest fixes in master for stable/24.09
* Revert processors fix

We can compile the software with go.mod version
```bash
go install golang.org/dl/go1.19@latest
go1.19 download
go1.19 build .
```