### PR TITLE
Remove test target for docker-build in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ else
 endif
 
 .PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
+docker-build: ## Build docker image with the manager.
 	docker build . --no-cache -t ${IMG} --target ${DOCKER_TARGET} --build-arg "GOBUILD_GCFLAGS=${GOBUILD_GCFLAGS}"
 
 .PHONY: docker-push


### PR DESCRIPTION
This commit removes the test target in the docker-build to avoid running tests twice when the user issues make command.

Test Case:
- make, tests must run before build
- make docker-build, tests must not run