### PR TITLE
Delay labels error return until after cpu config (#454)

### DIFF
--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -805,11 +805,6 @@ func (r *HostReconciler) ReconcileDisabledHost(client *gophercloud.ServiceClient
 		return err
 	}
 
-	err = r.ReconcileLabels(client, instance, profile, host)
-	if err != nil {
-		return err
-	}
-
 	err = r.ReconcilePTPInstances(client, instance, profile, host)
 	if err != nil {
 		return err
@@ -833,6 +828,11 @@ func (r *HostReconciler) ReconcileDisabledHost(client *gophercloud.ServiceClient
 		if err != nil {
 			return err
 		}
+	}
+
+	err = r.ReconcileLabels(client, instance, profile, host)
+	if err != nil {
+		return err
 	}
 
 	err = r.ReconcileNetworking(client, instance, profile, host)


### PR DESCRIPTION
The LabelsReconcile could fail because of cpu
configuration. Since, Labels are reconciled first
we shall delay the error response until
Processors/CPUs have been reconciled
So that the next round of reconciliation will pass labels reconcile

Test plan:

PASS - Deploy AIO-SX
        with stalld host labels with application
        isolated cpus .


(cherry picked from commit d582805b3540fa11e0f640e1b8173eb77abb3e9a)