### PR TITLE
Delay labels error return until after cpu config

### DIFF
--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -805,11 +805,6 @@ func (r *HostReconciler) ReconcileDisabledHost(client *gophercloud.ServiceClient
 		return err
 	}
 
-	err = r.ReconcileLabels(client, instance, profile, host)
-	if err != nil {
-		return err
-	}
-
 	err = r.ReconcilePTPInstances(client, instance, profile, host)
 	if err != nil {
 		return err
@@ -833,6 +828,11 @@ func (r *HostReconciler) ReconcileDisabledHost(client *gophercloud.ServiceClient
 		if err != nil {
 			return err
 		}
+	}
+
+	err = r.ReconcileLabels(client, instance, profile, host)
+	if err != nil {
+		return err
 	}
 
 	err = r.ReconcileNetworking(client, instance, profile, host)


### PR DESCRIPTION
The LabelsReconcile could fail because of cpu
configuration. Reconcile Labels after Processors. 
Processors/CPUs have been reconciled
So that the next round of reconciliation will pass labels reconcile

Test plan:

PASS - Deploy AIO-SX
        with stalld host labels with application
        isolated cpus .