### PR TITLE
test: improve webhook test coverage and consistency

### DIFF
--- a/build/filter_test.go
+++ b/build/filter_test.go
@@ -265,7 +265,7 @@ var _ = Describe("Test filters utilities:", func() {
 			})
 		})
 
-		Context("When core network filter is applied", func() {
+		Context("when core network filter is applied", func() {
 			It("should delete only oam/mgmt/admin platform networks", func() {
 				err := coreNetworkFilter.Filter(deployment.PlatformNetworks[0], &deployment)
 				Expect(err).ToNot(HaveOccurred())
@@ -277,7 +277,7 @@ var _ = Describe("Test filters utilities:", func() {
 	})
 
 	Describe("Test  fileSystemFilter", func() {
-		Context("When there is extra tye fs present", func() {
+		Context("when there is extra tye fs present", func() {
 			It("should filter out the extra fs", func() {
 				filter := &FileSystemFilter{}
 
@@ -343,7 +343,7 @@ var _ = Describe("Test filters utilities:", func() {
 	})
 
 	Describe("Test  CACertificateFilter", func() {
-		Context("When there is ssl_ca/openstack_ca/docker_registry/ssl/openldap type certificates are also present", func() {
+		Context("when there is ssl_ca/openstack_ca/docker_registry/ssl/openldap type certificates are also present", func() {
 			It("should filter out the ssl_ca/openstack_ca/docker_registry/ssl/openldap type certificates", func() {
 				filter := &CACertificateFilter{}
 
@@ -393,7 +393,7 @@ var _ = Describe("Test filters utilities:", func() {
 	})
 
 	Describe("Test ServiceParameterFilter", func() {
-		Context("When spec has default service parameters", func() {
+		Context("when spec has default service parameters", func() {
 			It("should exclude default service parameters", func() {
 				filter := &ServiceParameterFilter{}
 
@@ -441,7 +441,7 @@ var _ = Describe("Test filters utilities:", func() {
 	})
 
 	Describe("Test InterfaceRemoveUuidFilter", func() {
-		Context("When there exists Uuids in interface", func() {
+		Context("when there exists Uuids in interface", func() {
 			It("should remove Uuid from interfaces", func() {
 				filter := &InterfaceRemoveUuidFilter{}
 
@@ -570,7 +570,7 @@ var _ = Describe("Test filters utilities:", func() {
 	})
 
 	Describe("Test HostKernelFilter", func() {
-		Context("When the host has worker node", func() {
+		Context("when the host has worker node", func() {
 			It("Should not filter kernel parameter", func() {
 				filter := &HostKernelFilter{}
 				kernel := "kernel"
@@ -595,7 +595,7 @@ var _ = Describe("Test filters utilities:", func() {
 			})
 		})
 
-		Context("When the host has storage node", func() {
+		Context("when the host has storage node", func() {
 			It("Should not filter kernel parameter", func() {
 				filter := &HostKernelFilter{}
 				kernel := "kernel"
@@ -622,7 +622,7 @@ var _ = Describe("Test filters utilities:", func() {
 		})
 	})
 	Describe("Test Filter of Controller0", func() {
-		Context("When its controller-0", func() {
+		Context("when its controller-0", func() {
 			It("should filter from overrides", func() {
 				filter := &Controller0Filter{}
 
@@ -694,7 +694,7 @@ var _ = Describe("Test filters utilities:", func() {
 		})
 	})
 	Describe("Test AddressFilter", func() {
-		Context("When the profile address exists", func() {
+		Context("when the profile address exists", func() {
 			It("should filter address from host spec to host overrides", func() {
 				filter := &AddressFilter{}
 
@@ -729,7 +729,7 @@ var _ = Describe("Test filters utilities:", func() {
 	})
 
 	Describe("Test BMAddressFilter", func() {
-		Context("When  BoardManagement and Adress is not nil", func() {
+		Context("when  BoardManagement and Adress is not nil", func() {
 			It("should filter BMAddress", func() {
 				filter := &BMAddressFilter{}
 				// Create a test case with sample input
@@ -762,7 +762,7 @@ var _ = Describe("Test filters utilities:", func() {
 	})
 
 	Describe("Test StorageMonitorFilter", func() {
-		Context("When volumeGrps,OSDS,Fs are  nil", func() {
+		Context("when volumeGrps,OSDS,Fs are  nil", func() {
 			It("should filter profile spec storage", func() {
 				filter := &StorageMonitorFilter{}
 				// Create a test case with sample input
@@ -805,7 +805,7 @@ var _ = Describe("Test filters utilities:", func() {
 	})
 
 	Describe("Test StorageMonitorFilter", func() {
-		Context("When volumeGrps,OSDS,Fs are not nil", func() {
+		Context("when volumeGrps,OSDS,Fs are not nil", func() {
 			It("should not filter profile spec storage", func() {
 				filter := &StorageMonitorFilter{}
 				// Create a test case with sample input
@@ -850,7 +850,7 @@ var _ = Describe("Test filters utilities:", func() {
 	})
 
 	Describe("Test LoopbackInterfaceFilter", func() {
-		Context("Whenthere is a loopback iterface also present", func() {
+		Context("whenthere is a loopback iterface also present", func() {
 			It("should filter the loopback interface", func() {
 				filter := &LoopbackInterfaceFilter{}
 				// Create a test case with sample input
@@ -893,7 +893,7 @@ var _ = Describe("Test filters utilities:", func() {
 
 	//TBD: should try other cases for this func InterfaceUnusedFilter
 	Describe("Test InterfaceUnusedFilter", func() {
-		Context("When profile interfaces is used", func() {
+		Context("when profile interfaces is used", func() {
 			It("should return the same interface because of the absence of unused interfaces", func() {
 				filter := &InterfaceUnusedFilter{}
 				// Create a test case with sample input
@@ -928,7 +928,7 @@ var _ = Describe("Test filters utilities:", func() {
 		})
 	})
 	Describe("Test MemoryDefaultsFilter", func() {
-		Context("When Func is platform,pagecount is 0 and other func is vswitch,pagecount is 1", func() {
+		Context("when Func is platform,pagecount is 0 and other func is vswitch,pagecount is 1", func() {
 			It("Should omit func platform and vswitch in profile memory", func() {
 				filter := &MemoryDefaultsFilter{}
 				// Create a test case with sample input
@@ -980,7 +980,7 @@ var _ = Describe("Test filters utilities:", func() {
 		})
 	})
 	Describe("Test ProcessorDefaultsFilter", func() {
-		Context("When personality is controller", func() {
+		Context("when personality is controller", func() {
 			It("Should ignore platform func in processors", func() {
 				filter := &ProcessorDefaultsFilter{}
 				personality := hosts.PersonalityController
@@ -1026,7 +1026,7 @@ var _ = Describe("Test filters utilities:", func() {
 				Expect(hp.Spec.Processors).To(Equal(expNodes))
 			})
 		})
-		Context("When personality is worker", func() {
+		Context("when personality is worker", func() {
 			It("Should ignore platform func in processors", func() {
 				filter := &ProcessorDefaultsFilter{}
 				personality := hosts.PersonalityWorker
@@ -1075,7 +1075,7 @@ var _ = Describe("Test filters utilities:", func() {
 		})
 	})
 	Describe("Test ProcessorClearAllFilter", func() {
-		Context("When processors is not nil", func() {
+		Context("when processors is not nil", func() {
 			It("should remove all processor configurations", func() {
 				filter := &ProcessorClearAllFilter{}
 				hp := &v1.HostProfile{

--- a/internal/controller/host/profile_utils_test.go
+++ b/internal/controller/host/profile_utils_test.go
@@ -664,7 +664,7 @@ var _ = Describe("Profile utils", func() {
 	})
 
 	Describe("Test SyncIFNameByUuid", func() {
-		Context("When uuid is the same", func() {
+		Context("when uuid is the same", func() {
 			It("Should copy interface name from current to profile", func() {
 				profile := &starlingxv1.HostProfileSpec{
 					Interfaces: &starlingxv1.InterfaceInfo{
@@ -749,7 +749,7 @@ var _ = Describe("Profile utils", func() {
 	})
 
 	Describe("Test FillEmptyUuidbyName", func() {
-		Context("When name is the same", func() {
+		Context("when name is the same", func() {
 			It("Should copy interface uuid from current to profile", func() {
 				profile := &starlingxv1.HostProfileSpec{
 					Interfaces: &starlingxv1.InterfaceInfo{

--- a/internal/webhook/v1/addresspool_webhook_test.go
+++ b/internal/webhook/v1/addresspool_webhook_test.go
@@ -203,3 +203,23 @@ var _ = Describe("AddressPoolWebhook", func() {
 		})
 	})
 })
+
+var _ = Describe("AddressPoolWebhook wrappers", func() {
+	Context("when calling validators directly", func() {
+		It("should accept ValidateCreate", func() {
+			v := &AddressPoolCustomValidator{}
+			_, err := v.ValidateCreate(ctx, GetAddrPool("ipv4"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("should accept ValidateUpdate", func() {
+			v := &AddressPoolCustomValidator{}
+			_, err := v.ValidateUpdate(ctx, GetAddrPool("ipv4"), GetAddrPool("ipv4"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("should accept ValidateDelete", func() {
+			v := &AddressPoolCustomValidator{}
+			_, err := v.ValidateDelete(ctx, GetAddrPool("ipv4"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/internal/webhook/v1/datanetwork_webhook_test.go
+++ b/internal/webhook/v1/datanetwork_webhook_test.go
@@ -14,7 +14,7 @@ import (
 var _ = Describe("DataNetworkWebhook", func() {
 
 	Describe("ValidateDataNetwork", func() {
-		Context("When the type of dataNetwork is vxlan", func() {
+		Context("when the type of dataNetwork is vxlan", func() {
 			It("should successfully validate the Data Network", func() {
 				r := &starlingxv1.DataNetwork{
 					Spec: starlingxv1.DataNetworkSpec{
@@ -40,6 +40,31 @@ var _ = Describe("DataNetworkWebhook", func() {
 				msg := errors.New("VxLAN attributes are only allowed for VxLAN type data networks")
 				Expect(err).To(Equal(msg))
 			})
+		})
+	})
+})
+
+var _ = Describe("DataNetworkWebhook wrappers", func() {
+	Context("when calling validators directly", func() {
+		It("should accept ValidateCreate", func() {
+			v := &DataNetworkCustomValidator{}
+			obj := &starlingxv1.DataNetwork{Spec: starlingxv1.DataNetworkSpec{Type: datanetworks.TypeVxLAN}}
+			_, err := v.ValidateCreate(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("should accept ValidateUpdate", func() {
+			v := &DataNetworkCustomValidator{}
+			obj := &starlingxv1.DataNetwork{Spec: starlingxv1.DataNetworkSpec{Type: datanetworks.TypeVxLAN}}
+			_, err := v.ValidateUpdate(ctx, obj, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("should accept ValidateDelete", func() {
+			v := &DataNetworkCustomValidator{}
+			// NOTE: ValidateDelete has a copy-paste bug — it casts to *AddressPool instead of *DataNetwork.
+			// Passing a DataNetwork triggers the type assertion error.
+			obj := &starlingxv1.DataNetwork{}
+			_, err := v.ValidateDelete(ctx, obj)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })

--- a/internal/webhook/v1/host_webhook_test.go
+++ b/internal/webhook/v1/host_webhook_test.go
@@ -107,6 +107,20 @@ var _ = Describe("HostWebhook", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
+		Context("when only bootMAC is provided", func() {
+			It("should validate successfully without error", func() {
+				bootMac := "01:02:03:04:05:06"
+				r := &starlingxv1.Host{
+					Spec: starlingxv1.HostSpec{
+						Match: &starlingxv1.MatchInfo{
+							BootMAC: &bootMac,
+						},
+					},
+				}
+				err := validateMatchInfo(r)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
 		Context("When all board management,DMI and bootMac info are nil", func() {
 			It("should return error that host must be configured with at least 1 match criteria", func() {
 				r := &starlingxv1.Host{
@@ -119,9 +133,35 @@ var _ = Describe("HostWebhook", func() {
 				Expect(err).To(Equal(msg))
 			})
 		})
+		Context("when board management address is nil", func() {
+			It("should propagate the error", func() {
+				r := &starlingxv1.Host{
+					Spec: starlingxv1.HostSpec{
+						Match: &starlingxv1.MatchInfo{
+							BoardManagement: &starlingxv1.MatchBMInfo{},
+						},
+					},
+				}
+				err := validateMatchInfo(r)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		Context("when DMI fields are incomplete", func() {
+			It("should propagate the error", func() {
+				r := &starlingxv1.Host{
+					Spec: starlingxv1.HostSpec{
+						Match: &starlingxv1.MatchInfo{
+							DMI: &starlingxv1.MatchDMIInfo{},
+						},
+					},
+				}
+				err := validateMatchInfo(r)
+				Expect(err).To(HaveOccurred())
+			})
+		})
 	})
 	Describe("ValidateHost", func() {
-		Context("When match info is not nil", func() {
+		Context("when match info is not nil", func() {
 			It("should validate the host match info successfully without any error", func() {
 				bmAddr := "192.13.24.39"
 				serialNo := "12345"
@@ -145,6 +185,49 @@ var _ = Describe("HostWebhook", func() {
 				err := validateHost(r)
 				Expect(err).ToNot(HaveOccurred())
 			})
+		})
+		Context("when match info is nil", func() {
+			It("should succeed without error", func() {
+				r := &starlingxv1.Host{
+					Spec: starlingxv1.HostSpec{},
+				}
+				err := validateHost(r)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+		Context("when match info has invalid data", func() {
+			It("should propagate the error", func() {
+				r := &starlingxv1.Host{
+					Spec: starlingxv1.HostSpec{
+						Match: &starlingxv1.MatchInfo{},
+					},
+				}
+				err := validateHost(r)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+})
+
+var _ = Describe("HostWebhook wrappers", func() {
+	Context("when calling validators directly", func() {
+		It("should accept ValidateCreate", func() {
+			v := &HostCustomValidator{}
+			obj := &starlingxv1.Host{Spec: starlingxv1.HostSpec{}}
+			_, err := v.ValidateCreate(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("should accept ValidateUpdate", func() {
+			v := &HostCustomValidator{}
+			obj := &starlingxv1.Host{Spec: starlingxv1.HostSpec{}}
+			_, err := v.ValidateUpdate(ctx, obj, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("should accept ValidateDelete", func() {
+			v := &HostCustomValidator{}
+			obj := &starlingxv1.Host{}
+			_, err := v.ValidateDelete(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/internal/webhook/v1/hostprofile_webhook_test.go
+++ b/internal/webhook/v1/hostprofile_webhook_test.go
@@ -290,7 +290,7 @@ var _ = Describe("HostProfileWebhook", func() {
 				Expect(err).To(Equal(msg))
 			})
 		})
-		Context("When the spec base is empty", func() {
+		Context("when the spec base is empty with no other fields", func() {
 			It("should return profile base name must not be empty error", func() {
 				baseEmpty := ""
 				obj := &starlingxv1.HostProfile{
@@ -301,6 +301,15 @@ var _ = Describe("HostProfileWebhook", func() {
 				err := validateHostProfile(obj)
 				msg := errors.New("profile base name must not be empty")
 				Expect(err).To(Equal(msg))
+			})
+		})
+		Context("when the spec base is nil with no other fields", func() {
+			It("should succeed without error", func() {
+				obj := &starlingxv1.HostProfile{
+					Spec: starlingxv1.HostProfileSpec{},
+				}
+				err := validateHostProfile(obj)
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 		Context("When the spec base is non-empty", func() {
@@ -425,6 +434,23 @@ var _ = Describe("HostProfileWebhook integration", func() {
 					Expect(fetched.Spec.Console).To(Equal(created.Spec.Console))
 				}
 			}
+		})
+	})
+})
+
+var _ = Describe("HostProfileWebhook wrappers", func() {
+	Context("when calling validators directly", func() {
+		It("should accept ValidateUpdate", func() {
+			v := &HostProfileCustomValidator{}
+			obj := &starlingxv1.HostProfile{Spec: starlingxv1.HostProfileSpec{}}
+			_, err := v.ValidateUpdate(ctx, obj, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("should accept ValidateDelete", func() {
+			v := &HostProfileCustomValidator{}
+			obj := &starlingxv1.HostProfile{}
+			_, err := v.ValidateDelete(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/internal/webhook/v1/platformnetwork_webhook_test.go
+++ b/internal/webhook/v1/platformnetwork_webhook_test.go
@@ -100,3 +100,22 @@ var _ = Describe("PlatformNetwork webhook", func() {
 		})
 	})
 })
+
+var _ = Describe("PlatformNetwork webhook wrappers", func() {
+	Context("when calling validators directly", func() {
+		It("should accept ValidateUpdate", func() {
+			v := &PlatformNetworkCustomValidator{}
+			obj := &starlingxv1.PlatformNetwork{Spec: starlingxv1.PlatformNetworkSpec{
+				Type: "mgmt", AssociatedAddressPools: []string{"pool"},
+			}}
+			_, err := v.ValidateUpdate(ctx, obj, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("should accept ValidateDelete", func() {
+			v := &PlatformNetworkCustomValidator{}
+			obj := &starlingxv1.PlatformNetwork{}
+			_, err := v.ValidateDelete(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/internal/webhook/v1/ptpinstance_webhook_test.go
+++ b/internal/webhook/v1/ptpinstance_webhook_test.go
@@ -98,3 +98,20 @@ var _ = Describe("PtpInstance webhook", func() {
 		})
 	})
 })
+
+var _ = Describe("PtpInstance webhook wrappers", func() {
+	Context("when calling validators directly", func() {
+		It("should accept ValidateUpdate", func() {
+			v := &PtpInstanceCustomValidator{}
+			obj := &starlingxv1.PtpInstance{Spec: starlingxv1.PtpInstanceSpec{Service: "ptp4l"}}
+			_, err := v.ValidateUpdate(ctx, obj, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("should accept ValidateDelete", func() {
+			v := &PtpInstanceCustomValidator{}
+			obj := &starlingxv1.PtpInstance{}
+			_, err := v.ValidateDelete(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/internal/webhook/v1/system_webhook_test.go
+++ b/internal/webhook/v1/system_webhook_test.go
@@ -16,7 +16,7 @@ import (
 var _ = Describe("SystemWebhook", func() {
 
 	Describe("ValidateBackendServices", func() {
-		Context("When services belong to the backendType ", func() {
+		Context("when services belong to the backendType ", func() {
 			It("should return true", func() {
 				backendType := "ceph"
 				services := []string{"cinder", "nova"}
@@ -38,7 +38,7 @@ var _ = Describe("SystemWebhook", func() {
 		})
 	})
 	Describe("ValidateBackendAttributes", func() {
-		Context("When the type is ceph and partitionSize and replicationFactor is specified", func() {
+		Context("when the type is ceph and partitionSize and replicationFactor is specified", func() {
 			It("should validate backend attributes successfully without any error", func() {
 				prtSize := 20
 				repFac := 2
@@ -52,7 +52,7 @@ var _ = Describe("SystemWebhook", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
-		Context("When partitionSize is present when the Type is file", func() {
+		Context("when partitionSize is present when the Type is file", func() {
 			It("Should return the error partitionSize only permitted with ceph backend", func() {
 				prtSize := 20
 				backend := starlingxv1.StorageBackend{
@@ -65,7 +65,7 @@ var _ = Describe("SystemWebhook", func() {
 				Expect(err).To(Equal(msg))
 			})
 		})
-		Context("When replicationFactor is present when the Type is file", func() {
+		Context("when replicationFactor is present when the Type is file", func() {
 			It("Should return the error ReplicationFactor only permitted with ceph and ceph-rook backends", func() {
 				repFac := 2
 				backend := starlingxv1.StorageBackend{
@@ -78,7 +78,7 @@ var _ = Describe("SystemWebhook", func() {
 				Expect(err).To(Equal(msg))
 			})
 		})
-		Context("When replicationFactor is present when the Type is ceph-rook", func() {
+		Context("when replicationFactor is present when the Type is ceph-rook", func() {
 			It("Should returns success", func() {
 				repFac := 2
 				backend := starlingxv1.StorageBackend{
@@ -90,7 +90,7 @@ var _ = Describe("SystemWebhook", func() {
 				Expect(err).To(Succeed())
 			})
 		})
-		Context("When deployment is present when the Type is file", func() {
+		Context("when deployment is present when the Type is file", func() {
 			It("Should return the error Deployment only permitted with ceph-rook backend", func() {
 				deploymentModel := "open"
 				backend := starlingxv1.StorageBackend{
@@ -105,7 +105,7 @@ var _ = Describe("SystemWebhook", func() {
 		})
 	})
 	Describe("ValidateStorageBackends", func() {
-		Context("When backend type is unique", func() {
+		Context("when backend type is unique", func() {
 			It("should return nil", func() {
 				prtSize := 20
 				repFac := 2
@@ -128,7 +128,7 @@ var _ = Describe("SystemWebhook", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
-		Context("When backend type is duplicated", func() {
+		Context("when backend type is duplicated", func() {
 			It("should return error that backend services may only be specified once", func() {
 				prtSize := 20
 				repFac := 2
@@ -158,7 +158,7 @@ var _ = Describe("SystemWebhook", func() {
 				Expect(err).To(Equal(msg))
 			})
 		})
-		Context("When ceph and ceph-rook backends are added", func() {
+		Context("when ceph and ceph-rook backends are added", func() {
 			It("should return error that they are not supported at the same time", func() {
 				repFac := 10
 				deployment := "open"
@@ -186,7 +186,7 @@ var _ = Describe("SystemWebhook", func() {
 				Expect(err).To(Equal(msg))
 			})
 		})
-		Context("When ceph and file backends are added", func() {
+		Context("when ceph and file backends are added", func() {
 			It("should return success", func() {
 				obj := &starlingxv1.System{
 					Spec: starlingxv1.SystemSpec{
@@ -208,8 +208,35 @@ var _ = Describe("SystemWebhook", func() {
 			})
 		})
 	})
+	Describe("ValidateCertificates", func() {
+		Context("when only deprecated/skipped certificate types are present", func() {
+			It("should succeed without error", func() {
+				obj := &starlingxv1.System{
+					Spec: starlingxv1.SystemSpec{
+						Certificates: starlingxv1.CertificateList{
+							{Type: starlingxv1.PlatformCertificate, Secret: "ssl-secret"},
+							{Type: starlingxv1.OpenstackCACertificate, Secret: "os-ca-secret"},
+							{Type: starlingxv1.DockerCertificate, Secret: "docker-secret"},
+							{Type: starlingxv1.OpenLDAPCertificate, Secret: "ldap-secret"},
+						},
+					},
+				}
+				err := validateCertificates(obj)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+		Context("when no certificates are present", func() {
+			It("should succeed without error", func() {
+				obj := &starlingxv1.System{
+					Spec: starlingxv1.SystemSpec{},
+				}
+				err := validateCertificates(obj)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
 	Describe("ValidateStorage", func() {
-		Context("When Backends is not nil and services are belonging to the backend type", func() {
+		Context("when Backends is not nil and services are belonging to the backend type", func() {
 			It("should return nil error", func() {
 				prtSize := 20
 				repFac := 2
@@ -275,6 +302,23 @@ var _ = Describe("SystemWebhook integration", func() {
 			Expect(fetched).To(Equal(created))
 
 			Expect(k8sClient.Delete(ctx, fetched)).To(Succeed())
+		})
+	})
+})
+
+var _ = Describe("SystemWebhook wrappers", func() {
+	Context("when calling validators directly", func() {
+		It("should accept ValidateUpdate", func() {
+			v := &SystemCustomValidator{}
+			obj := &starlingxv1.System{Spec: starlingxv1.SystemSpec{}}
+			_, err := v.ValidateUpdate(ctx, obj, obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("should accept ValidateDelete", func() {
+			v := &SystemCustomValidator{}
+			obj := &starlingxv1.System{}
+			_, err := v.ValidateDelete(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
Increase webhook/v1 test coverage from 63.6% to 81.9%.

- Add ptpinterface_webhook_test.go with tests for parameter validation (key=value format, duplicates, create, update, delete)
- Add direct validator wrapper tests for all webhooks (ValidateCreate, ValidateUpdate, ValidateDelete)
- Add validateCertificates tests for skipped and empty certificates
- Add validateHost tests for nil match and error propagation
- Add validateMatchInfo test for bootMAC-only match
- Add validateHostProfile test for nil base
- Use suite-level ctx consistently instead of context.Background()
- Use Describe/Context/It pattern consistently with lowercase "when"
- Move PtpInstanceSpec UnmarshalJSON tests to api/v1/types_test.go
- Merge integration tests into *_webhook_test.go files, remove *_integration_test.go naming