### PR TITLE
Enable the creation of two data VLAN with same VID

### DIFF
--- a/controllers/host/networking.go
+++ b/controllers/host/networking.go
@@ -1458,7 +1458,7 @@ func (r *HostReconciler) ReconcileVLANInterfaces(client *gophercloud.ServiceClie
 	for _, vlanInfo := range profile.Interfaces.VLAN {
 		// For each configured bond interface create or update the related
 		// system resource.
-		ifuuid, found := host.FindVLANInterfaceUUID(vlanInfo.VID)
+		ifuuid, found := host.FindVLANInterfaceUUID(vlanInfo.VID, vlanInfo.Name)
 		if !found {
 			// Create the interface
 			opts := commonInterfaceOptions(vlanInfo.CommonInterfaceInfo, profile, host)

--- a/platform/info.go
+++ b/platform/info.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2022,2025 Wind River Systems, Inc. */
 
 package platform
 
@@ -432,13 +432,18 @@ func (in *HostInfo) FindInterfaceByName(name string) (*interfaces.Interface, boo
 
 // findVLANInterfaceUUID is a utility function to find a VLAN interface in the
 // list of interfaces returned by the systemAPI.
-func (in *HostInfo) FindVLANInterfaceUUID(vid int) (string, bool) {
+func (in *HostInfo) FindVLANInterfaceUUID(vid int, name string) (string, bool) {
 	for _, i := range in.Interfaces {
 		if i.Type != interfaces.IFTypeVLAN {
 			continue
 		}
 
-		if i.VID != nil && *i.VID == vid {
+		if i.VID == nil {
+			continue
+		}
+
+		// data class vlan can have the same uuid
+		if *i.VID == vid && i.Name == name {
 			return i.ID, true
 		}
 	}


### PR DESCRIPTION
This commit fixes the vlan interface search, searching the interface by name and VID to allow the creation of two VLAN with same VID when using two different physical interfaces.

Test Case:
- PASS: configure and verify two VLAN using the same VID