### PR TITLE
Update helm to v3 in the builder

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.22.2'
+        go-version: '1.23.0'
         cache: false
 
     - name: Build the Docker image

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ helm/wind-river-cloud-platform-deployment-manager/templates/rbac
 *.swo
 *~
 .vscode
+
+# Controller-gen generated empty CRD file
+config/crd/bases/_.yaml

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -33,13 +33,13 @@ cd downloads
 ```
 
 The Deployment Manager was developed during the period when GoLang version
-1.22.2 was prominent.  A newer version may work fine, but the minimum guaranteed
-version that will work with the tools and Makefile provided is v1.22.2.
+1.23.0 was prominent.  A newer version may work fine, but the minimum guaranteed
+version that will work with the tools and Makefile provided is v1.23.0.
 
 ```bash
 cd ${GOPATH}/downloads
-wget https://dl.google.com/go/go1.22.2.linux-amd64.tar.gz
-sudo tar -C /usr/local -zxf go1.22.2.linux-amd64.tar.gz
+wget https://dl.google.com/go/go1.23.0.linux-amd64.tar.gz
+sudo tar -C /usr/local -zxf go1.23.0.linux-amd64.tar.gz
 export PATH=${PATH}:/usr/local/go/bin
 ```
 
@@ -49,13 +49,13 @@ The recommended installation method of the Deployment Manager is to use a Helm
 chart.  This ensures that the required CRD resources are installed before the
 Deployment Manager pods are created.  It also ensures that recommended default
 values for specific Kubernetes attributes are used.  The minimum required
-version of Helm is v3.6.2 and can be installed on your workstation using the
+version of Helm is v3.17.1 and can be installed on your workstation using the
 following commands.
 
 ```bash
 cd ${GOPATH}/downloads
-wget https://get.helm.sh/helm-v3.6.2-linux-amd64.tar.gz
-tar zxf helm-v3.6.2-linux-amd64.tar.gz
+wget https://get.helm.sh/helm-v3.17.1-linux-amd64.tar.gz
+tar zxf helm-v3.17.1-linux-amd64.tar.gz
 sudo cp linux-amd64/helm /usr/local/bin/
 ```
 
@@ -485,8 +485,8 @@ public key to ~/.ssh/authorized_keys.
 
 #### Versions
 
-Try using Go 1.22.2 if newer versions aren't working. Check with:
+Try using Go 1.23.0 if newer versions aren't working. Check with:
 ```bash
 > go version
-go version go1.22.2 linux/amd64
+go version go1.23.0 linux/amd64
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Build the manager binary
-FROM golang:1.23.0 as dlvbuilder
+FROM golang:1.23.0 AS dlvbuilder
 
 # Build delve debugger
 RUN apt-get update && apt-get install -y git
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Build the manager binary
-FROM dlvbuilder as builder
+FROM dlvbuilder AS builder
 ARG GOBUILD_GCFLAGS=""
 
 WORKDIR /workspace
@@ -34,14 +34,14 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags "${GOBUILD_GCFLAGS}"
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM scratch as production
+FROM scratch AS production
 WORKDIR /
 COPY --from=builder /workspace/manager .
 
 ENTRYPOINT ["/manager"]
 
 # Copy the delve debugger into a debug image
-FROM ubuntu:noble as debug
+FROM ubuntu:noble AS debug
 WORKDIR /
 RUN apt-get update && apt-get install -y tcpdump net-tools iputils-ping iproute2
 COPY --from=dlvbuilder /go/bin/dlv /

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -3,9 +3,11 @@ FROM golang:1.23.0-bullseye
 # Install our required version of Kustomize to generate the examples
 RUN wget https://github.com/kubernetes-sigs/kustomize/releases/download/v1.0.11/kustomize_1.0.11_linux_amd64 -q -O /usr/local/bin/kustomize && chmod 755 /usr/local/bin/kustomize
 
-# Install our current version of Helm.  We can probably upgrade to a new version
-# but this one has been tested and verified to work.
-RUN wget https://get.helm.sh/helm-v2.16.10-linux-amd64.tar.gz -q -O - | tar zx -C /bin --strip-components=1 linux-amd64/helm
+# Install Helm v3.17.1
+RUN wget https://get.helm.sh/helm-v3.17.1-linux-amd64.tar.gz -O /tmp/helm.tar.gz && \
+    tar -zxf /tmp/helm.tar.gz -C /tmp && \
+    mv /tmp/linux-amd64/helm /usr/local/bin/helm && \
+    rm -rf /tmp/helm.tar.gz /tmp/linux-amd64
 
 # Install our required version of Kubebuilder.  We cannot upgrade to a later
 # version without significant effort.
@@ -31,9 +33,7 @@ ENV PATH="${PATH}:/usr/local/kubebuilder/bin:/bin"
 WORKDIR /go/src/github.com/wind-river/cloud-platform-deployment-manager
 RUN git config --global --add safe.directory /go/src/github.com/wind-river/cloud-platform-deployment-manager
 
-# Initialize helm within the container otherwise no helm commands will work.
-RUN helm init --stable-repo-url=https://charts.helm.sh/stable --client-only
-
+# Helm v3 is ready to use for packaging and linting
 # The entry command can be overwritten when launched but by default these are
 # the build steps that we will be running.
-CMD make && DEBUG=yes make docker-build
+CMD ["sh", "-c", "make && DEBUG=yes make docker-build"]

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ HELM_FORCE ?= 0
 DEFAULT_IMG ?= wind-river/cloud-platform-deployment-manager
 BUILDER_IMG ?= ${DEFAULT_IMG}-builder:latest
 
-HELM_CLIENT_VER := $(shell helm version --client --short 2>/dev/null | awk '{print $$NF}' | sed 's/^v//')
+HELM_CLIENT_VER := $(shell helm version --short 2>/dev/null | awk '{print $$1}' | sed 's/^v//')
 HELM_CLIENT_VER_REL := $(shell echo ${HELM_CLIENT_VER} | awk -F. '{print $$1}')
 HELM_CLIENT_VER_MAJ := $(shell echo ${HELM_CLIENT_VER} | awk -F. '{print $$2}')
 
@@ -210,8 +210,8 @@ builder-run: builder-build
 
 # Check minimum helm version
 helm-ver-check:
-	@if [[ ${HELM_CLIENT_VER_REL} < 2 || ( ${HELM_CLIENT_VER_REL} == 2 && ${HELM_CLIENT_VER_MAJ} < 16 ) ]]; then
-		@echo "Minimum required helm client version is v2.16. Installed version is ${HELM_CLIENT_VER}"
+	@if [[ ${HELM_CLIENT_VER_REL} < 3 ]]; then
+		@echo "Minimum required helm client version is v3.0. Installed version is ${HELM_CLIENT_VER}"
 		@/bin/false
 	@fi
 


### PR DESCRIPTION
This commit updates the helm in the builder container to v3 align with the version currently widely used.
This commit also updates the developer's doc to align with the go and helm version used.

Test:
Passed - make && DEBUG=yes make docker-build