### PR TITLE
Improve error messages for invalid IP addresses

### DIFF
--- a/controllers/host/profile_utils.go
+++ b/controllers/host/profile_utils.go
@@ -476,18 +476,18 @@ func (r *HostReconciler) validateBoardManagement(host *starlingxv1.Host, profile
 func (r *HostReconciler) validateProfileAddresses(host *starlingxv1.Host, profile *starlingxv1.HostProfileSpec) error {
 	for _, addr := range profile.Addresses {
 		if net.ParseIP(addr.Address) == nil {
-			msg := "'address' profile attributes need to be in a valid IPv4 or IPv6 address format"
+			msg := fmt.Sprintf("invalid IP address '%s' in profile attribute 'address'", addr.Address)
 			return common.NewValidationError(msg)
 		}
 	}
 
 	for _, rt := range profile.Routes {
 		if net.ParseIP(rt.Network) == nil {
-			msg := "'network' profile attributes need to be in a valid IPv4 or IPv6 address format"
+			msg := fmt.Sprintf("invalid IP address '%s' in profile attribute 'network'", rt.Network)
 			return common.NewValidationError(msg)
 		}
 		if net.ParseIP(rt.Gateway) == nil {
-			msg := "'gateway' profile attributes need to be in a valid IPv4 or IPv6 address format"
+			msg := fmt.Sprintf("invalid IP address '%s' in profile attribute 'gateway'", rt.Gateway)
 			return common.NewValidationError(msg)
 		}
 	}


### PR DESCRIPTION
Display the invalid IP address value in validation error messages for address, network, and gateway profile attributes to improve debuggability

Test Plan:
- PENDING: configure invalid ip address, verify