### PR TITLE
Restart pod post enroll if relesae is N-1

### DIFF
--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -409,6 +409,17 @@
             msg: Waiting after apply DM config
           when: not subcloud_enrollment
 
+        # To keep compatibility with 24.09 release, we need to restart the dm pod
+        # so the pod can handle subcloud enrollment re-configuration.
+        - name: Restart the deployment manager if subcloud enrollment
+          command: >-
+            kubectl -n platform-deployment-manager delete pods --selector control-plane=controller-manager
+          environment:
+            KUBECONFIG: "/etc/kubernetes/admin.conf"
+          when:
+            - subcloud_enrollment
+            - "get_software_version.stdout is version('25.09' , '<')"
+
       when: deploy_config is defined
 
     # Pre-verification block: it will search for administrative state applied


### PR DESCRIPTION
This commit updates the dm playbook to restart the dm pod if the subcloud is running N-1 release. It ensures all the configurations will be a applied.

Test Plan:
- PASS: enroll N-1 subcloud