### PR TITLE
Handle host controller validation error

### DIFF
--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -265,7 +265,13 @@ func (h *ErrorHandler) HandleReconcilerError(request reconcile.Request, in error
 
 		h.Error(in, "HTTPS client required", "request", request)
 
-	case ValidationError, ChangeAfterReconciled:
+	case ChangeAfterReconciled:
+		resetClient = false
+		result = RetryValidationError
+		err = nil
+		h.Info("Change after reconcile ignored", "request", request)
+
+	case ValidationError:
 		// These errors are data validation errors.  There is likely a problem
 		// with the data provided by the user so wait for the user to correct
 		// the data.  Retrying is pointless.

--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -2376,7 +2376,7 @@ func (r *HostReconciler) Reconcile(ctx context.Context, request ctrl.Request) (r
 	// Build a composite profile based on the profile chain and host overrides
 	profile, err := r.BuildAndValidateCompositeProfile(instance)
 	if err != nil {
-		return reconcile.Result{}, err
+		return r.ReconcilerErrorHandler.HandleReconcilerError(request, err)
 	}
 
 	// Update ReconciledAfterInSync and ObservedGeneration


### PR DESCRIPTION
This commit updates the host controller to handle user defined profile errors, avoids pointless retries and stops the reconcile loop until the user can correct the error.

Test Plan:
- PASS: Introduce an error in the manifest file and apply. DM must show the error in the logs and stop the reconcile loop.
- PASS: Correct the manifest file and apply, reconcile must continue.