### PR TITLE
Remove code to restore helm objects

### DIFF
--- a/controllers/addresspool_controller.go
+++ b/controllers/addresspool_controller.go
@@ -5,7 +5,6 @@ package controllers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -148,18 +147,6 @@ func (r *AddressPoolReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 		return reconcile.Result{}, err
 	}
 
-	// Restore the address pool status
-	if r.isRestoreInProgress(instance) {
-		r.ReconcilerEventLogger.NormalEvent(instance, common.ResourceUpdated, "Restoring '%s' Addresspool resource status without doing actual reconciliation", instance.Name)
-		if err := r.RestoreAddressPoolStatus(instance); err != nil {
-			return reconcile.Result{}, err
-		}
-		if err := r.ClearRestoreInProgress(instance); err != nil {
-			return reconcile.Result{}, err
-		}
-		return ctrl.Result{}, nil
-	}
-
 	if instance.DeletionTimestamp.IsZero() {
 		// Ensure that the object has a finalizer setup as a pre-delete hook so
 		// that we can delete any system resources that we previously added.
@@ -225,58 +212,4 @@ func (r *AddressPoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&starlingxv1.AddressPool{}).
 		Complete(r)
-}
-
-// Verify whether we have annotation restore-in-progress
-func (r *AddressPoolReconciler) isRestoreInProgress(instance *starlingxv1.AddressPool) bool {
-	restoreInProgress, ok := instance.Annotations[cloudManager.RestoreInProgress]
-	if ok && restoreInProgress != "" {
-		return true
-	}
-	return false
-}
-
-// Updates the AddressPool status while restoring
-func (r *AddressPoolReconciler) RestoreAddressPoolStatus(instance *starlingxv1.AddressPool) error {
-	annotation := instance.GetObjectMeta().GetAnnotations()
-	config, ok := annotation[cloudManager.RestoreInProgress]
-	if ok {
-		restoreStatus := &cloudManager.RestoreStatus{}
-		err := json.Unmarshal([]byte(config), &restoreStatus)
-		if err != nil {
-			logAddressPool.Error(err, "failed to unmarshal  restore status")
-			return nil
-		} else {
-			instance.Status.InSync = true
-			instance.Status.Reconciled = true
-			instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
-
-			err = r.Client.Status().Update(context.TODO(), instance)
-			if err != nil {
-				log_err_msg := fmt.Sprintf(
-					"Failed to update AddressPool status while restoring '%s' resource. Error: %s",
-					instance.Name,
-					err)
-				return common.NewResourceStatusDependency(log_err_msg)
-			}
-			StatusUpdate := fmt.Sprintf("Status updated for AddressPool resource '%s' during restore with following values: Reconciled=%t InSync=%t",
-				instance.Name, instance.Status.Reconciled, instance.Status.InSync)
-			r.ReconcilerEventLogger.NormalEvent(instance, common.ResourceUpdated, StatusUpdate)
-		}
-	}
-	return nil
-}
-
-// Clear annotation RestoreInProgress
-func (r *AddressPoolReconciler) ClearRestoreInProgress(instance *starlingxv1.AddressPool) error {
-	delete(instance.Annotations, cloudManager.RestoreInProgress)
-	if !utils.ContainsString(instance.ObjectMeta.Finalizers, AddressPoolFinalizerName) {
-		instance.ObjectMeta.Finalizers = append(instance.ObjectMeta.Finalizers, AddressPoolFinalizerName)
-	}
-	err := r.Client.Update(context.TODO(), instance)
-	if err != nil {
-		return common.NewResourceStatusDependency(fmt.Sprintf("Failed to update '%s' addresspool resource after removing '%s' annotation during restoration.",
-			instance.Name, cloudManager.RestoreInProgress))
-	}
-	return nil
 }

--- a/controllers/datanetwork_controller.go
+++ b/controllers/datanetwork_controller.go
@@ -5,7 +5,6 @@ package controllers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -524,18 +523,6 @@ func (r *DataNetworkReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 		return reconcile.Result{}, err
 	}
 
-	// Restore the data network status
-	if r.checkRestoreInProgress(instance) {
-		r.ReconcilerEventLogger.NormalEvent(instance, common.ResourceUpdated, "Restoring '%s' Data network resource status without doing actual reconciliation", instance.Name)
-		if err := r.RestoreDataNetworkStatus(instance); err != nil {
-			return reconcile.Result{}, err
-		}
-		if err := r.ClearRestoreInProgress(instance); err != nil {
-			return reconcile.Result{}, err
-		}
-		return ctrl.Result{}, nil
-	}
-
 	if err, _ := r.UpdateDeploymentScope(instance); err != nil {
 		return reconcile.Result{}, err
 	}
@@ -628,62 +615,4 @@ func (r *DataNetworkReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&starlingxv1.DataNetwork{}).
 		Complete(r)
-}
-
-// Verify whether we have annotation restore-in-progress
-func (r *DataNetworkReconciler) checkRestoreInProgress(instance *starlingxv1.DataNetwork) bool {
-	restoreInProgress, ok := instance.Annotations[cloudManager.RestoreInProgress]
-	if ok && restoreInProgress != "" {
-		return true
-	}
-	return false
-}
-
-// Update status
-func (r *DataNetworkReconciler) RestoreDataNetworkStatus(instance *starlingxv1.DataNetwork) error {
-	annotation := instance.GetObjectMeta().GetAnnotations()
-	config, ok := annotation[cloudManager.RestoreInProgress]
-	if ok {
-		restoreStatus := &cloudManager.RestoreStatus{}
-		err := json.Unmarshal([]byte(config), &restoreStatus)
-		if err == nil {
-			if restoreStatus.InSync != nil {
-				instance.Status.InSync = *restoreStatus.InSync
-			}
-			instance.Status.Reconciled = true
-			instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
-			instance.Status.DeploymentScope = "bootstrap"
-			instance.Status.StrategyRequired = "not_required"
-			err = r.Client.Status().Update(context.TODO(), instance)
-			if err != nil {
-				log_err_msg := fmt.Sprintf(
-					"Failed to update data network status while restoring '%s' resource. Error: %s",
-					instance.Name,
-					err)
-				return common.NewResourceStatusDependency(log_err_msg)
-			} else {
-				StatusUpdate := fmt.Sprintf("Status updated for DataNetwork resource '%s' during restore with following values: Reconciled=%t InSync=%t DeploymentScope=%s",
-					instance.Name, instance.Status.Reconciled, instance.Status.InSync, instance.Status.DeploymentScope)
-				r.ReconcilerEventLogger.NormalEvent(instance, common.ResourceUpdated, StatusUpdate)
-
-			}
-		} else {
-			r.ReconcilerEventLogger.NormalEvent(instance, common.ResourceUpdated, "Failed to unmarshal '%s'", err)
-		}
-	}
-	return nil
-}
-
-// Clear annotation RestoreInProgress
-func (r *DataNetworkReconciler) ClearRestoreInProgress(instance *starlingxv1.DataNetwork) error {
-	delete(instance.Annotations, cloudManager.RestoreInProgress)
-	if !utils.ContainsString(instance.ObjectMeta.Finalizers, DataNetworkFinalizerName) {
-		instance.ObjectMeta.Finalizers = append(instance.ObjectMeta.Finalizers, DataNetworkFinalizerName)
-	}
-	err := r.Client.Update(context.TODO(), instance)
-	if err != nil {
-		return common.NewResourceStatusDependency(fmt.Sprintf("Failed to update '%s' data network resource after removing '%s' annotation during restoration.",
-			instance.Name, cloudManager.RestoreInProgress))
-	}
-	return nil
 }

--- a/controllers/hostprofile_controller.go
+++ b/controllers/hostprofile_controller.go
@@ -11,7 +11,6 @@ import (
 	perrors "github.com/pkg/errors"
 	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
 	"github.com/wind-river/cloud-platform-deployment-manager/controllers/common"
-	cloudManager "github.com/wind-river/cloud-platform-deployment-manager/controllers/manager"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -143,11 +142,6 @@ func (r *HostProfileReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
-	if instance.ObjectMeta.Generation == 1 && r.checkRestoreInProgress(instance) {
-		r.ReconcilerEventLogger.NormalEvent(instance, common.ResourceUpdated, "Restoring '%s' HostProfile resource without doing actual reconciliation",
-			instance.Name)
-		return ctrl.Result{}, nil
-	}
 
 	// Force an update to each of the hosts that reference this profile.
 	err = r.UpdateHosts(instance)
@@ -172,13 +166,4 @@ func (r *HostProfileReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&starlingxv1.HostProfile{}).
 		Complete(r)
-}
-
-// Verify whether we have annotation restore-in-progress
-func (r *HostProfileReconciler) checkRestoreInProgress(instance *starlingxv1.HostProfile) bool {
-	restoreInProgress, ok := instance.Annotations[cloudManager.RestoreInProgress]
-	if ok && restoreInProgress != "" {
-		return true
-	}
-	return false
 }

--- a/controllers/manager/manager.go
+++ b/controllers/manager/manager.go
@@ -45,7 +45,6 @@ const (
 	// Defines annotation keys for resources.
 	NotificationCountKey = "deployment-manager/notifications"
 	ReconcileAfterInSync = "deployment-manager/reconcile-after-insync"
-	RestoreInProgress    = "deployment-manager/restore-in-progress"
 )
 
 const (


### PR DESCRIPTION
This commit removes the code used to restore objects during the migration from 22.12 to 24.09 version.

Test Plan:
- PASS: day-1 operation in an IO-SX, all resources insync/reconciled=true
- PASS: day-2 operation in an IO-SX, all resources insync/reconciled=true