### PR TITLE
Validate IP addresses before parsing and logging improvment

### DIFF
--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -346,6 +346,7 @@ func (r *HostReconciler) UpdateRequired(instance *starlingxv1.Host, profile *sta
 			if err != nil {
 				if errors.IsNotFound(err) {
 					msg := fmt.Sprintf("waiting for BM credentials secret: %q", info.Secret)
+					r.NormalEvent(instance, common.ResourceDependency, msg)
 					name := types.NamespacedName{Namespace: instance.Namespace, Name: info.Secret}
 					m := NewKubernetesSecretMonitor(instance, name)
 					return hosts.HostOpts{}, result, r.CloudManager.StartMonitor(m, msg)

--- a/controllers/host/profile_utils.go
+++ b/controllers/host/profile_utils.go
@@ -333,6 +333,12 @@ func (r *HostReconciler) BuildCompositeProfile(host *starlingxv1.Host) (*starlin
 		composite.Interfaces.Ethernet = nil
 	}
 
+	// IP address validation must occur before profile configuration updates
+	// to prevent nil invalid IP address values
+	if err := r.validateProfileAddresses(host, composite); err != nil {
+		return composite, err
+	}
+
 	// Remove leading zeros from each IP address in the composite profile
 	addressList := make([]starlingxv1.AddressInfo, 0)
 	for _, addr := range composite.Addresses {
@@ -476,18 +482,18 @@ func (r *HostReconciler) validateBoardManagement(host *starlingxv1.Host, profile
 func (r *HostReconciler) validateProfileAddresses(host *starlingxv1.Host, profile *starlingxv1.HostProfileSpec) error {
 	for _, addr := range profile.Addresses {
 		if net.ParseIP(addr.Address) == nil {
-			msg := "'address' profile attributes need to be in a valid IPv4 or IPv6 address format"
+			msg := fmt.Sprintf("invalid IP address '%s' in profile attribute 'address'", addr.Address)
 			return common.NewValidationError(msg)
 		}
 	}
 
 	for _, rt := range profile.Routes {
 		if net.ParseIP(rt.Network) == nil {
-			msg := "'network' profile attributes need to be in a valid IPv4 or IPv6 address format"
+			msg := fmt.Sprintf("invalid IP address '%s' in profile attribute 'network'", rt.Network)
 			return common.NewValidationError(msg)
 		}
 		if net.ParseIP(rt.Gateway) == nil {
-			msg := "'gateway' profile attributes need to be in a valid IPv4 or IPv6 address format"
+			msg := fmt.Sprintf("invalid IP address '%s' in profile attribute 'gateway'", rt.Gateway)
 			return common.NewValidationError(msg)
 		}
 	}
@@ -544,11 +550,6 @@ func (r *HostReconciler) validateProfileSpec(host *starlingxv1.Host, profile *st
 	}
 
 	err = r.validateBoardManagement(host, profile)
-	if err != nil {
-		return err
-	}
-
-	err = r.validateProfileAddresses(host, profile)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Move IP address validation before leading zero removal in
BuildCompositeProfile to catch malformed addresses earlier.
Improve error messages to include the invalid IP value.
Add event logging when BMC credentials secret is missing.

Test Plan:
- PASS - Verify invalid IP addresses are rejected
- PASS - Validate BMC secret missing logging
- PASS - AIO-SX subcloud deploy