### PR TITLE
Include all status of hosts except online

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -840,11 +840,11 @@
                 host_reconcile_retries: >
                   {{ 120 if  hosts_count.stdout | int == 2 else 240 }}
 
-            - name: Get offline hosts if not simplex
+            - name: Get hosts not online or not available if not simplex
               shell: >
                 kubectl get hosts -o custom-columns='NAME:.metadata.name,
                 OPERATIONAL:.status.availabilityStatus' -n deployment |
-                awk '$NF ~ /offline/ {print}'
+                awk '$NF !~ /online/ {print}'
               environment:
                 KUBECONFIG: "/etc/kubernetes/admin.conf"
               register: get_offline_hosts


### PR DESCRIPTION

Currently, the DM only checks for the offline state, not the power-off state, when hosts are not in simplex mode.
This change ensures that all host statuses, except online, are included.

Test-Plan
PASS: Deploy AIO-DX on VDM
PASS: DM adding the controller-1, check the controller-1 is added into the "system host-list",
power off the controller-1 using "system host-power-off controller-1