### PR TITLE
Increase ansible unlock monitor task timeout

### DIFF
--- a/docs/playbooks/roles/initial-config/tasks/lock-unlock.yaml
+++ b/docs/playbooks/roles/initial-config/tasks/lock-unlock.yaml
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright(c) 2025 Wind River Systems, Inc.
 - set_fact:
-    wait_for_dm_unlock: "{{ wait_for_dm_unlock | default(5) }}"
-    wait_for_dm_unlock_retries: "{{ wait_for_dm_unlock_retries | default(60) }}"
+    dm_unlock_timeout: "{{ dm_unlock_timeout | default(1200) }}"
 
 # TODO: Remove this workaround once Ansible 2.11+ is available in WRCP.
 # Replace with reboot_command: /bin/true in the reboot task below.
@@ -23,4 +22,5 @@
     # The reboot is triggered by the unlock operation.
     search_paths:
       - "/tmp/"
+    reboot_timeout: "{{ dm_unlock_timeout }}"
   register: unlock_reboot_status


### PR DESCRIPTION
Increases timeout from 10 to 20 minutes. Total unlock time becomes 40 minutes: 20 minutes for power-off + 20 minutes for power-on. Original timeout was higher but 20 minutes covers most hardware reboot cycles.

Test Plan:
- PASS: verify unlock on hardware that takes more than 10 minutes to reboot.