### PR TITLE
test: improve addresspool controller test coverage

### DIFF
--- a/internal/controller/addresspool_controller_test.go
+++ b/internal/controller/addresspool_controller_test.go
@@ -8,11 +8,34 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
-	comm "github.com/wind-river/cloud-platform-deployment-manager/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
+	comm "github.com/wind-river/cloud-platform-deployment-manager/common"
+	"github.com/wind-river/cloud-platform-deployment-manager/internal/controller/common"
+	cloudManager "github.com/wind-river/cloud-platform-deployment-manager/internal/controller/manager"
 )
+
+func newAddressPoolReconciler() *AddressPoolReconciler {
+	dm := &cloudManager.Dummymanager{}
+	logger := log.Log.WithName("test")
+	return &AddressPoolReconciler{
+		Client:       k8sClient,
+		CloudManager: dm,
+		ReconcilerErrorHandler: &common.ErrorHandler{
+			CloudManager: dm,
+			Logger:       logger,
+		},
+		ReconcilerEventLogger: &common.EventLogger{
+			EventRecorder: record.NewFakeRecorder(100),
+			Logger:        logger,
+		},
+	}
+}
 
 var _ = Describe("AddressPool controller", func() {
 	const (
@@ -67,4 +90,188 @@ var _ = Describe("AddressPool controller", func() {
 		})
 	})
 
+	Describe("statusUpdateRequired", func() {
+		var reconciler *AddressPoolReconciler
+
+		BeforeEach(func() {
+			reconciler = newAddressPoolReconciler()
+		})
+
+		Context("when status has not changed", func() {
+			It("should return false", func() {
+				instance := &starlingxv1.AddressPool{}
+				old := instance.Status.DeepCopy()
+				Expect(reconciler.statusUpdateRequired(instance, old)).To(BeFalse())
+			})
+		})
+
+		Context("when InSync changes", func() {
+			It("should return true", func() {
+				instance := &starlingxv1.AddressPool{}
+				old := instance.Status.DeepCopy()
+				instance.Status.InSync = true
+				Expect(reconciler.statusUpdateRequired(instance, old)).To(BeTrue())
+			})
+		})
+
+		Context("when Reconciled changes", func() {
+			It("should return true", func() {
+				instance := &starlingxv1.AddressPool{}
+				old := instance.Status.DeepCopy()
+				instance.Status.Reconciled = true
+				Expect(reconciler.statusUpdateRequired(instance, old)).To(BeTrue())
+			})
+		})
+
+		Context("when ID changes", func() {
+			It("should return true", func() {
+				id := "some-uuid"
+				instance := &starlingxv1.AddressPool{}
+				old := instance.Status.DeepCopy()
+				instance.Status.ID = &id
+				Expect(reconciler.statusUpdateRequired(instance, old)).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("UpdateInsyncStatus", func() {
+		var reconciler *AddressPoolReconciler
+
+		BeforeEach(func() {
+			reconciler = newAddressPoolReconciler()
+		})
+
+		Context("when status changed", func() {
+			It("should update the resource status", func() {
+				floating := "10.10.10.12"
+				instance := &starlingxv1.AddressPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ap-insync-changed",
+						Namespace: "default",
+					},
+					Spec: starlingxv1.AddressPoolSpec{
+						Subnet:          "10.10.10.0",
+						Prefix:          24,
+						FloatingAddress: &floating,
+					},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+				Eventually(func() bool {
+					_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+					return len(instance.Finalizers) > 0
+				}, timeout, interval).Should(BeTrue())
+
+				old := instance.Status.DeepCopy()
+				instance.Status.InSync = true
+				err := reconciler.UpdateInsyncStatus(nil, instance, old)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when status has not changed", func() {
+			It("should not update", func() {
+				floating := "10.10.10.13"
+				instance := &starlingxv1.AddressPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ap-insync-same",
+						Namespace: "default",
+					},
+					Spec: starlingxv1.AddressPoolSpec{
+						Subnet:          "10.10.10.0",
+						Prefix:          24,
+						FloatingAddress: &floating,
+					},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+				old := instance.Status.DeepCopy()
+				err := reconciler.UpdateInsyncStatus(nil, instance, old)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("ReconcileResource", func() {
+		Context("when the resource is being deleted", func() {
+			It("should remove the finalizer", func() {
+				floating := "10.10.10.14"
+				instance := &starlingxv1.AddressPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "ap-delete",
+						Namespace:  "default",
+						Finalizers: []string{AddressPoolFinalizerName},
+					},
+					Spec: starlingxv1.AddressPoolSpec{
+						Subnet:          "10.10.10.0",
+						Prefix:          24,
+						FloatingAddress: &floating,
+					},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+				Expect(k8sClient.Delete(ctx, instance)).To(Succeed())
+
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+					return err == nil && !instance.DeletionTimestamp.IsZero()
+				}, timeout, interval).Should(BeTrue())
+
+				reconciler := newAddressPoolReconciler()
+				err := reconciler.ReconcileResource(nil, instance, "default")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(instance.Finalizers).ToNot(ContainElement(AddressPoolFinalizerName))
+			})
+		})
+
+		Context("when the resource is created and generation changed", func() {
+			It("should notify the active host and update observed generation", func() {
+				floating := "10.10.10.15"
+				instance := &starlingxv1.AddressPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ap-notify",
+						Namespace: "default",
+					},
+					Spec: starlingxv1.AddressPoolSpec{
+						Subnet:          "10.10.10.0",
+						Prefix:          24,
+						FloatingAddress: &floating,
+					},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+				Eventually(func() bool {
+					_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+					return len(instance.Finalizers) > 0
+				}, timeout, interval).Should(BeTrue())
+
+				activeHost := &starlingxv1.Host{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "controller-0-ap",
+						Namespace: "default",
+					},
+				}
+				Expect(k8sClient.Create(ctx, activeHost)).To(Succeed())
+
+				dm := &cloudManager.Dummymanager{ActiveHost: activeHost}
+				logger := log.Log.WithName("test")
+				reconciler := &AddressPoolReconciler{
+					Client:       k8sClient,
+					CloudManager: dm,
+					ReconcilerErrorHandler: &common.ErrorHandler{
+						CloudManager: dm,
+						Logger:       logger,
+					},
+					ReconcilerEventLogger: &common.EventLogger{
+						EventRecorder: record.NewFakeRecorder(100),
+						Logger:        logger,
+					},
+				}
+
+				err := reconciler.ReconcileResource(nil, instance, "default")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(instance.Status.ObservedGeneration).To(Equal(instance.Generation))
+			})
+		})
+	})
 })

--- a/internal/controller/manager/dummy_manager.go
+++ b/internal/controller/manager/dummy_manager.go
@@ -38,6 +38,7 @@ type Dummymanager struct {
 	defaultUpdated     bool          // Simulate default update status
 	DefaultUpdateError error         // Simulate error for default update method
 	Client             client.Client // Added client field for the Kubernetes client
+	ActiveHost         *starlingxv1.Host
 }
 
 func (m *Dummymanager) ResetPlatformClient(namespace string) error {
@@ -156,6 +157,9 @@ func (m *Dummymanager) GetStrategyExpectedByOtherReconcilers() bool {
 	return false
 }
 func (m *Dummymanager) GetHostByPersonality(namespace string, client *gophercloud.ServiceClient, personality string) (*starlingxv1.Host, *hosts.Host, error) {
+	if m.ActiveHost != nil {
+		return m.ActiveHost, nil, nil
+	}
 	return nil, nil, nil
 }
 func (m *Dummymanager) GcShow(c *gophercloud.ServiceClient) (*systemconfigupdate.SystemConfigUpdate, error) {


### PR DESCRIPTION
Add tests for statusUpdateRequired, UpdateInsyncStatus, and ReconcileResource in addresspool_controller_test.go.

- statusUpdateRequired: no-change, InSync, Reconciled, ID -> 100%
- UpdateInsyncStatus: status changed, status unchanged -> 71.4%
- ReconcileResource: deletion path (finalizer removal), creation path (notify active host and update observed generation) -> 48.3%

Extend Dummymanager with ActiveHost field to support GetHostByPersonality in tests without gophercloud fixtures.