### PR TITLE
Improve get deployment namespace task

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -27,21 +27,24 @@
         wait_for_dm_unlock: " {{ wait_for_dm_unlock| default(5) }}"
       when: deployment_config is defined
 
-    - block:
-        - name: Set deployment namespace name fact
-          set_fact:
-            deployment_namespace: >-
-              {{ lookup('file', '{{ deploy_config }}')
-              | from_yaml_all
-              | selectattr('kind', 'equalto', 'Namespace')
-              | map(attribute='metadata.name')
-              | first }}
-      # in case the user does not define the namespace, the default namespace deployment
-      # must already exist, created by sysinv.
-      rescue:
-        - name: Set deployment namespace name fallback
-          set_fact:
-            deployment_namespace: "deployment"
+    - name: Get deployment namespace configured
+      shell: |
+        import yaml
+        with open("{{ deploy_config }}") as f:
+            resources = list(yaml.safe_load_all(f))
+        namespace = "deployment"
+        for resource in resources:
+            if isinstance(resource, dict) and resource.get("kind") == "Namespace":
+                namespace = resource["metadata"]["name"]
+                break
+        print(namespace.strip())
+      args:
+        executable: /usr/bin/python
+      delegate_to: localhost
+      register: get_deployment_namespace
+
+    - set_fact:
+        deployment_namespace: "{{ get_deployment_namespace.stdout }}"
 
     - debug:
         msg: "The crd namespace configured is {{ deployment_namespace }}"


### PR DESCRIPTION
This commit updates the "get deployment namespace" task to a more robust approach. The new approach handles cases where the user adds an empty item in the yam list (--- at the end of the file) and when the defined resource does not have the "kind" key.

Test Cases:
- PASS: deploy using a custom namespace
- PASS: deploy using the default namespace