### PR TITLE
Increase gomega internal to 500 milliseconds

### DIFF
--- a/api/v1/addresspool_types_test.go
+++ b/api/v1/addresspool_types_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Addresspool controller", func() {
 
 	const (
 		timeout  = time.Second * 30
-		interval = time.Millisecond * 250
+		interval = time.Millisecond * 500
 	)
 
 	Context("Addresspool with all data", func() {

--- a/api/v1/datanetwork_type_test.go
+++ b/api/v1/datanetwork_type_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Datanetwork controller", func() {
 
 	const (
 		timeout  = time.Second * 30
-		interval = time.Millisecond * 250
+		interval = time.Millisecond * 500
 	)
 	ctx := context.Background()
 	Context("DataNetwork with data", func() {

--- a/api/v1/host_type_test.go
+++ b/api/v1/host_type_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Datanetwork controller", func() {
 
 	const (
 		timeout  = time.Second * 30
-		interval = time.Millisecond * 250
+		interval = time.Millisecond * 500
 	)
 
 	Context("Host with data", func() {

--- a/api/v1/hostprofile_type_test.go
+++ b/api/v1/hostprofile_type_test.go
@@ -18,7 +18,7 @@ var _ = Describe("HostProfile controller", func() {
 
 	const (
 		timeout  = time.Second * 30
-		interval = time.Millisecond * 250
+		interval = time.Millisecond * 500
 	)
 	Context("Test IsKeyEqual func for AddressInfo", func() {
 		It("Should return true", func() {

--- a/api/v1/platformnetwork_type_test.go
+++ b/api/v1/platformnetwork_type_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Platformnetwork controller", func() {
 
 	const (
 		timeout  = time.Second * 30
-		interval = time.Millisecond * 250
+		interval = time.Millisecond * 500
 	)
 
 	Context("PlatformNetwork with all data", func() {

--- a/api/v1/ptpinstance_type_test.go
+++ b/api/v1/ptpinstance_type_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Datanetwork controller", func() {
 
 	const (
 		timeout  = time.Second * 30
-		interval = time.Millisecond * 250
+		interval = time.Millisecond * 500
 	)
 
 	Context("PtpInstance with data", func() {

--- a/api/v1/ptpinterface_type_test.go
+++ b/api/v1/ptpinterface_type_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Datanetwork controller", func() {
 
 	const (
 		timeout  = time.Second * 30
-		interval = time.Millisecond * 250
+		interval = time.Millisecond * 500
 	)
 
 	Context("PtpInstance with data", func() {

--- a/api/v1/system_type_test.go
+++ b/api/v1/system_type_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Datanetwork controller", func() {
 
 	const (
 		timeout  = time.Second * 30
-		interval = time.Millisecond * 250
+		interval = time.Millisecond * 500
 	)
 
 	Context("System with data", func() {

--- a/controllers/addresspool_controller_test.go
+++ b/controllers/addresspool_controller_test.go
@@ -17,7 +17,7 @@ import (
 var _ = Describe("AddressPool controller", func() {
 	const (
 		timeout  = time.Second * 30
-		interval = time.Millisecond * 250
+		interval = time.Millisecond * 500
 	)
 
 	Context("AddressPool with data", func() {

--- a/controllers/datanetwork_controller_test.go
+++ b/controllers/datanetwork_controller_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Datanetwork controller", func() {
 
 	const (
 		timeout  = time.Second * 30
-		interval = time.Millisecond * 250
+		interval = time.Millisecond * 500
 	)
 
 	Context("DataNetwork with data", func() {

--- a/controllers/host/host_controller_test.go
+++ b/controllers/host/host_controller_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Host controller", func() {
 
 	const (
 		timeout  = time.Second * 30
-		interval = time.Millisecond * 250
+		interval = time.Millisecond * 500
 	)
 
 	Context("Host with data", func() {

--- a/controllers/host/platformnetworks_test.go
+++ b/controllers/host/platformnetworks_test.go
@@ -28,7 +28,7 @@ const PlatformNetworkFinalizerName = "platformnetwork.finalizers.windriver.com"
 const TestNamespace = "default"
 const (
 	timeout  = time.Second * 30
-	interval = time.Millisecond * 250
+	interval = time.Millisecond * 500
 )
 
 func IntroducePlatformNetworkChange(platform_network *starlingxv1.PlatformNetwork) {

--- a/controllers/platformnetwork_controller_test.go
+++ b/controllers/platformnetwork_controller_test.go
@@ -17,7 +17,7 @@ import (
 var _ = Describe("Platformnetwork controller", func() {
 	const (
 		timeout  = time.Second * 30
-		interval = time.Millisecond * 250
+		interval = time.Millisecond * 500
 	)
 
 	Context("PlatformNetwork with data", func() {

--- a/controllers/ptpinstance_controller_test.go
+++ b/controllers/ptpinstance_controller_test.go
@@ -19,7 +19,7 @@ var _ = Describe("PtpInstance controller", func() {
 
 	const (
 		timeout  = time.Second * 30
-		interval = time.Millisecond * 250
+		interval = time.Millisecond * 500
 	)
 
 	Context("PtpInstance with data", func() {

--- a/controllers/ptpinterface_controller_test.go
+++ b/controllers/ptpinterface_controller_test.go
@@ -19,7 +19,7 @@ var _ = Describe("PtpInterface controller", func() {
 
 	const (
 		timeout  = time.Second * 30
-		interval = time.Millisecond * 250
+		interval = time.Millisecond * 500
 	)
 
 	Context("PtpInstance with data", func() {


### PR DESCRIPTION
This commit increases the gomega internal to 500 milliseconds.	This is a attempt to reduce intermittent test failures.

Test Case:
- PASS: Run tests multiple times in a small environment 1G of memory and 2 CPUs with success.