### PR TITLE
Delay reconcile loop if mutating web hooks are not available

### DIFF
--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -2265,7 +2265,7 @@ func (r *HostReconciler) Reconcile(ctx context.Context, request ctrl.Request) (r
 
 	err, scopeUpdated := r.UpdateDeploymentScope(instance)
 	if err != nil {
-		return reconcile.Result{}, err
+		return r.HandleReconcilerError(request, err)
 	}
 
 	if r.instanceConfigCompleted(instance) && !platformNetUpdateRequired && !scopeUpdated {

--- a/controllers/platformnetwork_controller.go
+++ b/controllers/platformnetwork_controller.go
@@ -279,15 +279,13 @@ func (r *PlatformNetworkReconciler) Reconcile(ctx context.Context, request ctrl.
 
 	err, scopeUpdated := r.UpdateDeploymentScope(instance)
 	if err != nil {
-		return reconcile.Result{}, err
+		return r.HandleReconcilerError(request, err)
 	}
 
 	// Update ReconciledAfterInSync and ObservedGeneration.
 	logPlatformNetwork.V(2).Info("before UpdateConfigStatus", "instance", instance)
-	err = r.UpdateConfigStatus(instance, request.Namespace)
-	if err != nil {
-		logPlatformNetwork.Error(err, "unable to update ReconciledAfterInSync or ObservedGeneration.")
-		return reconcile.Result{}, err
+	if err := r.UpdateConfigStatus(instance, request.Namespace); err != nil {
+		return r.HandleReconcilerError(request, err)
 	}
 	logPlatformNetwork.V(2).Info("after UpdateConfigStatus", "instance", instance)
 

--- a/controllers/ptpinstance_controller.go
+++ b/controllers/ptpinstance_controller.go
@@ -582,15 +582,14 @@ func (r *PtpInstanceReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 	}
 
 	if err, _ := r.UpdateDeploymentScope(instance); err != nil {
-		return reconcile.Result{}, err
+		return r.HandleReconcilerError(request, err)
 	}
 
 	// Update ReconciledAfterInSync and ObservedGeneration.
 	logPtpInstance.V(2).Info("before UpdateConfigStatus", "instance", instance)
 	err = r.UpdateConfigStatus(instance, request.Namespace)
 	if err != nil {
-		logPtpInstance.Error(err, "unable to update ReconciledAfterInSync or ObservedGeneration.")
-		return reconcile.Result{}, err
+		return r.HandleReconcilerError(request, err)
 	}
 	logPtpInstance.V(2).Info("after UpdateConfigStatus", "instance", instance)
 

--- a/controllers/ptpinterface_controller.go
+++ b/controllers/ptpinterface_controller.go
@@ -608,16 +608,15 @@ func (r *PtpInterfaceReconciler) Reconcile(ctx context.Context, request ctrl.Req
 	}
 
 	if err, _ := r.UpdateDeploymentScope(instance); err != nil {
-		return reconcile.Result{}, err
+		return r.HandleReconcilerError(request, err)
 	}
 
 	// Update ReconciledAfterInSync and ObservedGeneration.
 	logPtpInterface.V(2).Info("before UpdateConfigStatus", "instance", instance)
-	err = r.UpdateConfigStatus(instance, request.Namespace)
-	if err != nil {
-		logPtpInterface.Error(err, "unable to update ReconciledAfterInSync or ObservedGeneration.")
-		return reconcile.Result{}, err
+	if err := r.UpdateConfigStatus(instance, request.Namespace); err != nil {
+		return r.HandleReconcilerError(request, err)
 	}
+
 	logPtpInterface.V(2).Info("after UpdateConfigStatus", "instance", instance)
 
 	if instance.DeletionTimestamp.IsZero() {

--- a/controllers/system/system_controller.go
+++ b/controllers/system/system_controller.go
@@ -1626,10 +1626,8 @@ func (r *SystemReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 	// Update ReconciledAfterInSync and ObservedGeneration
 	logSystem.V(2).Info("before UpdateConfigStatus", "instance", instance)
 
-	err = r.UpdateConfigStatus(instance, request.Namespace)
-	if err != nil {
-		logSystem.Error(err, "unable to update ReconciledAfterInSync or ObservedGeneration")
-		return reconcile.Result{}, err
+	if err := r.UpdateConfigStatus(instance, request.Namespace); err != nil {
+		return r.HandleReconcilerError(request, err)
 	}
 	logSystem.V(2).Info("after UpdateConfigStatus", "instance", instance)
 


### PR DESCRIPTION
DM relies on mutating webhooks [1] to update resources, in short period of time, after the the pod start, the webhooks can still be unavailable.

This commit updates the error handler to catch this error if the webhook is not available and display a friendly message.

Test Plan:
- PASS: Day-2 operations using the dm playbook

[1]: kubectl describe mutatingwebhookconfigurations \
        platform-deployment-manager-mutating-webhook-configuration