### PR TITLE
Log errs for each configuration apply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ DEEPEQUAL_GEN ?= $(LOCALBIN)/deepequal-gen
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
-SETPUP_ENVTEST_VERSION ?= release-0.16
+SETPUP_ENVTEST_VERSION ?= release-0.20
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 

--- a/api/v1/ptpinstance_type_test.go
+++ b/api/v1/ptpinstance_type_test.go
@@ -86,7 +86,7 @@ var _ = Describe("PtpInstance controller", func() {
 				    }
 				}`
 				expected := map[string][]string{
-					"global": {"param1", "param2", "param3"},
+					"global":                 {"param1", "param2", "param3"},
 					"unicast_master_table_x": {"param1", "param2"},
 				}
 

--- a/docs/playbooks/roles/common/tasks/apply-config.yaml
+++ b/docs/playbooks/roles/common/tasks/apply-config.yaml
@@ -10,19 +10,30 @@
     distributed_cloud_role == "subcloud" or
     distributed_cloud_role == ""
 
-- name: Apply deployment configuration file
-  shell: kubectl apply -f {{ deploy_config }}
-  environment:
-    KUBECONFIG: "/etc/kubernetes/admin.conf"
-  register: apply_deploy_config
-  retries: 5
-  delay: 10
-  until: apply_deploy_config.rc == 0
-  failed_when: false
+- name: Apply deployment configuration with retries
+  block:
+    - name: Apply deployment configuration file
+      shell: kubectl apply -f {{ deploy_config }}
+      environment:
+        KUBECONFIG: "/etc/kubernetes/admin.conf"
+      register: apply_deploy_config
 
-- name: Fail if deploy configuration failed to apply
-  fail:
-    msg: >
-      stderr is: {{ apply_deploy_config.stderr }}
-      stdout is: {{ apply_deploy_config.stdout }}
-  when: apply_deploy_config.rc != 0
+  rescue:
+    - name: Retry apply deployment configuration
+      shell: kubectl apply -f {{ deploy_config }}
+      environment:
+        KUBECONFIG: "/etc/kubernetes/admin.conf"
+      register: apply_deploy_config
+      retries: 3
+      delay: 10
+      until: apply_deploy_config.rc == 0
+      failed_when: false
+
+    - name: Fail if all retries exhausted
+      fail:
+        msg:
+          - "Failed to apply deployment configuration after
+            {{ apply_deploy_config.attempts + 2 }} attempts."
+          - "stderr: {{ apply_deploy_config.stderr }}"
+          - "stdout: {{ apply_deploy_config.stdout }}"
+      when: apply_deploy_config.rc != 0

--- a/docs/playbooks/roles/initial-config/tasks/monitor-deployment.yaml
+++ b/docs/playbooks/roles/initial-config/tasks/monitor-deployment.yaml
@@ -92,9 +92,9 @@
   failed_when: false
 
 - debug:
-    msg: >
-      stderr is: {{ unreconciled.stderr }}
-      stdout is: {{ unreconciled.stdout }}
+    msg:
+      - "stderr is: {{ unreconciled.stderr }}"
+      - "stdout is: {{ unreconciled.stdout }}"
 
 - name: Get DM pod error logs
   shell: >-


### PR DESCRIPTION
The current playbook only logs the last round of logs of applying the deployment configurations.

In the case of syntax errors in one CR, or rejected by the validation webhooks, as the host may get reconciled and unlocked, the error log about the fatal error of lost connection due to unlock may not be logged, and difficult for trouble shooting.

For the ease of trouble shooting, this commit logs the stdout and stderr after the first apply, ensuring enough logs to understand the potential problem in the config file.

This commit also updates the SETPUP_ENVTEST_VERSION to release-0.20 which fit for golang 1.23. The previous version is deprecated.

Test plan:

1. Passed - make test
2. Passed - verified the 1st apply failed with an error message,s but the retry in the rescue block continues, until the retries are exhausted.
3. Passed - verified normal apply and reconfig successful