### PR TITLE
Move finalizer check inside Eventually block

### DIFF
--- a/internal/controller/addresspool_controller_test.go
+++ b/internal/controller/addresspool_controller_test.go
@@ -55,16 +55,15 @@ var _ = Describe("AddressPool controller", func() {
 				Spec: spec}
 			Expect(k8sClient.Create(ctx, created)).To(Succeed())
 
-			expected := created.DeepCopy()
-
 			fetched := &starlingxv1.AddressPool{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, key, fetched)
-				return err == nil &&
-					fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion
+				if err != nil {
+					return false
+				}
+				_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{AddressPoolFinalizerName})
+				return found
 			}, timeout, interval).Should(BeTrue())
-			_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{AddressPoolFinalizerName})
-			Expect(found).To(BeTrue())
 		})
 	})
 

--- a/internal/controller/datanetwork_controller_test.go
+++ b/internal/controller/datanetwork_controller_test.go
@@ -44,16 +44,15 @@ var _ = Describe("Datanetwork controller", func() {
 				}}
 			Expect(k8sClient.Create(ctx, created)).To(Succeed())
 
-			expected := created.DeepCopy()
-
 			fetched := &starlingxv1.DataNetwork{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, key, fetched)
-				return err == nil &&
-					fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion
+				if err != nil {
+					return false
+				}
+				_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{DataNetworkFinalizerName})
+				return found
 			}, timeout, interval).Should(BeTrue())
-			_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{DataNetworkFinalizerName})
-			Expect(found).To(BeTrue())
 		})
 	})
 })

--- a/internal/controller/host/host_controller_test.go
+++ b/internal/controller/host/host_controller_test.go
@@ -61,16 +61,15 @@ var _ = Describe("Host controller", func() {
 				}}
 			Expect(k8sClient.Create(ctx, created)).To(Succeed())
 
-			expected := created.DeepCopy()
-
 			fetched := &starlingxv1.Host{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, key, fetched)
-				return err == nil &&
-					fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion
+				if err != nil {
+					return false
+				}
+				_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{HostFinalizerName})
+				return found
 			}, timeout, interval).Should(BeTrue())
-			_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{HostFinalizerName})
-			Expect(found).To(BeTrue())
 		})
 	})
 

--- a/internal/controller/platformnetwork_controller_test.go
+++ b/internal/controller/platformnetwork_controller_test.go
@@ -39,16 +39,15 @@ var _ = Describe("Platformnetwork controller", func() {
 				}}
 			Expect(k8sClient.Create(ctx, created)).To(Succeed())
 
-			expected := created.DeepCopy()
-
 			fetched := &starlingxv1.PlatformNetwork{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, key, fetched)
-				return err == nil &&
-					fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion
+				if err != nil {
+					return false
+				}
+				_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PlatformNetworkFinalizerName})
+				return found
 			}, timeout, interval).Should(BeTrue())
-			_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PlatformNetworkFinalizerName})
-			Expect(found).To(BeTrue())
 		})
 	})
 

--- a/internal/controller/ptpinstance_controller_test.go
+++ b/internal/controller/ptpinstance_controller_test.go
@@ -41,16 +41,15 @@ var _ = Describe("PtpInstance controller", func() {
 					}}
 				Expect(k8sClient.Create(ctx, created)).To(Succeed())
 
-				expected := created.DeepCopy()
-
 				fetched := &starlingxv1.PtpInstance{}
 				Eventually(func() bool {
 					err := k8sClient.Get(ctx, key, fetched)
-					return err == nil &&
-						fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion
+					if err != nil {
+						return false
+					}
+					_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PtpInstanceFinalizerName})
+					return found
 				}, timeout, interval).Should(BeTrue())
-				_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PtpInstanceFinalizerName})
-				Expect(found).To(BeTrue())
 			})
 		})
 	})
@@ -82,16 +81,15 @@ var _ = Describe("PtpInstance controller", func() {
 				}
 				Expect(k8sClient.Create(ctx, created)).To(Succeed())
 
-				expected := created.DeepCopy()
-
 				fetched := &starlingxv1.PtpInstance{}
 				Eventually(func() bool {
 					err := k8sClient.Get(ctx, key, fetched)
-					return err == nil &&
-						fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion
+					if err != nil {
+						return false
+					}
+					_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PtpInstanceFinalizerName})
+					return found
 				}, timeout, interval).Should(BeTrue())
-				_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PtpInstanceFinalizerName})
-				Expect(found).To(BeTrue())
 			})
 		})
 	})

--- a/internal/controller/ptpinterface_controller_test.go
+++ b/internal/controller/ptpinterface_controller_test.go
@@ -40,16 +40,15 @@ var _ = Describe("PtpInterface controller", func() {
 				}}
 			Expect(k8sClient.Create(ctx, created)).To(Succeed())
 
-			expected := created.DeepCopy()
-
 			fetched := &starlingxv1.PtpInterface{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, key, fetched)
-				return err == nil &&
-					fetched.ObjectMeta.ResourceVersion != expected.ObjectMeta.ResourceVersion
+				if err != nil {
+					return false
+				}
+				_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PtpInterfaceFinalizerName})
+				return found
 			}, timeout, interval).Should(BeTrue())
-			_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PtpInterfaceFinalizerName})
-			Expect(found).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
The finalizer assertion was outside the Eventually block, which only waited for a ResourceVersion change. Since the reconciler updates annotations and status before adding the finalizer, the ResourceVersion changes early, causing the Eventually to exit before the finalizer is registered.

Move the finalizer check inside the Eventually block so it polls until the finalizer is actually present.

Test Plan:
- PASS: make test