### PR TITLE
ci: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
+    - uses: actions/checkout@v6
+    - uses: actions/setup-go@v6
       with:
         go-version: '1.23.5'
 
@@ -29,8 +29,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
+    - uses: actions/checkout@v6
+    - uses: actions/setup-go@v6
       with:
         # when the files to be extracted are already present,
         # tar extraction in Golangci Lint fails with the "File exists"
@@ -42,6 +42,6 @@ jobs:
         cache: false
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v4
+      uses: golangci/golangci-lint-action@v9
       with:
-        version: v1.64.8
+        version: v2.11.4

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
+    - uses: actions/checkout@v6
+    - uses: actions/setup-go@v6
       with:
         go-version: '1.23.0'
         cache: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,4 @@
-output:
-  verbose: true
-
-run:
-  timeout: 15m
+version: "2"
 
 linters:
   enable:


### PR DESCRIPTION
- actions/checkout v4 -> v6
- actions/setup-go v5 -> v6
- golangci/golangci-lint-action v4 -> v9

Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 2nd, 2026, with full removal on September 16th, 2026.