### PR TITLE
Remove test target in for docker-build in Makefile (#428)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ else
 endif
 
 .PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
+docker-build: ## Build docker image with the manager.
 	docker build . --no-cache -t ${IMG} --target ${DOCKER_TARGET} --build-arg "GOBUILD_GCFLAGS=${GOBUILD_GCFLAGS}"
 
 .PHONY: docker-push


### PR DESCRIPTION
This commit removes the test target in the docker-build to avoid running tests twice when the user issues make command.

Test Case:
- make, tests must run before build
- make docker-build, tests must not run

(cherry picked from commit 0df7901d407d3a7a64f9106a30d0cfd179f320d2)