### PR TITLE
Fix get administrative state tasks

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -204,7 +204,7 @@
         shell: source /etc/platform/openrc; system application-list --nowrap | grep deployment-manager | awk '{ print $10 }'
         register: dm_app_status
 
-      - name: Fail if the deployment manager application staus is not ready to apply
+      - name: Fail if the deployment manager application status is not ready to apply
         fail:
           msg: >
             Deployment manager application is not in expected status:
@@ -537,37 +537,61 @@
     # Search first in host resource config. If not present, search into hostprofile.
     - block:
         - name: Search administrativeState into host resource
-          shell: |
-            source /etc/platform/openrc;
-            kubectl get host "{{ get_host_name.stdout}}" -n "{{ deployment_namespace }}" -o=jsonpath='{.spec.administrativeState}'
+          shell: >
+            kubectl get host "{{ get_host_name.stdout }}"
+            -n "{{ deployment_namespace }}"
+            -o=go-template
+            --template
+            {% raw %}
+            '{{ if .spec.overrides.administrativeState }}
+            {{ .spec.overrides.administrativeState }}
+            {{ end }}'
+            {% endraw %}
           environment:
             KUBECONFIG: "/etc/kubernetes/admin.conf"
-          register: get_host_adminstate
+          register: get_host_admin_state
           ignore_errors: yes
 
-        # If config not found in host -previous task- then search into hostprofile
         - name: Get hostprofile name for this host
-          shell: |
-            source /etc/platform/openrc;
-            kubectl get host "{{get_host_name.stdout}}" -n "{{ deployment_namespace }}" -o=jsonpath='{.spec.profile}'
+          shell: >
+            kubectl get host "{{get_host_name.stdout}}"
+            -n "{{ deployment_namespace }}"
+            -o=jsonpath='{.spec.profile}'
           environment:
             KUBECONFIG: "/etc/kubernetes/admin.conf"
           register: get_hostprofile_name
-          when: get_host_adminstate.stdout == ""
           ignore_errors: yes
 
         - name: Search administrativeState into hostprofile resource
-          shell: |
-            source /etc/platform/openrc;
-            kubectl get hostprofile "{{get_hostprofile_name.stdout}}" -n "{{ deployment_namespace }}" -o=jsonpath='{.spec.administrativeState}'
+          shell: >
+            kubectl get hostprofile "{{ get_hostprofile_name.stdout }}"
+            -n "{{ deployment_namespace }}"
+            -o=jsonpath='{.spec.administrativeState}'
           environment:
             KUBECONFIG: "/etc/kubernetes/admin.conf"
           register: get_hostprofile_adminstate
-          when: (get_hostprofile_name.stdout != "" and get_hostprofile_name.stderr == "")
+          ignore_errors: yes
 
-        - set_fact:
-            administrative_state: "{{get_host_adminstate.stdout + get_hostprofile_adminstate.stdout}}"
-          when: (get_host_name.stderr == "" and get_hostprofile_name.stderr == "")
+        - name: Show administrative state from host and hostprofile
+          debug:
+            msg:
+              - "host administrative state is '{{get_host_admin_state.stdout.strip()}}'"
+              - "profile administrative state is '{{get_hostprofile_adminstate.stdout.strip()}}'"
+
+        - name: Fail if unable to retrieve desired administrative state
+          fail:
+            msg:
+              - "Add administrative state in host or hostprofile and retry."
+          when:
+            - get_host_admin_state.stdout.strip() == ""
+            - get_hostprofile_adminstate.stdout.strip() == ""
+
+        - name: Set administrative state value
+          set_fact:
+            administrative_state: >
+              {{ get_host_admin_state.stdout.strip()
+                 if get_host_admin_state.stdout.strip() != ""
+                 else get_hostprofile_adminstate.stdout.strip() }}
 
         - name: Show config administrativeState
           debug:


### PR DESCRIPTION
This commit fixes the logic to retrieve the administrative state,
search on host resource and host profile resource. And the playbook
fails if the unable to retrieve the desired final administrative
state.

In a SX subcloud, if the the desired final configured state on
host/hostprofile is "unlocked", the playbook will wait the host to be
in an unlocked administrative state, otherwise it will skip the
verification.

Test Plan:
- PASS: playbook executation must wait the host be unlocked when:
  1) administrativeState: "unlocked" is configured only on the host
     resource.
  2) administrativeState: "unlocked" is configured only on the
     host profile resource.
  3) administrativeState: "unlocked" is configured on the host
     resource and administrativeState: "locked" on the host profile
     resource.
- PASS: playbook execution must skip unlock verification when:
  1) administrativeState: "locked" is configured on host profile
     resource.
  2) administrativeState: "locked" is configured on host resource.

Failure Path:
- PASS: administrativeState not configured on host resource or host
        profile resource.
- PASS: playbook execution unable to retrieve administrativeState.