### PR TITLE
Increase Gomega Eventually timeout to 30 seconds (#430)

### DIFF
--- a/api/v1/addresspool_types_test.go
+++ b/api/v1/addresspool_types_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("Addresspool controller", func() {
 
 	const (
-		timeout  = time.Second * 10
+		timeout  = time.Second * 30
 		interval = time.Millisecond * 250
 	)
 

--- a/api/v1/datanetwork_type_test.go
+++ b/api/v1/datanetwork_type_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("Datanetwork controller", func() {
 
 	const (
-		timeout  = time.Second * 10
+		timeout  = time.Second * 30
 		interval = time.Millisecond * 250
 	)
 	ctx := context.Background()

--- a/api/v1/host_type_test.go
+++ b/api/v1/host_type_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("Datanetwork controller", func() {
 
 	const (
-		timeout  = time.Second * 10
+		timeout  = time.Second * 30
 		interval = time.Millisecond * 250
 	)
 

--- a/api/v1/hostprofile_type_test.go
+++ b/api/v1/hostprofile_type_test.go
@@ -17,7 +17,7 @@ import (
 var _ = Describe("HostProfile controller", func() {
 
 	const (
-		timeout  = time.Second * 10
+		timeout  = time.Second * 30
 		interval = time.Millisecond * 250
 	)
 	Context("Test IsKeyEqual func for AddressInfo", func() {

--- a/api/v1/platformnetwork_type_test.go
+++ b/api/v1/platformnetwork_type_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("Platformnetwork controller", func() {
 
 	const (
-		timeout  = time.Second * 10
+		timeout  = time.Second * 30
 		interval = time.Millisecond * 250
 	)
 

--- a/api/v1/ptpinstance_type_test.go
+++ b/api/v1/ptpinstance_type_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("Datanetwork controller", func() {
 
 	const (
-		timeout  = time.Second * 10
+		timeout  = time.Second * 30
 		interval = time.Millisecond * 250
 	)
 

--- a/api/v1/ptpinterface_type_test.go
+++ b/api/v1/ptpinterface_type_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("Datanetwork controller", func() {
 
 	const (
-		timeout  = time.Second * 10
+		timeout  = time.Second * 30
 		interval = time.Millisecond * 250
 	)
 

--- a/api/v1/system_type_test.go
+++ b/api/v1/system_type_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("Datanetwork controller", func() {
 
 	const (
-		timeout  = time.Second * 10
+		timeout  = time.Second * 30
 		interval = time.Millisecond * 250
 	)
 

--- a/controllers/addresspool_controller_test.go
+++ b/controllers/addresspool_controller_test.go
@@ -16,7 +16,7 @@ import (
 
 var _ = Describe("AddressPool controller", func() {
 	const (
-		timeout  = time.Second * 10
+		timeout  = time.Second * 30
 		interval = time.Millisecond * 250
 	)
 

--- a/controllers/datanetwork_controller_test.go
+++ b/controllers/datanetwork_controller_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("Datanetwork controller", func() {
 
 	const (
-		timeout  = time.Second * 20
+		timeout  = time.Second * 30
 		interval = time.Millisecond * 250
 	)
 

--- a/controllers/host/host_controller_test.go
+++ b/controllers/host/host_controller_test.go
@@ -25,7 +25,7 @@ import (
 var _ = Describe("Host controller", func() {
 
 	const (
-		timeout  = time.Second * 10
+		timeout  = time.Second * 30
 		interval = time.Millisecond * 250
 	)
 

--- a/controllers/host/platformnetworks_test.go
+++ b/controllers/host/platformnetworks_test.go
@@ -27,7 +27,7 @@ const PlatformNetworkFinalizerName = "platformnetwork.finalizers.windriver.com"
 
 const TestNamespace = "default"
 const (
-	timeout  = time.Second * 10
+	timeout  = time.Second * 30
 	interval = time.Millisecond * 250
 )
 

--- a/controllers/platformnetwork_controller_test.go
+++ b/controllers/platformnetwork_controller_test.go
@@ -16,7 +16,7 @@ import (
 
 var _ = Describe("Platformnetwork controller", func() {
 	const (
-		timeout  = time.Second * 20
+		timeout  = time.Second * 30
 		interval = time.Millisecond * 250
 	)
 

--- a/controllers/ptpinstance_controller_test.go
+++ b/controllers/ptpinstance_controller_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("PtpInstance controller", func() {
 
 	const (
-		timeout  = time.Second * 20
+		timeout  = time.Second * 30
 		interval = time.Millisecond * 250
 	)
 

--- a/controllers/ptpinterface_controller_test.go
+++ b/controllers/ptpinterface_controller_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("PtpInterface controller", func() {
 
 	const (
-		timeout  = time.Second * 20
+		timeout  = time.Second * 30
 		interval = time.Millisecond * 250
 	)
 


### PR DESCRIPTION
This commit increases the Gomago Eventuall timeout to 30 seconds in all tests cases to avoid tests failures by timeout [1].

[1]: https://github.com/Wind-River/cloud-platform-deployment-manager/pull/429/checks?check_run_id=33619644827

Test Case:
PASS - make test

Signed-off-by: Wallysson Silva <wallysson.silva@windriver.com>
(cherry picked from commit 675c541c3fc5bf6f6d7b4452760190f74fd401f1)