### PR TITLE
Optionally skip tests during build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,4 +20,4 @@ jobs:
         cache: false
 
     - name: Build the Docker image
-      run: make builder-run
+      run: make BUILD_TEST=0 builder-run

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -33,7 +33,9 @@ ENV PATH="${PATH}:/usr/local/kubebuilder/bin:/bin"
 WORKDIR /go/src/github.com/wind-river/cloud-platform-deployment-manager
 RUN git config --global --add safe.directory /go/src/github.com/wind-river/cloud-platform-deployment-manager
 
+ARG BUILD_TEST=1
+
 # Helm v3 is ready to use for packaging and linting
 # The entry command can be overwritten when launched but by default these are
 # the build steps that we will be running.
-CMD ["sh", "-c", "make && DEBUG=yes make docker-build"]
+CMD ["sh", "-c", "DEBUG=yes BUILD_TEST=${BUILD_TEST} make"]

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,15 @@ HELM_CRDS=helm/wind-river-cloud-platform-deployment-manager/templates/crds.yaml
 # DeepCopy auto generated file
 DEEPCOPY_GEN_FILE=./api/v1/zz_generated.deepcopy.go
 
+BUILD_TEST ?= 1
+ifeq ($(BUILD_TEST),1)
+ALL_TARGETS = helm-ver-check test build tools helm-package docker-build examples
+else
+ALL_TARGETS = helm-ver-check build tools helm-package docker-build examples
+endif
+
 .PHONY: all
-all: helm-ver-check test build tools helm-package docker-build examples
+all: $(ALL_TARGETS)
 
 # Publish all artifacts
 publish: helm-package docker-push
@@ -185,7 +192,7 @@ $(DEEPEQUAL_GEN): $(LOCALBIN)
 
 # Build the builder image
 builder-build:
-	docker build . --no-cache -t ${BUILDER_IMG} -f Dockerfile.builder
+	docker build . --no-cache --build-arg "BUILD_TEST=${BUILD_TEST}" -t ${BUILDER_IMG} -f Dockerfile.builder
 
 builder-run: builder-build
 	docker run -v /var/run/docker.sock:/var/run/docker.sock \


### PR DESCRIPTION
This commit introduces BUILD_TEST flag to conditionally include the
'test' target in the 'all' recipe to skip tests. The test target is
excluded from the default 'all' make target, allowing faster builds
when testing is not required (e.g., CI docker image builds).

Test Plan:
- PASS: "BUILD_TEST=0 make" and verify tests did not run
- PASS: "make" and verify tests run