### PR TITLE
Upgrading go version to 1.22.4 to fix critical vulnerability seen in DM image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.2 as dlvbuilder
+FROM golang:1.22.4 as dlvbuilder
 
 # Build delve debugger
 RUN apt-get update && apt-get install -y git


### PR DESCRIPTION
Performed CVE scan for DM image encountered security issue in net/netip: check if address is v6 mapped in Is methods with go 1.22.2 version. With the recipe version 1.22.4 no critical vulnerability is seen.

Test plan:
- Built DM image and pushed into docker registry
- Removed existing system app and re applied the system app with the newly built image