### PR TITLE
Remove tasks to check and create default registry secret

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -534,22 +534,6 @@
 
       when: deploy_config is defined
 
-    # Create default registry key in platform-deployment-manager for future image pulls
-    - name: Get platform-deployment-manager namespace default registry key
-      command: >-
-        kubectl --kubeconfig=/etc/kubernetes/admin.conf get secret default-registry-key --namespace=platform-deployment-manager
-      failed_when: false
-      register: get_dm_default_registry_key
-
-    - name: Copy default-registry-key to platform-deployment-manager namespace
-      shell: >-
-        kubectl get secret default-registry-key --namespace=kube-system -o yaml
-        | sed 's/namespace: kube-system/namespace: platform-deployment-manager/'
-        | kubectl apply --namespace=platform-deployment-manager -f -
-      environment:
-        KUBECONFIG: "/etc/kubernetes/admin.conf"
-      when: get_dm_default_registry_key.stdout == ""
-
     # Pre-verification block: it will search for administrative state applied
     # in order to avoid waiting for unlock when config administrativeState=locked.
     # Search first in host resource config. If not present, search into hostprofile.


### PR DESCRIPTION
The default registry key is now created automatically by the flux controller after system application apply. There's no need to create this secret manually after the initial application deployment.

This commit removes the tasks to check and create the default registry key.

Test pass:
1. Verify the default registry key created right after the application apply.
2. Verifiy the day-2 operation with a new debug image tag.