### PR TITLE
Skip get deployment namespace task if deploy_config is missing

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -27,27 +27,29 @@
         wait_for_dm_unlock: " {{ wait_for_dm_unlock| default(5) }}"
       when: deployment_config is defined
 
-    - name: Get deployment namespace configured
-      shell: |
-        import yaml
-        with open("{{ deploy_config }}") as f:
-            resources = list(yaml.safe_load_all(f))
-        namespace = "deployment"
-        for resource in resources:
-            if isinstance(resource, dict) and resource.get("kind") == "Namespace":
-                namespace = resource["metadata"]["name"]
-                break
-        print(namespace.strip())
-      args:
-        executable: /usr/bin/python
-      delegate_to: localhost
-      register: get_deployment_namespace
+    - block:
+      - name: Get deployment namespace configured
+        shell: |
+          import yaml
+          with open("{{ deploy_config }}") as f:
+              resources = list(yaml.safe_load_all(f))
+          namespace = "deployment"
+          for resource in resources:
+              if isinstance(resource, dict) and resource.get("kind") == "Namespace":
+                  namespace = resource["metadata"]["name"]
+                  break
+          print(namespace.strip())
+        args:
+          executable: /usr/bin/python
+        delegate_to: localhost
+        register: get_deployment_namespace
 
-    - set_fact:
-        deployment_namespace: "{{ get_deployment_namespace.stdout }}"
+      - set_fact:
+          deployment_namespace: "{{ get_deployment_namespace.stdout }}"
 
-    - debug:
-        msg: "The crd namespace configured is {{ deployment_namespace }}"
+      - debug:
+          msg: "The crd namespace configured is {{ deployment_namespace }}"
+      when: deploy_config is defined
 
     - set_fact:
         manager_app_chart: "{{ manager_app_chart | default('/usr/local/share/applications/helm/deployment-manager-*.tgz') }}"


### PR DESCRIPTION
Test Plan:
PASS: execute the playbook omitting deploy_config variable, playbook
      must ignore the task and install dm.
PASS: execute the playbook providing deploy_config variable, playbook
      must install dm and apply the deployment configuration.