### PR TITLE
Update the minimum Golang version to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wind-river/cloud-platform-deployment-manager
 
-go 1.19
+go 1.22
 
 require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137


### PR DESCRIPTION
This commit updates the minimum golang version to 1.22, to match the version used in the development Dockerfile [1].

[1]: https://github.com/Wind-River/cloud-platform-deployment-manager/blob/2ee64391edf40c4931342f1be69ddfba9aa33a72/Dockerfile#L2

Test Plan:
- PASS: make docker-build