### PR TITLE
Fail playbook execution if config failed to apply

### DIFF
--- a/docs/playbooks/roles/common/tasks/apply-config.yaml
+++ b/docs/playbooks/roles/common/tasks/apply-config.yaml
@@ -18,4 +18,11 @@
   retries: 5
   delay: 10
   until: apply_deploy_config.rc == 0
-  ignore_errors: true
+  failed_when: true
+
+- name: Fail if deploy configuration failed to apply
+  fail:
+    msg: >
+      stderr is: {{ apply_deploy_config.stderr }}
+      stdout is: {{ apply_deploy_config.stdout }}
+  when: apply_deploy_config.rc != 0

--- a/docs/playbooks/roles/initial-config/tasks/main.yaml
+++ b/docs/playbooks/roles/initial-config/tasks/main.yaml
@@ -27,6 +27,7 @@
   block:
     - include_tasks:
         file: lock-unlock.yaml
+      when: current_administrative_state == "locked"
 
     - include_tasks:
         file: monitor-deployment.yaml

--- a/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
+++ b/docs/playbooks/wind-river-cloud-platform-deployment-manager.yaml
@@ -11,7 +11,9 @@
 
     - include_role:
         name: initial-config
-      when: not initial_configuration_done
+      when:
+        - not subcloud_enrollment
+        - not scope_principal
 
     - include_role:
         name: reconfig


### PR DESCRIPTION
This commit updates the Ansible playbook to fail if the deployment configuration failed to apply. Additionally, it resolves a playbook replay issue by attempting to unlock only when the host is in a locked state.

Test Plan:
- PASS: deploy a SX subcloud
- PASS: replay the deployment configuration

Failure Path:
- PASS: playbook fails with invalid config file