### PR TITLE
Add required labels to rook-ceph examples

### DIFF
--- a/examples/aio-dx-rook-ceph-deployment-controller.yaml
+++ b/examples/aio-dx-rook-ceph-deployment-controller.yaml
@@ -148,10 +148,13 @@ spec:
       port:
         name: eth1001
   labels:
+    ceph-mgr-placement: enabled
+    ceph-mon-placement: enabled
     openstack-compute-node: enabled
     openstack-control-plane: enabled
     openvswitch: enabled
     sriov: enabled
+    topology.rook.io/chassis: "group-0"
   personality: controller
   processors:
   - functions:

--- a/examples/aio-dx-rook-ceph-deployment-dedicated.yaml
+++ b/examples/aio-dx-rook-ceph-deployment-dedicated.yaml
@@ -80,6 +80,9 @@ metadata:
   namespace: deployment
 spec:
   overrides:
+    labels:
+      ceph-mgr-placement: enabled
+      ceph-mon-placement: enabled
     bootMAC: COMPUTE0MAC
     storage:
       filesystems:
@@ -188,6 +191,8 @@ spec:
       port:
         name: eth1001
   labels:
+    ceph-mgr-placement: enabled
+    ceph-mon-placement: enabled
     openstack-compute-node: enabled
     openstack-control-plane: enabled
     openvswitch: enabled
@@ -253,6 +258,7 @@ spec:
     openstack-compute-node: enabled
     openvswitch: enabled
     sriov: enabled
+    topology.rook.io/chassis: "group-0"
   personality: worker
   processors:
   - functions:

--- a/examples/aio-dx-rook-ceph-deployment-open.yaml
+++ b/examples/aio-dx-rook-ceph-deployment-open.yaml
@@ -184,10 +184,13 @@ spec:
       port:
         name: eth1001
   labels:
+    ceph-mgr-placement: enabled
+    ceph-mon-placement: enabled
     openstack-compute-node: enabled
     openstack-control-plane: enabled
     openvswitch: enabled
     sriov: enabled
+    topology.rook.io/chassis: "group-0"
   personality: controller
   processors:
   - functions:
@@ -250,9 +253,12 @@ spec:
       port:
         name: eth1001
   labels:
+    ceph-mgr-placement: enabled
+    ceph-mon-placement: enabled
     openstack-compute-node: enabled
     openvswitch: enabled
     sriov: enabled
+    topology.rook.io/chassis: "group-0"
   personality: worker
   processors:
   - functions:

--- a/examples/aio-sx-rook-ceph-deployment-controller.yaml
+++ b/examples/aio-sx-rook-ceph-deployment-controller.yaml
@@ -127,10 +127,13 @@ spec:
       port:
         name: eth1001
   labels:
+    ceph-mgr-placement: enabled
+    ceph-mon-placement: enabled
     openstack-compute-node: enabled
     openstack-control-plane: enabled
     openvswitch: enabled
     sriov: enabled
+    topology.rook.io/chassis: "group-0"
   personality: controller
   processors:
   - functions:

--- a/examples/aio-sx-rook-ceph-deployment-open.yaml
+++ b/examples/aio-sx-rook-ceph-deployment-open.yaml
@@ -127,10 +127,13 @@ spec:
       port:
         name: eth1001
   labels:
+    ceph-mgr-placement: enabled
+    ceph-mon-placement: enabled
     openstack-compute-node: enabled
     openstack-control-plane: enabled
     openvswitch: enabled
     sriov: enabled
+    topology.rook.io/chassis: "group-0"
   personality: controller
   processors:
   - functions:

--- a/examples/standard-rook-ceph-deployment-controller.yaml
+++ b/examples/standard-rook-ceph-deployment-controller.yaml
@@ -78,6 +78,9 @@ metadata:
   namespace: deployment
 spec:
   overrides:
+    labels:
+      ceph-mgr-placement: enabled
+      ceph-mon-placement: enabled
     bootMAC: COMPUTE0MAC
     storage:
       filesystems:
@@ -173,7 +176,10 @@ spec:
       port:
         name: enp0s3
   labels:
+    ceph-mgr-placement: enabled
+    ceph-mon-placement: enabled
     openstack-control-plane: enabled
+    topology.rook.io/chassis: "group-0"
   personality: controller
   storage:
     filesystems:

--- a/examples/standard-rook-ceph-deployment-dedicated.yaml
+++ b/examples/standard-rook-ceph-deployment-dedicated.yaml
@@ -78,6 +78,9 @@ metadata:
   namespace: deployment
 spec:
   overrides:
+    labels:
+      ceph-mgr-placement: enabled
+      ceph-mon-placement: enabled
     bootMAC: COMPUTE0MAC
     storage:
       filesystems:
@@ -173,6 +176,8 @@ spec:
       port:
         name: enp0s3
   labels:
+    ceph-mgr-placement: enabled
+    ceph-mon-placement: enabled
     openstack-control-plane: enabled
   personality: controller
   storage:
@@ -209,6 +214,7 @@ spec:
     openstack-compute-node: enabled
     openvswitch: enabled
     sriov: enabled
+    topology.rook.io/chassis: "group-0"
   personality: worker
   processors:
   - functions:

--- a/examples/standard-rook-ceph-deployment-open.yaml
+++ b/examples/standard-rook-ceph-deployment-open.yaml
@@ -78,6 +78,9 @@ metadata:
   namespace: deployment
 spec:
   overrides:
+    labels:
+      ceph-mgr-placement: enabled
+      ceph-mon-placement: enabled
     bootMAC: COMPUTE0MAC
     storage:
       filesystems:
@@ -173,7 +176,10 @@ spec:
       port:
         name: enp0s3
   labels:
+    ceph-mgr-placement: enabled
+    ceph-mon-placement: enabled
     openstack-control-plane: enabled
+    topology.rook.io/chassis: "group-0"
   personality: controller
   storage:
     filesystems:
@@ -213,6 +219,7 @@ spec:
     openstack-compute-node: enabled
     openvswitch: enabled
     sriov: enabled
+    topology.rook.io/chassis: "group-0"
   personality: worker
   processors:
   - functions:


### PR DESCRIPTION
For configurations that use rook-ceph, the mon, mgr, and chassis placement labels are mandatory.

If Deployment Manager is configured without the labels ceph-mgr-placement: enabled, ceph-mon-placement: enabled, and the required chassis label (for example, topology.rook.io/chassis: "group-0") defined in the deployment-config.yaml of the Host Custom Resource, the system will complete initialization and reach an online state. However, the Deployment Manager will report INSYNC=false.

These labels are required to ensure proper placement of Ceph MON and MGR pods and to maintain alignment between the Deployment Manager and the underlying Rook-Ceph topology. Without them, the cluster may appear operational, but it will remain in a degraded synchronization state from the Deployment Manager perspective.