### PR TITLE
test: improve controller test coverage with fixtures

### DIFF
--- a/internal/controller/datanetwork_controller_test.go
+++ b/internal/controller/datanetwork_controller_test.go
@@ -4,19 +4,111 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"time"
 
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/datanetworks"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
 	comm "github.com/wind-river/cloud-platform-deployment-manager/common"
+	"github.com/wind-river/cloud-platform-deployment-manager/internal/controller/common"
+	cloudManager "github.com/wind-river/cloud-platform-deployment-manager/internal/controller/manager"
 )
 
-var _ = Describe("Datanetwork controller", func() {
+const dataNetworkResponse = `{
+	"uuid": "test-dn-uuid",
+	"name": "group0-data0",
+	"description": "",
+	"network_type": "flat",
+	"mtu": 1500
+}`
 
+const dataNetworkListResponse = `{
+	"datanetworks": [` + dataNetworkResponse + `]
+}`
+
+func newDataNetworkFixtureServer() (*httptest.Server, *gophercloud.ServiceClient) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/datanetworks", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = fmt.Fprint(w, dataNetworkListResponse)
+		case http.MethodPost:
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			name, _ := body["name"].(string)
+			ntype, _ := body["network_type"].(string)
+			resp := fmt.Sprintf(`{"uuid":"new-dn-uuid","name":"%s","network_type":"%s","mtu":1500,"description":""}`, name, ntype)
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, resp)
+		}
+	})
+	mux.HandleFunc("/datanetworks/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = fmt.Fprint(w, dataNetworkResponse)
+		case http.MethodPatch:
+			_, _ = fmt.Fprint(w, dataNetworkResponse)
+		case http.MethodDelete:
+			id := strings.TrimPrefix(r.URL.Path, "/datanetworks/")
+			if id == "fail-delete" {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = fmt.Fprint(w, `{"error": "internal error"}`)
+			} else {
+				w.WriteHeader(http.StatusNoContent)
+			}
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	sc := &gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{TokenID: "test-token"},
+		Endpoint:       server.URL + "/",
+	}
+	return server, sc
+}
+
+func newDataNetworkReconciler() *DataNetworkReconciler {
+	dm := &cloudManager.Dummymanager{}
+	logger := log.Log.WithName("test")
+	return &DataNetworkReconciler{
+		Client:       k8sClient,
+		CloudManager: dm,
+		ReconcilerErrorHandler: &common.ErrorHandler{
+			CloudManager: dm,
+			Logger:       logger,
+		},
+		ReconcilerEventLogger: &common.EventLogger{
+			EventRecorder: record.NewFakeRecorder(100),
+			Logger:        logger,
+		},
+	}
+}
+
+func newGopherDataNetwork(name, ntype string) *datanetworks.DataNetwork {
+	return &datanetworks.DataNetwork{
+		ID:   "test-dn-uuid",
+		Name: name,
+		Type: ntype,
+		MTU:  1500,
+	}
+}
+
+var _ = Describe("Datanetwork controller", func() {
 	const (
 		timeout  = time.Second * 30
 		interval = time.Millisecond * 500
@@ -53,6 +145,290 @@ var _ = Describe("Datanetwork controller", func() {
 				_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{DataNetworkFinalizerName})
 				return found
 			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Describe("FindExistingResource", func() {
+		var (
+			server     *httptest.Server
+			gcClient   *gophercloud.ServiceClient
+			reconciler *DataNetworkReconciler
+		)
+
+		BeforeEach(func() {
+			server, gcClient = newDataNetworkFixtureServer()
+			reconciler = newDataNetworkReconciler()
+		})
+
+		AfterEach(func() {
+			server.Close()
+		})
+
+		Context("when the resource has a status ID", func() {
+			It("should fetch by ID", func() {
+				id := "test-dn-uuid"
+				instance := &starlingxv1.DataNetwork{
+					ObjectMeta: metav1.ObjectMeta{Name: "group0-data0", Namespace: "default"},
+					Spec:       starlingxv1.DataNetworkSpec{Type: "flat"},
+				}
+				instance.Status.ID = &id
+				network, err := reconciler.FindExistingResource(gcClient, instance)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(network).ToNot(BeNil())
+				Expect(network.ID).To(Equal("test-dn-uuid"))
+			})
+		})
+
+		Context("when the resource has no status ID", func() {
+			It("should find by name and type from list", func() {
+				instance := &starlingxv1.DataNetwork{
+					ObjectMeta: metav1.ObjectMeta{Name: "group0-data0", Namespace: "default"},
+					Spec:       starlingxv1.DataNetworkSpec{Type: "flat"},
+				}
+				network, err := reconciler.FindExistingResource(gcClient, instance)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(network).ToNot(BeNil())
+				Expect(network.Name).To(Equal("group0-data0"))
+			})
+		})
+
+		Context("when the resource does not exist in the list", func() {
+			It("should return nil", func() {
+				instance := &starlingxv1.DataNetwork{
+					ObjectMeta: metav1.ObjectMeta{Name: "nonexistent", Namespace: "default"},
+					Spec:       starlingxv1.DataNetworkSpec{Type: "flat"},
+				}
+				network, err := reconciler.FindExistingResource(gcClient, instance)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(network).To(BeNil())
+			})
+		})
+	})
+
+	Describe("ReconcileNew", func() {
+		var (
+			server     *httptest.Server
+			gcClient   *gophercloud.ServiceClient
+			reconciler *DataNetworkReconciler
+		)
+
+		BeforeEach(func() {
+			server, gcClient = newDataNetworkFixtureServer()
+			reconciler = newDataNetworkReconciler()
+		})
+
+		AfterEach(func() {
+			server.Close()
+		})
+
+		Context("when creating a flat data network", func() {
+			It("should succeed", func() {
+				instance := &starlingxv1.DataNetwork{
+					ObjectMeta: metav1.ObjectMeta{Name: "dn-new-flat", Namespace: "default"},
+					Spec:       starlingxv1.DataNetworkSpec{Type: "flat"},
+				}
+				network, err := reconciler.ReconcileNew(gcClient, instance)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(network).ToNot(BeNil())
+				Expect(network.ID).To(Equal("new-dn-uuid"))
+			})
+		})
+
+		Context("when already reconciled and StopAfterInSync", func() {
+			It("should return ChangeAfterInSync error", func() {
+				instance := &starlingxv1.DataNetwork{
+					ObjectMeta: metav1.ObjectMeta{Name: "dn-new-stop", Namespace: "default"},
+					Spec:       starlingxv1.DataNetworkSpec{Type: "flat"},
+				}
+				instance.Status.Reconciled = true
+
+				_, err := reconciler.ReconcileNew(gcClient, instance)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("provisioning ignored"))
+			})
+		})
+	})
+
+	Describe("ReconcileUpdated", func() {
+		var (
+			server     *httptest.Server
+			gcClient   *gophercloud.ServiceClient
+			reconciler *DataNetworkReconciler
+		)
+
+		BeforeEach(func() {
+			server, gcClient = newDataNetworkFixtureServer()
+			reconciler = newDataNetworkReconciler()
+		})
+
+		AfterEach(func() {
+			server.Close()
+		})
+
+		Context("when no update is required", func() {
+			It("should return nil", func() {
+				instance := &starlingxv1.DataNetwork{
+					ObjectMeta: metav1.ObjectMeta{Name: "dn-update-noop", Namespace: "default"},
+					Spec:       starlingxv1.DataNetworkSpec{Type: "flat"},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+				Eventually(func() bool {
+					_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+					return len(instance.Finalizers) > 0
+				}, timeout, interval).Should(BeTrue())
+
+				current := &starlingxv1.DataNetwork{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), current)).To(Succeed())
+
+				network := newGopherDataNetwork("dn-update-noop", "flat")
+				err := reconciler.ReconcileUpdated(gcClient, current, network)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("ReconciledDeleted", func() {
+		var (
+			server     *httptest.Server
+			gcClient   *gophercloud.ServiceClient
+			reconciler *DataNetworkReconciler
+		)
+
+		BeforeEach(func() {
+			server, gcClient = newDataNetworkFixtureServer()
+			reconciler = newDataNetworkReconciler()
+		})
+
+		AfterEach(func() {
+			server.Close()
+		})
+
+		Context("when the resource has a finalizer and network exists", func() {
+			It("should delete the network and remove the finalizer", func() {
+				instance := &starlingxv1.DataNetwork{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "dn-delete",
+						Namespace:  "default",
+						Finalizers: []string{DataNetworkFinalizerName},
+					},
+					Spec: starlingxv1.DataNetworkSpec{Type: "flat"},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, instance)).To(Succeed())
+
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+					return err == nil && !instance.DeletionTimestamp.IsZero()
+				}, timeout, interval).Should(BeTrue())
+
+				network := newGopherDataNetwork("dn-delete", "flat")
+				err := reconciler.ReconciledDeleted(gcClient, instance, network)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(instance.Finalizers).ToNot(ContainElement(DataNetworkFinalizerName))
+			})
+		})
+
+		Context("when the network is nil", func() {
+			It("should just remove the finalizer", func() {
+				instance := &starlingxv1.DataNetwork{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "dn-delete-nil",
+						Namespace:  "default",
+						Finalizers: []string{DataNetworkFinalizerName},
+					},
+					Spec: starlingxv1.DataNetworkSpec{Type: "flat"},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, instance)).To(Succeed())
+
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+					return err == nil && !instance.DeletionTimestamp.IsZero()
+				}, timeout, interval).Should(BeTrue())
+
+				err := reconciler.ReconciledDeleted(gcClient, instance, nil)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(instance.Finalizers).ToNot(ContainElement(DataNetworkFinalizerName))
+			})
+		})
+	})
+
+	Describe("ReconcileResource", func() {
+		var (
+			server     *httptest.Server
+			gcClient   *gophercloud.ServiceClient
+			reconciler *DataNetworkReconciler
+		)
+
+		BeforeEach(func() {
+			server, gcClient = newDataNetworkFixtureServer()
+			reconciler = newDataNetworkReconciler()
+		})
+
+		AfterEach(func() {
+			server.Close()
+		})
+
+		Context("when the resource exists on the system", func() {
+			It("should reconcile successfully", func() {
+				instance := &starlingxv1.DataNetwork{
+					ObjectMeta: metav1.ObjectMeta{Name: "dn-reconcile-exist", Namespace: "default"},
+					Spec:       starlingxv1.DataNetworkSpec{Type: "flat"},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+				Eventually(func() bool {
+					_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+					return len(instance.Finalizers) > 0
+				}, timeout, interval).Should(BeTrue())
+
+				// FindExistingResource will list and not find "dn-reconcile-exist"
+				// in the fixture, so it will call ReconcileNew instead.
+				// To test the "exists" path, set a status ID so it fetches by UUID.
+				id := "test-dn-uuid"
+				instance.Status.ID = &id
+				err := reconciler.ReconcileResource(gcClient, instance)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when the resource does not exist on the system", func() {
+			It("should create a new data network", func() {
+				instance := &starlingxv1.DataNetwork{
+					ObjectMeta: metav1.ObjectMeta{Name: "dn-reconcile-new", Namespace: "default"},
+					Spec:       starlingxv1.DataNetworkSpec{Type: "flat"},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+				Eventually(func() bool {
+					_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+					return len(instance.Finalizers) > 0
+				}, timeout, interval).Should(BeTrue())
+
+				err := reconciler.ReconcileResource(gcClient, instance)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("removeDataNetworkFinalizer", func() {
+		Context("when the resource has a finalizer", func() {
+			It("should remove it", func() {
+				instance := &starlingxv1.DataNetwork{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "dn-rm-finalizer",
+						Namespace:  "default",
+						Finalizers: []string{DataNetworkFinalizerName},
+					},
+					Spec: starlingxv1.DataNetworkSpec{Type: "flat"},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+				reconciler := newDataNetworkReconciler()
+				reconciler.removeDataNetworkFinalizer(instance)
+				Expect(instance.Finalizers).ToNot(ContainElement(DataNetworkFinalizerName))
+			})
 		})
 	})
 })

--- a/internal/controller/manager/dummy_manager.go
+++ b/internal/controller/manager/dummy_manager.go
@@ -38,6 +38,7 @@ type Dummymanager struct {
 	defaultUpdated     bool          // Simulate default update status
 	DefaultUpdateError error         // Simulate error for default update method
 	Client             client.Client // Added client field for the Kubernetes client
+	ActiveHost         *starlingxv1.Host
 }
 
 func (m *Dummymanager) ResetPlatformClient(namespace string) error {
@@ -156,6 +157,9 @@ func (m *Dummymanager) GetStrategyExpectedByOtherReconcilers() bool {
 	return false
 }
 func (m *Dummymanager) GetHostByPersonality(namespace string, client *gophercloud.ServiceClient, personality string) (*starlingxv1.Host, *hosts.Host, error) {
+	if m.ActiveHost != nil {
+		return m.ActiveHost, nil, nil
+	}
 	return nil, nil, nil
 }
 func (m *Dummymanager) GcShow(c *gophercloud.ServiceClient) (*systemconfigupdate.SystemConfigUpdate, error) {

--- a/internal/controller/platformnetwork_controller_test.go
+++ b/internal/controller/platformnetwork_controller_test.go
@@ -8,11 +8,33 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
-	comm "github.com/wind-river/cloud-platform-deployment-manager/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
+	comm "github.com/wind-river/cloud-platform-deployment-manager/common"
+	"github.com/wind-river/cloud-platform-deployment-manager/internal/controller/common"
+	cloudManager "github.com/wind-river/cloud-platform-deployment-manager/internal/controller/manager"
 )
+
+func newPlatformNetworkReconciler(dm *cloudManager.Dummymanager) *PlatformNetworkReconciler {
+	logger := log.Log.WithName("test")
+	return &PlatformNetworkReconciler{
+		Client:       k8sClient,
+		CloudManager: dm,
+		ReconcilerErrorHandler: &common.ErrorHandler{
+			CloudManager: dm,
+			Logger:       logger,
+		},
+		ReconcilerEventLogger: &common.EventLogger{
+			EventRecorder: record.NewFakeRecorder(100),
+			Logger:        logger,
+		},
+	}
+}
 
 var _ = Describe("Platformnetwork controller", func() {
 	const (
@@ -51,4 +73,128 @@ var _ = Describe("Platformnetwork controller", func() {
 		})
 	})
 
+	Describe("statusUpdateRequired", func() {
+		It("should return false when status has not changed", func() {
+			dm := &cloudManager.Dummymanager{}
+			reconciler := newPlatformNetworkReconciler(dm)
+			instance := &starlingxv1.PlatformNetwork{}
+			old := instance.Status.DeepCopy()
+			Expect(reconciler.statusUpdateRequired(instance, old)).To(BeFalse())
+		})
+
+		It("should return true when InSync changes", func() {
+			dm := &cloudManager.Dummymanager{}
+			reconciler := newPlatformNetworkReconciler(dm)
+			instance := &starlingxv1.PlatformNetwork{}
+			old := instance.Status.DeepCopy()
+			instance.Status.InSync = true
+			Expect(reconciler.statusUpdateRequired(instance, old)).To(BeTrue())
+		})
+	})
+
+	Describe("UpdateInsyncStatus", func() {
+		It("should update when status changed", func() {
+			dm := &cloudManager.Dummymanager{}
+			reconciler := newPlatformNetworkReconciler(dm)
+			instance := &starlingxv1.PlatformNetwork{
+				ObjectMeta: metav1.ObjectMeta{Name: "pn-insync", Namespace: "default"},
+				Spec: starlingxv1.PlatformNetworkSpec{
+					Type:                   "mgmt",
+					Dynamic:                true,
+					AssociatedAddressPools: []string{"management-ipv4"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+			Eventually(func() bool {
+				_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+				return len(instance.Finalizers) > 0
+			}, timeout, interval).Should(BeTrue())
+
+			old := instance.Status.DeepCopy()
+			instance.Status.InSync = true
+			err := reconciler.UpdateInsyncStatus(nil, instance, old)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should not update when status unchanged", func() {
+			dm := &cloudManager.Dummymanager{}
+			reconciler := newPlatformNetworkReconciler(dm)
+			instance := &starlingxv1.PlatformNetwork{
+				ObjectMeta: metav1.ObjectMeta{Name: "pn-insync-noop", Namespace: "default"},
+				Spec: starlingxv1.PlatformNetworkSpec{
+					Type:                   "mgmt",
+					Dynamic:                true,
+					AssociatedAddressPools: []string{"management-ipv4"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+			old := instance.Status.DeepCopy()
+			err := reconciler.UpdateInsyncStatus(nil, instance, old)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("ReconcileResource", func() {
+		Context("when the resource is being deleted", func() {
+			It("should remove the finalizer", func() {
+				dm := &cloudManager.Dummymanager{}
+				reconciler := newPlatformNetworkReconciler(dm)
+				instance := &starlingxv1.PlatformNetwork{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "pn-delete",
+						Namespace:  "default",
+						Finalizers: []string{PlatformNetworkFinalizerName},
+					},
+					Spec: starlingxv1.PlatformNetworkSpec{
+						Type:                   "mgmt",
+						Dynamic:                true,
+						AssociatedAddressPools: []string{"management-ipv4"},
+					},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, instance)).To(Succeed())
+
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+					return err == nil && !instance.DeletionTimestamp.IsZero()
+				}, timeout, interval).Should(BeTrue())
+
+				err := reconciler.ReconcileResource(nil, instance, "default", false)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(instance.Finalizers).ToNot(ContainElement(PlatformNetworkFinalizerName))
+			})
+		})
+
+		Context("when the resource generation changed", func() {
+			It("should notify the active host", func() {
+				activeHost := &starlingxv1.Host{
+					ObjectMeta: metav1.ObjectMeta{Name: "controller-0-pn", Namespace: "default"},
+				}
+				Expect(k8sClient.Create(ctx, activeHost)).To(Succeed())
+
+				dm := &cloudManager.Dummymanager{ActiveHost: activeHost}
+				reconciler := newPlatformNetworkReconciler(dm)
+				instance := &starlingxv1.PlatformNetwork{
+					ObjectMeta: metav1.ObjectMeta{Name: "pn-notify", Namespace: "default"},
+					Spec: starlingxv1.PlatformNetworkSpec{
+						Type:                   "oam",
+						Dynamic:                false,
+						AssociatedAddressPools: []string{"oam-ipv4"},
+					},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+				Eventually(func() bool {
+					_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+					return len(instance.Finalizers) > 0
+				}, timeout, interval).Should(BeTrue())
+
+				err := reconciler.ReconcileResource(nil, instance, "default", false)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(instance.Status.ObservedGeneration).To(Equal(instance.Generation))
+			})
+		})
+	})
 })

--- a/internal/controller/ptpinstance_controller_test.go
+++ b/internal/controller/ptpinstance_controller_test.go
@@ -4,19 +4,95 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"time"
 
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/ptpinstances"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
 	comm "github.com/wind-river/cloud-platform-deployment-manager/common"
+	"github.com/wind-river/cloud-platform-deployment-manager/internal/controller/common"
+	cloudManager "github.com/wind-river/cloud-platform-deployment-manager/internal/controller/manager"
 )
 
-var _ = Describe("PtpInstance controller", func() {
+const ptpInstanceResponse = `{
+	"uuid": "test-ptp-uuid",
+	"id": 1,
+	"name": "ptp4l-instance-0",
+	"service": "ptp4l",
+	"parameters": {}
+}`
 
+const ptpInstanceListResponse = `{
+	"ptp_instances": [` + ptpInstanceResponse + `]
+}`
+
+func newPtpInstanceFixtureServer() (*httptest.Server, *gophercloud.ServiceClient) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ptp_instances", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = fmt.Fprint(w, ptpInstanceListResponse)
+		case http.MethodPost:
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			name, _ := body["name"].(string)
+			svc, _ := body["service"].(string)
+			resp := fmt.Sprintf(`{"uuid":"new-ptp-uuid","id":2,"name":"%s","service":"%s","parameters":{}}`, name, svc)
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, resp)
+		}
+	})
+	mux.HandleFunc("/ptp_instances/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = fmt.Fprint(w, ptpInstanceResponse)
+		case http.MethodPatch:
+			_, _ = fmt.Fprint(w, ptpInstanceResponse)
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	sc := &gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{TokenID: "test-token"},
+		Endpoint:       server.URL + "/",
+	}
+	return server, sc
+}
+
+func newPtpInstanceReconciler() *PtpInstanceReconciler {
+	dm := &cloudManager.Dummymanager{}
+	logger := log.Log.WithName("test")
+	return &PtpInstanceReconciler{
+		Client:       k8sClient,
+		CloudManager: dm,
+		ReconcilerErrorHandler: &common.ErrorHandler{
+			CloudManager: dm,
+			Logger:       logger,
+		},
+		ReconcilerEventLogger: &common.EventLogger{
+			EventRecorder: record.NewFakeRecorder(100),
+			Logger:        logger,
+		},
+	}
+}
+
+var _ = Describe("PtpInstance controller", func() {
 	const (
 		timeout  = time.Second * 30
 		interval = time.Millisecond * 500
@@ -37,7 +113,7 @@ var _ = Describe("PtpInstance controller", func() {
 					},
 					Spec: starlingxv1.PtpInstanceSpec{
 						Service:            "ptp4l",
-						InstanceParameters: map[string][]string{"global": []string{"domainNumber=24", "clientOnly=0"}},
+						InstanceParameters: map[string][]string{"global": {"domainNumber=24", "clientOnly=0"}},
 					}}
 				Expect(k8sClient.Create(ctx, created)).To(Succeed())
 
@@ -53,6 +129,7 @@ var _ = Describe("PtpInstance controller", func() {
 			})
 		})
 	})
+
 	Describe("Create PtpInstance", func() {
 		Context("with multiple section data", func() {
 			It("should create successfully", func() {
@@ -69,8 +146,8 @@ var _ = Describe("PtpInstance controller", func() {
 					Spec: starlingxv1.PtpInstanceSpec{
 						Service: "ptp4l",
 						InstanceParameters: map[string][]string{
-							"global": []string{"domainNumber=24", "clientOnly=0"},
-							"unicast_master_table_1": []string{
+							"global": {"domainNumber=24", "clientOnly=0"},
+							"unicast_master_table_1": {
 								"table_id=1",
 								"UDPv4=1.2.3.4", "UDPv4=2.3.4.5",
 								"L2=00:01:FF:00:01:CD", "L2=00:02:FF:00:01:CD",
@@ -90,6 +167,212 @@ var _ = Describe("PtpInstance controller", func() {
 					_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PtpInstanceFinalizerName})
 					return found
 				}, timeout, interval).Should(BeTrue())
+			})
+		})
+	})
+
+	Describe("FindExistingPTPInstance", func() {
+		var (
+			server     *httptest.Server
+			gcClient   *gophercloud.ServiceClient
+			reconciler *PtpInstanceReconciler
+		)
+
+		BeforeEach(func() {
+			server, gcClient = newPtpInstanceFixtureServer()
+			reconciler = newPtpInstanceReconciler()
+		})
+		AfterEach(func() { server.Close() })
+
+		Context("when the resource has a status ID", func() {
+			It("should fetch by UUID", func() {
+				id := "test-ptp-uuid"
+				instance := &starlingxv1.PtpInstance{
+					ObjectMeta: metav1.ObjectMeta{Name: "ptp4l-instance-0", Namespace: "default"},
+					Spec:       starlingxv1.PtpInstanceSpec{Service: "ptp4l"},
+				}
+				instance.Status.ID = &id
+				found, err := reconciler.FindExistingPTPInstance(gcClient, instance)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).ToNot(BeNil())
+				Expect(found.UUID).To(Equal("test-ptp-uuid"))
+			})
+		})
+
+		Context("when the resource has no status ID", func() {
+			It("should find by name from list", func() {
+				instance := &starlingxv1.PtpInstance{
+					ObjectMeta: metav1.ObjectMeta{Name: "ptp4l-instance-0", Namespace: "default"},
+					Spec:       starlingxv1.PtpInstanceSpec{Service: "ptp4l"},
+				}
+				found, err := reconciler.FindExistingPTPInstance(gcClient, instance)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).ToNot(BeNil())
+			})
+		})
+
+		Context("when the resource does not exist", func() {
+			It("should return nil", func() {
+				instance := &starlingxv1.PtpInstance{
+					ObjectMeta: metav1.ObjectMeta{Name: "nonexistent", Namespace: "default"},
+					Spec:       starlingxv1.PtpInstanceSpec{Service: "ptp4l"},
+				}
+				found, err := reconciler.FindExistingPTPInstance(gcClient, instance)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeNil())
+			})
+		})
+	})
+
+	Describe("ReconcileNew", func() {
+		var (
+			server     *httptest.Server
+			gcClient   *gophercloud.ServiceClient
+			reconciler *PtpInstanceReconciler
+		)
+
+		BeforeEach(func() {
+			server, gcClient = newPtpInstanceFixtureServer()
+			reconciler = newPtpInstanceReconciler()
+		})
+		AfterEach(func() { server.Close() })
+
+		Context("when creating a ptp instance", func() {
+			It("should succeed", func() {
+				instance := &starlingxv1.PtpInstance{
+					ObjectMeta: metav1.ObjectMeta{Name: "pi-new", Namespace: "default"},
+					Spec:       starlingxv1.PtpInstanceSpec{Service: "ptp4l"},
+				}
+				result, err := reconciler.ReconcileNew(gcClient, instance)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).ToNot(BeNil())
+				Expect(result.UUID).To(Equal("new-ptp-uuid"))
+			})
+		})
+
+		Context("when already reconciled and StopAfterInSync", func() {
+			It("should return error", func() {
+				instance := &starlingxv1.PtpInstance{
+					ObjectMeta: metav1.ObjectMeta{Name: "pi-new-stop", Namespace: "default"},
+					Spec:       starlingxv1.PtpInstanceSpec{Service: "ptp4l"},
+				}
+				instance.Status.Reconciled = true
+				_, err := reconciler.ReconcileNew(gcClient, instance)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("ReconciledDeleted", func() {
+		var (
+			server     *httptest.Server
+			gcClient   *gophercloud.ServiceClient
+			reconciler *PtpInstanceReconciler
+		)
+
+		BeforeEach(func() {
+			server, gcClient = newPtpInstanceFixtureServer()
+			reconciler = newPtpInstanceReconciler()
+		})
+		AfterEach(func() { server.Close() })
+
+		Context("when the resource has a finalizer and instance exists", func() {
+			It("should delete and remove the finalizer", func() {
+				instance := &starlingxv1.PtpInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "pi-delete",
+						Namespace:  "default",
+						Finalizers: []string{PtpInstanceFinalizerName},
+					},
+					Spec: starlingxv1.PtpInstanceSpec{Service: "ptp4l"},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, instance)).To(Succeed())
+
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+					return err == nil && !instance.DeletionTimestamp.IsZero()
+				}, timeout, interval).Should(BeTrue())
+
+				existing := &ptpinstances.PTPInstance{UUID: "test-ptp-uuid", Name: "pi-delete"}
+				err := reconciler.ReconciledDeleted(gcClient, instance, existing)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(instance.Finalizers).ToNot(ContainElement(PtpInstanceFinalizerName))
+			})
+		})
+
+		Context("when the instance is nil", func() {
+			It("should just remove the finalizer", func() {
+				instance := &starlingxv1.PtpInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "pi-delete-nil",
+						Namespace:  "default",
+						Finalizers: []string{PtpInstanceFinalizerName},
+					},
+					Spec: starlingxv1.PtpInstanceSpec{Service: "ptp4l"},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, instance)).To(Succeed())
+
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+					return err == nil && !instance.DeletionTimestamp.IsZero()
+				}, timeout, interval).Should(BeTrue())
+
+				err := reconciler.ReconciledDeleted(gcClient, instance, nil)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("ReconcileResource", func() {
+		var (
+			server     *httptest.Server
+			gcClient   *gophercloud.ServiceClient
+			reconciler *PtpInstanceReconciler
+		)
+
+		BeforeEach(func() {
+			server, gcClient = newPtpInstanceFixtureServer()
+			reconciler = newPtpInstanceReconciler()
+		})
+		AfterEach(func() { server.Close() })
+
+		Context("when the resource exists on the system", func() {
+			It("should reconcile successfully", func() {
+				instance := &starlingxv1.PtpInstance{
+					ObjectMeta: metav1.ObjectMeta{Name: "pi-reconcile-exist", Namespace: "default"},
+					Spec:       starlingxv1.PtpInstanceSpec{Service: "ptp4l"},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+				Eventually(func() bool {
+					_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+					return len(instance.Finalizers) > 0
+				}, timeout, interval).Should(BeTrue())
+
+				id := "test-ptp-uuid"
+				instance.Status.ID = &id
+				err := reconciler.ReconcileResource(gcClient, instance)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when the resource does not exist on the system", func() {
+			It("should create a new ptp instance", func() {
+				instance := &starlingxv1.PtpInstance{
+					ObjectMeta: metav1.ObjectMeta{Name: "pi-reconcile-new", Namespace: "default"},
+					Spec:       starlingxv1.PtpInstanceSpec{Service: "ptp4l"},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+				Eventually(func() bool {
+					_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+					return len(instance.Finalizers) > 0
+				}, timeout, interval).Should(BeTrue())
+
+				err := reconciler.ReconcileResource(gcClient, instance)
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 	})

--- a/internal/controller/ptpinterface_controller_test.go
+++ b/internal/controller/ptpinterface_controller_test.go
@@ -3,20 +3,106 @@
 package controller
 
 import (
-	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"time"
 
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/ptpinterfaces"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
 	comm "github.com/wind-river/cloud-platform-deployment-manager/common"
+	"github.com/wind-river/cloud-platform-deployment-manager/internal/controller/common"
+	cloudManager "github.com/wind-river/cloud-platform-deployment-manager/internal/controller/manager"
 )
 
-var _ = Describe("PtpInterface controller", func() {
+const ptpInterfaceResponse = `{
+	"uuid": "test-ptpif-uuid",
+	"id": 1,
+	"name": "ptp-iface-0",
+	"ptp_instance_uuid": "test-ptp-uuid",
+	"ptp_instance_name": "ptp4l-instance-0",
+	"parameters": []
+}`
 
+const ptpInterfaceListResponse = `{
+	"ptp_interfaces": [` + ptpInterfaceResponse + `]
+}`
+
+func newPtpInterfaceFixtureServer() (*httptest.Server, *gophercloud.ServiceClient) {
+	mux := http.NewServeMux()
+
+	// ptp_instances endpoint needed by findPTPInstanceByName
+	mux.HandleFunc("/ptp_instances", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, ptpInstanceListResponse)
+	})
+	mux.HandleFunc("/ptp_instances/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, ptpInstanceResponse)
+	})
+
+	mux.HandleFunc("/ptp_interfaces", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = fmt.Fprint(w, ptpInterfaceListResponse)
+		case http.MethodPost:
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			name, _ := body["name"].(string)
+			resp := fmt.Sprintf(`{"uuid":"new-ptpif-uuid","id":2,"name":"%s","ptp_instance_uuid":"test-ptp-uuid","ptp_instance_name":"ptp4l-instance-0","parameters":[]}`, name)
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, resp)
+		}
+	})
+	mux.HandleFunc("/ptp_interfaces/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = fmt.Fprint(w, ptpInterfaceResponse)
+		case http.MethodPatch:
+			_, _ = fmt.Fprint(w, ptpInterfaceResponse)
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	sc := &gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{TokenID: "test-token"},
+		Endpoint:       server.URL + "/",
+	}
+	return server, sc
+}
+
+func newPtpInterfaceReconciler() *PtpInterfaceReconciler {
+	dm := &cloudManager.Dummymanager{}
+	logger := log.Log.WithName("test")
+	return &PtpInterfaceReconciler{
+		Client:       k8sClient,
+		CloudManager: dm,
+		ReconcilerErrorHandler: &common.ErrorHandler{
+			CloudManager: dm,
+			Logger:       logger,
+		},
+		ReconcilerEventLogger: &common.EventLogger{
+			EventRecorder: record.NewFakeRecorder(100),
+			Logger:        logger,
+		},
+	}
+}
+
+var _ = Describe("PtpInterface controller", func() {
 	const (
 		timeout  = time.Second * 30
 		interval = time.Millisecond * 500
@@ -24,19 +110,17 @@ var _ = Describe("PtpInterface controller", func() {
 
 	Context("with PtpInterface data", func() {
 		It("should be created successfully", func() {
-			ctx := context.Background()
 			key := types.NamespacedName{
-				Name:      "foo",
+				Name:      "ptp-iface-create",
 				Namespace: "default",
 			}
 			created := &starlingxv1.PtpInterface{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
+					Name:      "ptp-iface-create",
 					Namespace: "default",
 				},
 				Spec: starlingxv1.PtpInterfaceSpec{
-					PtpInstance:         "ptp1",
-					InterfaceParameters: []string{"foo1=bar1", "foo2=bar2"},
+					PtpInstance: "ptp4l-instance-0",
 				}}
 			Expect(k8sClient.Create(ctx, created)).To(Succeed())
 
@@ -49,6 +133,241 @@ var _ = Describe("PtpInterface controller", func() {
 				_, found := comm.ListIntersect(fetched.ObjectMeta.Finalizers, []string{PtpInterfaceFinalizerName})
 				return found
 			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Describe("FindExistingPTPInterface", func() {
+		var (
+			server     *httptest.Server
+			gcClient   *gophercloud.ServiceClient
+			reconciler *PtpInterfaceReconciler
+		)
+
+		BeforeEach(func() {
+			server, gcClient = newPtpInterfaceFixtureServer()
+			reconciler = newPtpInterfaceReconciler()
+		})
+		AfterEach(func() { server.Close() })
+
+		Context("when the resource has a status ID", func() {
+			It("should fetch by UUID", func() {
+				id := "test-ptpif-uuid"
+				instance := &starlingxv1.PtpInterface{
+					ObjectMeta: metav1.ObjectMeta{Name: "ptp-iface-0", Namespace: "default"},
+					Spec:       starlingxv1.PtpInterfaceSpec{PtpInstance: "ptp4l-instance-0"},
+				}
+				instance.Status.ID = &id
+				found, err := reconciler.FindExistingPTPInterface(gcClient, instance)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).ToNot(BeNil())
+				Expect(found.UUID).To(Equal("test-ptpif-uuid"))
+			})
+		})
+
+		Context("when the resource has no status ID", func() {
+			It("should find by name from list", func() {
+				instance := &starlingxv1.PtpInterface{
+					ObjectMeta: metav1.ObjectMeta{Name: "ptp-iface-0", Namespace: "default"},
+					Spec:       starlingxv1.PtpInterfaceSpec{PtpInstance: "ptp4l-instance-0"},
+				}
+				found, err := reconciler.FindExistingPTPInterface(gcClient, instance)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).ToNot(BeNil())
+			})
+		})
+
+		Context("when the resource does not exist", func() {
+			It("should return nil", func() {
+				instance := &starlingxv1.PtpInterface{
+					ObjectMeta: metav1.ObjectMeta{Name: "nonexistent", Namespace: "default"},
+					Spec:       starlingxv1.PtpInterfaceSpec{PtpInstance: "ptp4l-instance-0"},
+				}
+				found, err := reconciler.FindExistingPTPInterface(gcClient, instance)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeNil())
+			})
+		})
+	})
+
+	Describe("ReconcileNew", func() {
+		var (
+			server     *httptest.Server
+			gcClient   *gophercloud.ServiceClient
+			reconciler *PtpInterfaceReconciler
+		)
+
+		BeforeEach(func() {
+			server, gcClient = newPtpInterfaceFixtureServer()
+			reconciler = newPtpInterfaceReconciler()
+		})
+		AfterEach(func() { server.Close() })
+
+		Context("when creating a ptp interface", func() {
+			It("should succeed", func() {
+				instance := &starlingxv1.PtpInterface{
+					ObjectMeta: metav1.ObjectMeta{Name: "ptpif-new", Namespace: "default"},
+					Spec:       starlingxv1.PtpInterfaceSpec{PtpInstance: "ptp4l-instance-0"},
+				}
+				result, err := reconciler.ReconcileNew(gcClient, instance)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).ToNot(BeNil())
+				Expect(result.UUID).To(Equal("new-ptpif-uuid"))
+			})
+		})
+
+		Context("when already reconciled and StopAfterInSync", func() {
+			It("should return error", func() {
+				instance := &starlingxv1.PtpInterface{
+					ObjectMeta: metav1.ObjectMeta{Name: "ptpif-new-stop", Namespace: "default"},
+					Spec:       starlingxv1.PtpInterfaceSpec{PtpInstance: "ptp4l-instance-0"},
+				}
+				instance.Status.Reconciled = true
+				_, err := reconciler.ReconcileNew(gcClient, instance)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("ReconciledDeleted", func() {
+		var (
+			server     *httptest.Server
+			gcClient   *gophercloud.ServiceClient
+			reconciler *PtpInterfaceReconciler
+		)
+
+		BeforeEach(func() {
+			server, gcClient = newPtpInterfaceFixtureServer()
+			reconciler = newPtpInterfaceReconciler()
+		})
+		AfterEach(func() { server.Close() })
+
+		Context("when the resource has a finalizer and interface exists", func() {
+			It("should delete and remove the finalizer", func() {
+				instance := &starlingxv1.PtpInterface{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "ptpif-delete",
+						Namespace:  "default",
+						Finalizers: []string{PtpInterfaceFinalizerName},
+					},
+					Spec: starlingxv1.PtpInterfaceSpec{PtpInstance: "ptp4l-instance-0"},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, instance)).To(Succeed())
+
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+					return err == nil && !instance.DeletionTimestamp.IsZero()
+				}, timeout, interval).Should(BeTrue())
+
+				existing := &ptpinterfaces.PTPInterface{UUID: "test-ptpif-uuid", Name: "ptpif-delete"}
+				err := reconciler.ReconciledDeleted(gcClient, instance, existing)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(instance.Finalizers).ToNot(ContainElement(PtpInterfaceFinalizerName))
+			})
+		})
+
+		Context("when the interface is nil", func() {
+			It("should just remove the finalizer", func() {
+				instance := &starlingxv1.PtpInterface{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "ptpif-delete-nil",
+						Namespace:  "default",
+						Finalizers: []string{PtpInterfaceFinalizerName},
+					},
+					Spec: starlingxv1.PtpInterfaceSpec{PtpInstance: "ptp4l-instance-0"},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, instance)).To(Succeed())
+
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+					return err == nil && !instance.DeletionTimestamp.IsZero()
+				}, timeout, interval).Should(BeTrue())
+
+				err := reconciler.ReconciledDeleted(gcClient, instance, nil)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("ReconcileResource", func() {
+		var (
+			server     *httptest.Server
+			gcClient   *gophercloud.ServiceClient
+			reconciler *PtpInterfaceReconciler
+		)
+
+		BeforeEach(func() {
+			server, gcClient = newPtpInterfaceFixtureServer()
+			reconciler = newPtpInterfaceReconciler()
+		})
+		AfterEach(func() { server.Close() })
+
+		Context("when the resource exists on the system", func() {
+			It("should reconcile successfully", func() {
+				instance := &starlingxv1.PtpInterface{
+					ObjectMeta: metav1.ObjectMeta{Name: "ptpif-reconcile-exist", Namespace: "default"},
+					Spec:       starlingxv1.PtpInterfaceSpec{PtpInstance: "ptp4l-instance-0"},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+				Eventually(func() bool {
+					_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+					return len(instance.Finalizers) > 0
+				}, timeout, interval).Should(BeTrue())
+
+				id := "test-ptpif-uuid"
+				instance.Status.ID = &id
+				err := reconciler.ReconcileResource(gcClient, instance)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when the resource does not exist on the system", func() {
+			It("should create a new ptp interface", func() {
+				instance := &starlingxv1.PtpInterface{
+					ObjectMeta: metav1.ObjectMeta{Name: "ptpif-reconcile-new", Namespace: "default"},
+					Spec:       starlingxv1.PtpInterfaceSpec{PtpInstance: "ptp4l-instance-0"},
+				}
+				Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+				Eventually(func() bool {
+					_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)
+					return len(instance.Finalizers) > 0
+				}, timeout, interval).Should(BeTrue())
+
+				err := reconciler.ReconcileResource(gcClient, instance)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("findPTPInstanceByName", func() {
+		var (
+			server   *httptest.Server
+			gcClient *gophercloud.ServiceClient
+		)
+
+		BeforeEach(func() {
+			server, gcClient = newPtpInterfaceFixtureServer()
+		})
+		AfterEach(func() { server.Close() })
+
+		Context("when the instance exists", func() {
+			It("should return it", func() {
+				found, err := findPTPInstanceByName(gcClient, "ptp4l-instance-0")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).ToNot(BeNil())
+				Expect(found.Name).To(Equal("ptp4l-instance-0"))
+			})
+		})
+
+		Context("when the instance does not exist", func() {
+			It("should return nil", func() {
+				found, err := findPTPInstanceByName(gcClient, "nonexistent")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeNil())
+			})
 		})
 	})
 })


### PR DESCRIPTION
Add HTTP fixture servers and reconciliation tests for datanetwork, ptpinstance, ptpinterface, and platformnetwork controllers.

- datanetwork_controller_test.go: fixture server for CRUD endpoints, tests for FindExistingResource, ReconcileNew, ReconcileUpdated, ReconciledDeleted, ReconcileResource, removeDataNetworkFinalizer
- ptpinstance_controller_test.go: fixture server for ptp_instances, tests for FindExistingPTPInstance, ReconcileNew, ReconciledDeleted, ReconcileResource
- ptpinterface_controller_test.go: fixture server for ptp_interfaces and ptp_instances, tests for FindExistingPTPInterface, ReconcileNew, ReconciledDeleted, ReconcileResource, findPTPInstanceByName
- platformnetwork_controller_test.go: tests for statusUpdateRequired, UpdateInsyncStatus, ReconcileResource (delete + notify paths)
- update_required_test.go: tests for instanceUpdateRequired, interfaceUpdateRequired, dataNetworkUpdateRequired, instanceParameterUpdateRequired, intefaceParameterUpdateRequired, statusUpdateRequired for DataNetwork/PtpInstance/PtpInterface
- Extend Dummymanager with ActiveHost field for GetHostByPersonality

internal/controller/ coverage: 25.6% -> 60.6%