### PR TITLE
Fix ready state notification race condition in system controller

### DIFF
--- a/controllers/addresspool_controller.go
+++ b/controllers/addresspool_controller.go
@@ -160,10 +160,6 @@ func (r *AddressPoolReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 		return ctrl.Result{}, nil
 	}
 
-	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation && instance.Status.Reconciled {
-		return ctrl.Result{}, nil
-	}
-
 	if instance.DeletionTimestamp.IsZero() {
 		// Ensure that the object has a finalizer setup as a pre-delete hook so
 		// that we can delete any system resources that we previously added.

--- a/controllers/datanetwork_controller.go
+++ b/controllers/datanetwork_controller.go
@@ -536,8 +536,7 @@ func (r *DataNetworkReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 		return ctrl.Result{}, nil
 	}
 
-	err, scope_updated := r.UpdateDeploymentScope(instance)
-	if err != nil {
+	if err, _ := r.UpdateDeploymentScope(instance); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -549,16 +548,6 @@ func (r *DataNetworkReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 		err := r.UpdateStatusForFactoryInstall(request.Namespace, instance)
 		if err != nil {
 			return reconcile.Result{}, err
-		}
-	}
-
-	// The status reaches its desired status post reconciled
-	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation &&
-		instance.Status.Reconciled {
-
-		if !scope_updated && !factory {
-			logDataNetwork.V(2).Info("reconcile finished, desired state reached after reconciled.")
-			return reconcile.Result{}, nil
 		}
 	}
 

--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -2323,6 +2323,7 @@ func (r *HostReconciler) Reconcile(ctx context.Context, request ctrl.Request) (r
 		return reconcile.Result{}, err
 	}
 
+	// TODO(wasnio): remove this once migration from helm chart to fluxcd is done
 	// The status reaches its desired status post reconciled
 	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation &&
 		instance.Status.Reconciled &&

--- a/controllers/ptpinstance_controller.go
+++ b/controllers/ptpinstance_controller.go
@@ -595,8 +595,7 @@ func (r *PtpInstanceReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 		return ctrl.Result{}, nil
 	}
 
-	err, scope_updated := r.UpdateDeploymentScope(instance)
-	if err != nil {
+	if err, _ := r.UpdateDeploymentScope(instance); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -608,15 +607,6 @@ func (r *PtpInstanceReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 		err := r.UpdateStatusForFactoryInstall(request.Namespace, instance)
 		if err != nil {
 			return reconcile.Result{}, err
-		}
-	}
-
-	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation &&
-		instance.Status.Reconciled {
-
-		if !scope_updated && !factory {
-			logPtpInstance.V(2).Info("reconcile finished, desired state reached after reconciled.")
-			return ctrl.Result{}, nil
 		}
 	}
 

--- a/controllers/ptpinterface_controller.go
+++ b/controllers/ptpinterface_controller.go
@@ -620,8 +620,7 @@ func (r *PtpInterfaceReconciler) Reconcile(ctx context.Context, request ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
-	err, scope_updated := r.UpdateDeploymentScope(instance)
-	if err != nil {
+	if err, _ := r.UpdateDeploymentScope(instance); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -633,15 +632,6 @@ func (r *PtpInterfaceReconciler) Reconcile(ctx context.Context, request ctrl.Req
 		err := r.UpdateStatusForFactoryInstall(request.Namespace, instance)
 		if err != nil {
 			return reconcile.Result{}, err
-		}
-	}
-
-	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation &&
-		instance.Status.Reconciled {
-
-		if !scope_updated && !factory {
-			logPtpInterface.V(2).Info("reconcile finished, desired state reached after reconciled.")
-			return ctrl.Result{}, nil
 		}
 	}
 

--- a/controllers/system/system_controller.go
+++ b/controllers/system/system_controller.go
@@ -1705,8 +1705,7 @@ func (r *SystemReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
-	err, scope_updated := r.UpdateDeploymentScope(instance)
-	if err != nil {
+	if err, _ := r.UpdateDeploymentScope(instance); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -1718,17 +1717,6 @@ func (r *SystemReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		err := r.UpdateStatusForFactoryInstall(request.Namespace, instance)
 		if err != nil {
 			return reconcile.Result{}, err
-		}
-	}
-
-	// The status reaches its desired status post reconciled
-	if instance.Status.ObservedGeneration == instance.ObjectMeta.Generation &&
-		instance.Status.Reconciled &&
-		platformClient != nil {
-
-		if !scope_updated && !factory {
-			logSystem.V(2).Info("reconcile finished, desired state reached after reconciled.")
-			return reconcile.Result{}, nil
 		}
 	}
 


### PR DESCRIPTION
When system controller is ready, it will notify all the other reconcilers
about the ready state, so the other controllers can start the
reconciliation loop. This commit ensures that the system controller
can notify the other controller even if the last iteration failed to
call the webhook, but the system is reconciled.

Test Case:
- PASS: Deploy AIO-SX