### PR TITLE
test: improve host controller test coverage

### DIFF
--- a/internal/controller/host/host_controller_fixtures.go
+++ b/internal/controller/host/host_controller_fixtures.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2024-2025 Wind River Systems, Inc. */
+/* Copyright(c) 2024-2026 Wind River Systems, Inc. */
 package host
 
 import (
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/addresspools"
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/networkAddressPools"
@@ -1456,27 +1457,31 @@ func GetPlatformNetworksFromFixtures(namespace string) (map[string]*starlingxv1.
 	return PlatformNetworks, AddressPoolInstances
 }
 
+var hostAPIHandlersOnce sync.Once
+
 func HostControllerAPIHandlers() {
-	HostsListBodyResponse = HostsListBody
-	SingleSystemBodyResponse = SingleSystemBody
-	AddressPoolAPIS()
-	NetworkAPIS()
-	OAMNetworkAPIS()
-	SystemAPIS()
-	HostAPIS()
-	OtherAPIS()
+	hostAPIHandlersOnce.Do(func() {
+		HostsListBodyResponse = HostsListBody
+		SingleSystemBodyResponse = SingleSystemBody
+		AddressPoolAPIS()
+		NetworkAPIS()
+		OAMNetworkAPIS()
+		SystemAPIS()
+		HostAPIS()
+		OtherAPIS()
 
-	var Networks struct {
-		NetworkList []networks.Network `json:"networks"`
-	}
-	_ = json.Unmarshal([]byte(NetworkListBody), &Networks)
-
-	for _, network := range Networks.NetworkList {
-		if network.Type == cloudManager.OAMNetworkType {
-			th.Mux.HandleFunc("/iextoam/"+network.UUID, HandleOAMNetworkRequests)
-		} else {
-			th.Mux.HandleFunc("/networks/"+network.UUID, HandleNetworkRequests)
+		var Networks struct {
+			NetworkList []networks.Network `json:"networks"`
 		}
-		th.Mux.HandleFunc("/addrpools/"+network.PoolUUID, HandleAddressPoolRequests)
-	}
+		_ = json.Unmarshal([]byte(NetworkListBody), &Networks)
+
+		for _, network := range Networks.NetworkList {
+			if network.Type == cloudManager.OAMNetworkType {
+				th.Mux.HandleFunc("/iextoam/"+network.UUID, HandleOAMNetworkRequests)
+			} else {
+				th.Mux.HandleFunc("/networks/"+network.UUID, HandleNetworkRequests)
+			}
+			th.Mux.HandleFunc("/addrpools/"+network.PoolUUID, HandleAddressPoolRequests)
+		}
+	})
 }

--- a/internal/controller/host/host_controller_test.go
+++ b/internal/controller/host/host_controller_test.go
@@ -19,6 +19,7 @@ import (
 
 	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
 	comm "github.com/wind-river/cloud-platform-deployment-manager/common"
+	cloudManager "github.com/wind-river/cloud-platform-deployment-manager/internal/controller/manager"
 )
 
 var _ = Describe("Host controller", func() {
@@ -1108,6 +1109,227 @@ var _ = Describe("Host controller", func() {
 			Expect(opts).NotTo(BeNil())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeTrue())
+		})
+	})
+
+	Describe("CompareDisabledAttributes", func() {
+		var r *HostReconciler
+
+		BeforeEach(func() {
+			r = &HostReconciler{
+				CloudManager: &cloudManager.Dummymanager{},
+			}
+		})
+
+		Context("when other is nil", func() {
+			It("should return false", func() {
+				in := &starlingxv1.HostProfileSpec{}
+				Expect(r.CompareDisabledAttributes(in, nil, "default", "controller", false)).To(BeFalse())
+			})
+		})
+
+		Context("when profiles are identical", func() {
+			It("should return true", func() {
+				personality := "controller"
+				admin := "unlocked"
+				in := &starlingxv1.HostProfileSpec{
+					ProfileBaseAttributes: starlingxv1.ProfileBaseAttributes{
+						Personality:         &personality,
+						AdministrativeState: &admin,
+					},
+					Interfaces: &starlingxv1.InterfaceInfo{},
+				}
+				other := in.DeepCopy()
+				Expect(r.CompareDisabledAttributes(in, other, "default", "controller", false)).To(BeTrue())
+			})
+		})
+
+		Context("when base attributes differ", func() {
+			It("should return false", func() {
+				p1 := "controller"
+				p2 := "worker"
+				admin := "unlocked"
+				in := &starlingxv1.HostProfileSpec{
+					ProfileBaseAttributes: starlingxv1.ProfileBaseAttributes{
+						Personality:         &p1,
+						AdministrativeState: &admin,
+					},
+				}
+				other := &starlingxv1.HostProfileSpec{
+					ProfileBaseAttributes: starlingxv1.ProfileBaseAttributes{
+						Personality:         &p2,
+						AdministrativeState: &admin,
+					},
+				}
+				Expect(r.CompareDisabledAttributes(in, other, "default", "controller", false)).To(BeFalse())
+			})
+		})
+
+		Context("when board management differs", func() {
+			It("should return false", func() {
+				personality := "controller"
+				admin := "unlocked"
+				bmType := "bmc"
+				in := &starlingxv1.HostProfileSpec{
+					ProfileBaseAttributes: starlingxv1.ProfileBaseAttributes{
+						Personality:         &personality,
+						AdministrativeState: &admin,
+					},
+					BoardManagement: &starlingxv1.BMInfo{Type: &bmType},
+					Interfaces:      &starlingxv1.InterfaceInfo{},
+				}
+				other := &starlingxv1.HostProfileSpec{
+					ProfileBaseAttributes: starlingxv1.ProfileBaseAttributes{
+						Personality:         &personality,
+						AdministrativeState: &admin,
+					},
+					Interfaces: &starlingxv1.InterfaceInfo{},
+				}
+				Expect(r.CompareDisabledAttributes(in, other, "default", "controller", false)).To(BeFalse())
+			})
+		})
+
+		Context("when interfaces differ", func() {
+			It("should return false", func() {
+				personality := "controller"
+				admin := "unlocked"
+				in := &starlingxv1.HostProfileSpec{
+					ProfileBaseAttributes: starlingxv1.ProfileBaseAttributes{
+						Personality:         &personality,
+						AdministrativeState: &admin,
+					},
+					Interfaces: &starlingxv1.InterfaceInfo{
+						Ethernet: starlingxv1.EthernetList{
+							{CommonInterfaceInfo: starlingxv1.CommonInterfaceInfo{Name: "eth0"}},
+						},
+					},
+				}
+				other := &starlingxv1.HostProfileSpec{
+					ProfileBaseAttributes: starlingxv1.ProfileBaseAttributes{
+						Personality:         &personality,
+						AdministrativeState: &admin,
+					},
+					Interfaces: &starlingxv1.InterfaceInfo{},
+				}
+				Expect(r.CompareDisabledAttributes(in, other, "default", "controller", false)).To(BeFalse())
+			})
+		})
+
+		Context("when in reconfig mode with different admin state", func() {
+			It("should ignore admin state difference", func() {
+				personality := "controller"
+				admin1 := "unlocked"
+				admin2 := "locked"
+				in := &starlingxv1.HostProfileSpec{
+					ProfileBaseAttributes: starlingxv1.ProfileBaseAttributes{
+						Personality:         &personality,
+						AdministrativeState: &admin1,
+					},
+					Interfaces: &starlingxv1.InterfaceInfo{},
+				}
+				other := &starlingxv1.HostProfileSpec{
+					ProfileBaseAttributes: starlingxv1.ProfileBaseAttributes{
+						Personality:         &personality,
+						AdministrativeState: &admin2,
+					},
+					Interfaces: &starlingxv1.InterfaceInfo{},
+				}
+				Expect(r.CompareDisabledAttributes(in, other, "default", "controller", true)).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("CompareEnabledAttributes", func() {
+		var r *HostReconciler
+
+		BeforeEach(func() {
+			r = &HostReconciler{
+				CloudManager: &cloudManager.Dummymanager{},
+			}
+		})
+
+		Context("when other is nil", func() {
+			It("should return false", func() {
+				in := &starlingxv1.HostProfileSpec{}
+				instance := &starlingxv1.Host{}
+				info := &cloudManager.SystemInfo{}
+				Expect(r.CompareEnabledAttributes(in, nil, instance, "controller", info)).To(BeFalse())
+			})
+		})
+
+		Context("when profiles are identical", func() {
+			It("should return true", func() {
+				in := &starlingxv1.HostProfileSpec{}
+				other := in.DeepCopy()
+				instance := &starlingxv1.Host{}
+				info := &cloudManager.SystemInfo{}
+				Expect(r.CompareEnabledAttributes(in, other, instance, "controller", info)).To(BeTrue())
+			})
+		})
+
+		Context("when routes differ", func() {
+			It("should return false", func() {
+				in := &starlingxv1.HostProfileSpec{
+					Routes: starlingxv1.RouteList{
+						{Interface: "eth0", Network: "10.0.0.0", Prefix: 24, Gateway: "10.0.0.1"},
+					},
+				}
+				other := &starlingxv1.HostProfileSpec{}
+				instance := &starlingxv1.Host{}
+				info := &cloudManager.SystemInfo{}
+				Expect(r.CompareEnabledAttributes(in, other, instance, "controller", info)).To(BeFalse())
+			})
+		})
+
+		Context("when filesystem sizes differ", func() {
+			It("should return false", func() {
+				in := &starlingxv1.HostProfileSpec{
+					Storage: &starlingxv1.ProfileStorageInfo{
+						FileSystems: starlingxv1.FileSystemList{
+							{Name: "backup", Size: 50},
+						},
+					},
+				}
+				other := &starlingxv1.HostProfileSpec{
+					Storage: &starlingxv1.ProfileStorageInfo{
+						FileSystems: starlingxv1.FileSystemList{
+							{Name: "backup", Size: 30},
+						},
+					},
+				}
+				instance := &starlingxv1.Host{}
+				info := &cloudManager.SystemInfo{}
+				Expect(r.CompareEnabledAttributes(in, other, instance, "controller", info)).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("FindExistingHost", func() {
+		It("should find a host by boot MAC match", func() {
+			HostControllerAPIHandlers()
+			client := gcClient.ServiceClient()
+			bootMAC := "08:08:08:08:08:08"
+			match := starlingxv1.MatchInfo{BootMAC: &bootMAC}
+
+			hostList, err := hosts.ListHosts(client)
+			Expect(err).ToNot(HaveOccurred())
+
+			found := FindExistingHost(hostList, "", &match, &bootMAC)
+			Expect(found).ToNot(BeNil())
+			Expect(found.Hostname).To(Equal("controller-0"))
+		})
+
+		It("should return nil when no match", func() {
+			HostControllerAPIHandlers()
+			client := gcClient.ServiceClient()
+			bootMAC := "ff:ff:ff:ff:ff:ff"
+			match := starlingxv1.MatchInfo{BootMAC: &bootMAC}
+
+			hostList, err := hosts.ListHosts(client)
+			Expect(err).ToNot(HaveOccurred())
+
+			found := FindExistingHost(hostList, "", &match, &bootMAC)
+			Expect(found).To(BeNil())
 		})
 	})
 })

--- a/internal/controller/host/kernel_test.go
+++ b/internal/controller/host/kernel_test.go
@@ -1,0 +1,85 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2026 Wind River Systems, Inc. */
+package host
+
+import (
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/cpus"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/kernel"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
+	v1info "github.com/wind-river/cloud-platform-deployment-manager/platform"
+)
+
+var _ = Describe("GetKernelUpdateOpts", func() {
+	Context("when kernel matches", func() {
+		It("should return false", func() {
+			k := "standard"
+			profile := &starlingxv1.HostProfileSpec{
+				ProfileBaseAttributes: starlingxv1.ProfileBaseAttributes{Kernel: &k},
+			}
+			current := &kernel.Kernel{ProvisionedKernel: "standard"}
+			_, required := GetKernelUpdateOpts(current, profile)
+			Expect(required).To(BeFalse())
+		})
+	})
+
+	Context("when kernel differs", func() {
+		It("should return true with updated kernel", func() {
+			k := "lowlatency"
+			profile := &starlingxv1.HostProfileSpec{
+				ProfileBaseAttributes: starlingxv1.ProfileBaseAttributes{Kernel: &k},
+			}
+			current := &kernel.Kernel{ProvisionedKernel: "standard"}
+			opts, required := GetKernelUpdateOpts(current, profile)
+			Expect(required).To(BeTrue())
+			Expect(*opts.Kernel).To(Equal("lowlatency"))
+		})
+	})
+})
+
+var _ = Describe("GetCPUUpdateOpts", func() {
+	Context("when CPU counts match", func() {
+		It("should return false", func() {
+			r := &HostReconciler{}
+			profile := &starlingxv1.HostProfileSpec{
+				Processors: starlingxv1.ProcessorNodeList{
+					{Node: 0, Functions: starlingxv1.ProcessorFunctionList{
+						{Function: cpus.CPUFunctionPlatform, Count: 2},
+					}},
+				},
+			}
+			host := &v1info.HostInfo{
+				CPU: []cpus.CPU{
+					{Processor: 0, Function: cpus.CPUFunctionPlatform},
+					{Processor: 0, Function: cpus.CPUFunctionPlatform},
+				},
+			}
+			_, required := r.GetCPUUpdateOpts(profile, host)
+			Expect(required).To(BeFalse())
+		})
+	})
+
+	Context("when CPU counts differ", func() {
+		It("should return true with opts", func() {
+			r := &HostReconciler{}
+			profile := &starlingxv1.HostProfileSpec{
+				Processors: starlingxv1.ProcessorNodeList{
+					{Node: 0, Functions: starlingxv1.ProcessorFunctionList{
+						{Function: cpus.CPUFunctionPlatform, Count: 4},
+					}},
+				},
+			}
+			host := &v1info.HostInfo{
+				CPU: []cpus.CPU{
+					{Processor: 0, Function: cpus.CPUFunctionPlatform},
+					{Processor: 0, Function: cpus.CPUFunctionPlatform},
+				},
+			}
+			opts, required := r.GetCPUUpdateOpts(profile, host)
+			Expect(required).To(BeTrue())
+			Expect(opts).To(HaveLen(1))
+			Expect(opts[0].Function).To(Equal(cpus.CPUFunctionPlatform))
+		})
+	})
+})

--- a/internal/controller/host/memory_test.go
+++ b/internal/controller/host/memory_test.go
@@ -1,4 +1,4 @@
-// /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: Apache-2.0 */
 /* Copyright(c) 2024-2026 Wind River Systems, Inc. */
 package host
 
@@ -10,55 +10,234 @@ import (
 )
 
 var _ = Describe("Memory utils", func() {
-	Context("when processor does not match node", func() {
-		var pagesize starlingxv1.PageSize = "PageSize1G"
-		node := 2
+	Describe("vswitchCountMemoryByFunction", func() {
+		Context("when processor does not match node", func() {
+			It("should return zero", func() {
+				memories := []memory.Memory{{ID: "234", Processor: 1}}
+				got, err := vswitchCountMemoryByFunction(memories, 2, starlingxv1.PageSize1G)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(got).To(Equal(0))
+			})
+		})
 
-		memories := []memory.Memory{{
-			ID:        "234",
-			Processor: 1,
-		}}
-		want := 0
-		got, err := vswitchCountMemoryByFunction(memories, node, pagesize)
+		Context("when hugepages required is nil", func() {
+			It("should return the count", func() {
+				memories := []memory.Memory{{
+					ID: "234", Processor: 2,
+					VSwitchHugepagesSize:     2,
+					VSwitchHugepagesCount:    1,
+					VSwitchHugepagesRequired: nil,
+				}}
+				got, err := vswitchCountMemoryByFunction(memories, 2, starlingxv1.PageSize2M)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(got).To(Equal(1))
+			})
+		})
 
-		Expect(got).To(Equal(want))
-		Expect(err).ToNot(HaveOccurred())
-
+		Context("when hugepages required is set", func() {
+			It("should return the required value", func() {
+				required := 2
+				memories := []memory.Memory{{
+					ID: "345", Processor: 2,
+					VSwitchHugepagesSize:     2,
+					VSwitchHugepagesRequired: &required,
+					VSwitchHugepagesCount:    5,
+				}}
+				got, err := vswitchCountMemoryByFunction(memories, 2, starlingxv1.PageSize2M)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(got).To(Equal(2))
+			})
+		})
 	})
-	Context("when hugepages size is zero and required is nil", func() {
-		var pagesize starlingxv1.PageSize = "PageSize2M"
-		node := 2
 
-		memories := []memory.Memory{{
-			ID:                       "234",
-			Processor:                2,
-			VSwitchHugepagesSize:     0,
-			VSwitchHugepagesCount:    1,
-			VSwitchHugepagesRequired: nil,
-		}}
-		want := 1
-		got, err := vswitchCountMemoryByFunction(memories, node, pagesize)
-		Expect(got).To(Equal(want))
-		Expect(err).ToNot(HaveOccurred())
+	Describe("vmCountMemoryByFunction", func() {
+		Context("when using 2M pages with pending value", func() {
+			It("should return the pending count", func() {
+				pending := 10
+				memories := []memory.Memory{{
+					Processor:            0,
+					VM2MHugepagesCount:   5,
+					VM2MHugepagesPending: &pending,
+				}}
+				got, err := vmCountMemoryByFunction(memories, 0, starlingxv1.PageSize2M)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(got).To(Equal(10))
+			})
+		})
 
+		Context("when using 2M pages without pending", func() {
+			It("should return the current count", func() {
+				memories := []memory.Memory{{
+					Processor:          0,
+					VM2MHugepagesCount: 5,
+				}}
+				got, err := vmCountMemoryByFunction(memories, 0, starlingxv1.PageSize2M)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(got).To(Equal(5))
+			})
+		})
+
+		Context("when using 1G pages with pending value", func() {
+			It("should return the pending count", func() {
+				pending := 4
+				memories := []memory.Memory{{
+					Processor:            0,
+					VM1GHugepagesCount:   2,
+					VM1GHugepagesPending: &pending,
+				}}
+				got, err := vmCountMemoryByFunction(memories, 0, starlingxv1.PageSize1G)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(got).To(Equal(4))
+			})
+		})
+
+		Context("when using 1G pages without pending", func() {
+			It("should return the current count", func() {
+				memories := []memory.Memory{{
+					Processor:          0,
+					VM1GHugepagesCount: 2,
+				}}
+				got, err := vmCountMemoryByFunction(memories, 0, starlingxv1.PageSize1G)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(got).To(Equal(2))
+			})
+		})
 	})
 
-	Context("when hugepages required is set", func() {
-		var pagesize starlingxv1.PageSize = "PageSize2M"
-		node := 2
-		required := 2
+	Describe("platformCountMemoryByFunction", func() {
+		Context("when using 4K pages", func() {
+			It("should convert MiB platform memory to 4K page count", func() {
+				memories := []memory.Memory{{
+					Processor: 0,
+					Platform:  1024, // 1024 MiB
+				}}
+				got, err := platformCountMemoryByFunction(memories, 0, starlingxv1.PageSize4K)
+				Expect(err).ToNot(HaveOccurred())
+				// 1024 MiB * 1048576 / 4096 = 262144
+				Expect(got).To(Equal(262144))
+			})
+		})
 
-		memories := []memory.Memory{{
-			ID:                       "345",
-			Processor:                2,
-			VSwitchHugepagesSize:     0,
-			VSwitchHugepagesRequired: &required,
-			VSwitchHugepagesCount:    2,
-		}}
-		want := 2
-		got, err := vswitchCountMemoryByFunction(memories, node, pagesize)
-		Expect(got).To(Equal(want))
-		Expect(err).ToNot(HaveOccurred())
+		Context("when using non-4K pages", func() {
+			It("should return zero", func() {
+				memories := []memory.Memory{{
+					Processor: 0,
+					Platform:  1024,
+				}}
+				got, err := platformCountMemoryByFunction(memories, 0, starlingxv1.PageSize2M)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(got).To(Equal(0))
+			})
+		})
+	})
 
+	Describe("memoryCountByFunction", func() {
+		var memories []memory.Memory
+
+		BeforeEach(func() {
+			memories = []memory.Memory{{Processor: 0, Platform: 512, VM2MHugepagesCount: 3}}
+		})
+
+		It("should dispatch to vswitch", func() {
+			_, err := memoryCountByFunction(memories, 0, memory.MemoryFunctionVSwitch, starlingxv1.PageSize2M)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should dispatch to vm", func() {
+			got, err := memoryCountByFunction(memories, 0, memory.MemoryFunctionVM, starlingxv1.PageSize2M)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got).To(Equal(3))
+		})
+
+		It("should dispatch to platform", func() {
+			_, err := memoryCountByFunction(memories, 0, memory.MemoryFunctionPlatform, starlingxv1.PageSize4K)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return error for unsupported function", func() {
+			_, err := memoryCountByFunction(memories, 0, "unknown", starlingxv1.PageSize2M)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("memoryUpdateRequired", func() {
+		Context("when counts match", func() {
+			It("should return false", func() {
+				f := starlingxv1.MemoryFunctionInfo{
+					Function:  memory.MemoryFunctionVM,
+					PageSize:  string(starlingxv1.PageSize2M),
+					PageCount: 10,
+				}
+				_, result := memoryUpdateRequired(f, 10)
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("when VM 1G pages differ", func() {
+			It("should return true with VMHugepages1G set", func() {
+				f := starlingxv1.MemoryFunctionInfo{
+					Function:  memory.MemoryFunctionVM,
+					PageSize:  string(starlingxv1.PageSize1G),
+					PageCount: 4,
+				}
+				opts, result := memoryUpdateRequired(f, 2)
+				Expect(result).To(BeTrue())
+				Expect(*opts.VMHugepages1G).To(Equal(4))
+			})
+		})
+
+		Context("when VM 2M pages differ", func() {
+			It("should return true with VMHugepages2M set", func() {
+				f := starlingxv1.MemoryFunctionInfo{
+					Function:  memory.MemoryFunctionVM,
+					PageSize:  string(starlingxv1.PageSize2M),
+					PageCount: 100,
+				}
+				opts, result := memoryUpdateRequired(f, 50)
+				Expect(result).To(BeTrue())
+				Expect(*opts.VMHugepages2M).To(Equal(100))
+			})
+		})
+
+		Context("when vswitch 1G pages differ", func() {
+			It("should return true with VSwitchHugepages set", func() {
+				f := starlingxv1.MemoryFunctionInfo{
+					Function:  memory.MemoryFunctionVSwitch,
+					PageSize:  string(starlingxv1.PageSize1G),
+					PageCount: 2,
+				}
+				opts, result := memoryUpdateRequired(f, 1)
+				Expect(result).To(BeTrue())
+				Expect(*opts.VSwitchHugepages).To(Equal(2))
+				Expect(*opts.VSwitchHugepageSize).To(Equal(1024))
+			})
+		})
+
+		Context("when vswitch 2M pages differ", func() {
+			It("should return true with size 2", func() {
+				f := starlingxv1.MemoryFunctionInfo{
+					Function:  memory.MemoryFunctionVSwitch,
+					PageSize:  string(starlingxv1.PageSize2M),
+					PageCount: 8,
+				}
+				opts, result := memoryUpdateRequired(f, 4)
+				Expect(result).To(BeTrue())
+				Expect(*opts.VSwitchHugepageSize).To(Equal(2))
+			})
+		})
+
+		Context("when platform pages differ", func() {
+			It("should return true with Platform set in MiB", func() {
+				f := starlingxv1.MemoryFunctionInfo{
+					Function:  memory.MemoryFunctionPlatform,
+					PageSize:  string(starlingxv1.PageSize4K),
+					PageCount: 262144, // 1024 MiB worth of 4K pages
+				}
+				opts, result := memoryUpdateRequired(f, 131072)
+				Expect(result).To(BeTrue())
+				// 262144 * 4096 / 1048576 = 1024
+				Expect(*opts.Platform).To(Equal(1024))
+			})
+		})
 	})
 })

--- a/internal/controller/host/networking_test.go
+++ b/internal/controller/host/networking_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/interfaces"
 	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
 	v1info "github.com/wind-river/cloud-platform-deployment-manager/platform"
+
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/addresspools"
 )
 
 var _ = Describe("Networking utils", func() {
@@ -815,6 +817,214 @@ var _ = Describe("Networking utils", func() {
 					Expect(reflect.DeepEqual(got, tt.want)).To(BeTrue())
 					Expect(got1).To(Equal(tt.want1))
 				}
+			})
+		})
+	})
+
+	Describe("hasIPv4StaticAddresses", func() {
+		It("should return true when matching IPv4 address exists", func() {
+			info := starlingxv1.CommonInterfaceInfo{Name: "eth0"}
+			profile := &starlingxv1.HostProfileSpec{
+				Addresses: starlingxv1.AddressList{
+					{Interface: "eth0", Address: "10.0.0.1", Prefix: 24},
+				},
+			}
+			Expect(hasIPv4StaticAddresses(info, profile)).To(BeTrue())
+		})
+
+		It("should return false when no matching address", func() {
+			info := starlingxv1.CommonInterfaceInfo{Name: "eth1"}
+			profile := &starlingxv1.HostProfileSpec{
+				Addresses: starlingxv1.AddressList{
+					{Interface: "eth0", Address: "10.0.0.1", Prefix: 24},
+				},
+			}
+			Expect(hasIPv4StaticAddresses(info, profile)).To(BeFalse())
+		})
+	})
+
+	Describe("hasIPv6StaticAddresses", func() {
+		It("should return true when matching IPv6 address exists", func() {
+			info := starlingxv1.CommonInterfaceInfo{Name: "eth0"}
+			profile := &starlingxv1.HostProfileSpec{
+				Addresses: starlingxv1.AddressList{
+					{Interface: "eth0", Address: "fd00::1", Prefix: 64},
+				},
+			}
+			Expect(hasIPv6StaticAddresses(info, profile)).To(BeTrue())
+		})
+
+		It("should return false when address is IPv4", func() {
+			info := starlingxv1.CommonInterfaceInfo{Name: "eth0"}
+			profile := &starlingxv1.HostProfileSpec{
+				Addresses: starlingxv1.AddressList{
+					{Interface: "eth0", Address: "10.0.0.1", Prefix: 24},
+				},
+			}
+			Expect(hasIPv6StaticAddresses(info, profile)).To(BeFalse())
+		})
+	})
+
+	Describe("hasIPv4DynamicAddresses", func() {
+		It("should return true when platform network has IPv4 pool", func() {
+			info := starlingxv1.CommonInterfaceInfo{
+				Name:             "eth0",
+				PlatformNetworks: starlingxv1.PlatformNetworkItemList{"mgmt"},
+			}
+			host := &v1info.HostInfo{
+				Pools: []addresspools.AddressPool{
+					{Name: "mgmt", Network: "10.0.0.0"},
+				},
+			}
+			pool, ok := hasIPv4DynamicAddresses(info, host)
+			Expect(ok).To(BeTrue())
+			Expect(pool).ToNot(BeNil())
+		})
+
+		It("should return false when platform networks is nil", func() {
+			info := starlingxv1.CommonInterfaceInfo{Name: "eth0"}
+			host := &v1info.HostInfo{}
+			_, ok := hasIPv4DynamicAddresses(info, host)
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Describe("hasIPv6DynamicAddresses", func() {
+		It("should return true when platform network has IPv6 pool", func() {
+			info := starlingxv1.CommonInterfaceInfo{
+				Name:             "eth0",
+				PlatformNetworks: starlingxv1.PlatformNetworkItemList{"mgmt"},
+			}
+			host := &v1info.HostInfo{
+				Pools: []addresspools.AddressPool{
+					{Name: "mgmt", Network: "fd00::"},
+				},
+			}
+			pool, ok := hasIPv6DynamicAddresses(info, host)
+			Expect(ok).To(BeTrue())
+			Expect(pool).ToNot(BeNil())
+		})
+	})
+
+	Describe("getInterfaceIPv4Addressing", func() {
+		It("should return static when IPv4 static address exists", func() {
+			info := starlingxv1.CommonInterfaceInfo{Name: "eth0"}
+			profile := &starlingxv1.HostProfileSpec{
+				Addresses: starlingxv1.AddressList{
+					{Interface: "eth0", Address: "10.0.0.1", Prefix: 24},
+				},
+			}
+			host := &v1info.HostInfo{}
+			mode, pool := getInterfaceIPv4Addressing(info, profile, host)
+			Expect(mode).To(Equal(interfaces.AddressModeStatic))
+			Expect(pool).To(BeNil())
+		})
+
+		It("should return pool when dynamic IPv4 pool exists", func() {
+			info := starlingxv1.CommonInterfaceInfo{
+				Name:             "eth0",
+				PlatformNetworks: starlingxv1.PlatformNetworkItemList{"mgmt"},
+			}
+			profile := &starlingxv1.HostProfileSpec{}
+			host := &v1info.HostInfo{
+				Pools: []addresspools.AddressPool{
+					{ID: "pool-uuid", Name: "mgmt", Network: "10.0.0.0"},
+				},
+			}
+			mode, pool := getInterfaceIPv4Addressing(info, profile, host)
+			Expect(mode).To(Equal(interfaces.AddressModePool))
+			Expect(pool).ToNot(BeNil())
+		})
+
+		It("should return disabled when no addresses", func() {
+			info := starlingxv1.CommonInterfaceInfo{Name: "eth0"}
+			profile := &starlingxv1.HostProfileSpec{}
+			host := &v1info.HostInfo{}
+			mode, _ := getInterfaceIPv4Addressing(info, profile, host)
+			Expect(mode).To(Equal(interfaces.AddressModeDisabled))
+		})
+	})
+
+	Describe("getInterfaceIPv6Addressing", func() {
+		It("should return static when IPv6 static address exists", func() {
+			info := starlingxv1.CommonInterfaceInfo{Name: "eth0"}
+			profile := &starlingxv1.HostProfileSpec{
+				Addresses: starlingxv1.AddressList{
+					{Interface: "eth0", Address: "fd00::1", Prefix: 64},
+				},
+			}
+			host := &v1info.HostInfo{}
+			mode, pool := getInterfaceIPv6Addressing(info, profile, host)
+			Expect(mode).To(Equal(interfaces.AddressModeStatic))
+			Expect(pool).To(BeNil())
+		})
+
+		It("should return disabled when no addresses", func() {
+			info := starlingxv1.CommonInterfaceInfo{Name: "eth0"}
+			profile := &starlingxv1.HostProfileSpec{}
+			host := &v1info.HostInfo{}
+			mode, _ := getInterfaceIPv6Addressing(info, profile, host)
+			Expect(mode).To(Equal(interfaces.AddressModeDisabled))
+		})
+	})
+
+	Describe("interfaceUpdateRequired", func() {
+		Context("when name differs on ethernet interface", func() {
+			It("should return true", func() {
+				info := starlingxv1.CommonInterfaceInfo{Name: "eth0", Class: "platform"}
+				iface := &interfaces.Interface{Name: "enp0s3", Type: interfaces.IFTypeEthernet, Class: "platform"}
+				profile := &starlingxv1.HostProfileSpec{}
+				host := &v1info.HostInfo{}
+				opts, result := interfaceUpdateRequired(info, iface, profile, host)
+				Expect(result).To(BeTrue())
+				Expect(*opts.Name).To(Equal("eth0"))
+			})
+		})
+
+		Context("when name differs on virtual interface", func() {
+			It("should not rename", func() {
+				info := starlingxv1.CommonInterfaceInfo{Name: "lo2", Class: "platform"}
+				iface := &interfaces.Interface{Name: "lo", Type: interfaces.IFTypeVirtual, Class: "platform"}
+				profile := &starlingxv1.HostProfileSpec{}
+				host := &v1info.HostInfo{}
+				_, result := interfaceUpdateRequired(info, iface, profile, host)
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("when class differs", func() {
+			It("should return true", func() {
+				info := starlingxv1.CommonInterfaceInfo{Name: "eth0", Class: interfaces.IFClassData}
+				iface := &interfaces.Interface{Name: "eth0", Type: interfaces.IFTypeEthernet, Class: "platform"}
+				profile := &starlingxv1.HostProfileSpec{}
+				host := &v1info.HostInfo{}
+				opts, result := interfaceUpdateRequired(info, iface, profile, host)
+				Expect(result).To(BeTrue())
+				Expect(*opts.Class).To(Equal(interfaces.IFClassData))
+			})
+		})
+
+		Context("when MTU differs", func() {
+			It("should return true", func() {
+				mtu := 9000
+				info := starlingxv1.CommonInterfaceInfo{Name: "eth0", Class: "platform", MTU: &mtu}
+				iface := &interfaces.Interface{Name: "eth0", Type: interfaces.IFTypeEthernet, Class: "platform", MTU: 1500}
+				profile := &starlingxv1.HostProfileSpec{}
+				host := &v1info.HostInfo{}
+				opts, result := interfaceUpdateRequired(info, iface, profile, host)
+				Expect(result).To(BeTrue())
+				Expect(*opts.MTU).To(Equal(9000))
+			})
+		})
+
+		Context("when all fields match", func() {
+			It("should return false", func() {
+				info := starlingxv1.CommonInterfaceInfo{Name: "eth0", Class: "platform"}
+				iface := &interfaces.Interface{Name: "eth0", Type: interfaces.IFTypeEthernet, Class: "platform"}
+				profile := &starlingxv1.HostProfileSpec{}
+				host := &v1info.HostInfo{}
+				_, result := interfaceUpdateRequired(info, iface, profile, host)
+				Expect(result).To(BeFalse())
 			})
 		})
 	})

--- a/internal/controller/host/profile_utils_test.go
+++ b/internal/controller/host/profile_utils_test.go
@@ -1009,4 +1009,164 @@ var _ = Describe("Profile utils", func() {
 			})
 		})
 	})
+
+	Describe("validateBoardManagement", func() {
+		var reconciler *HostReconciler
+		host := &starlingxv1.Host{}
+
+		BeforeEach(func() {
+			reconciler = &HostReconciler{}
+		})
+
+		Context("when board management is nil", func() {
+			It("should return nil", func() {
+				profile := &starlingxv1.HostProfileSpec{}
+				Expect(reconciler.validateBoardManagement(host, profile)).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when type is nil", func() {
+			It("should return error", func() {
+				profile := &starlingxv1.HostProfileSpec{
+					BoardManagement: &starlingxv1.BMInfo{},
+				}
+				err := reconciler.validateBoardManagement(host, profile)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("type"))
+			})
+		})
+
+		Context("when type is none", func() {
+			It("should return nil", func() {
+				t := "none"
+				profile := &starlingxv1.HostProfileSpec{
+					BoardManagement: &starlingxv1.BMInfo{Type: &t},
+				}
+				Expect(reconciler.validateBoardManagement(host, profile)).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when credentials are nil", func() {
+			It("should return error", func() {
+				t := "bmc"
+				addr := "10.0.0.1"
+				profile := &starlingxv1.HostProfileSpec{
+					BoardManagement: &starlingxv1.BMInfo{Type: &t, Address: &addr},
+				}
+				err := reconciler.validateBoardManagement(host, profile)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("credentials"))
+			})
+		})
+
+		Context("when password is nil", func() {
+			It("should return error", func() {
+				t := "bmc"
+				addr := "10.0.0.1"
+				profile := &starlingxv1.HostProfileSpec{
+					BoardManagement: &starlingxv1.BMInfo{
+						Type:        &t,
+						Address:     &addr,
+						Credentials: &starlingxv1.BMCredentials{},
+					},
+				}
+				err := reconciler.validateBoardManagement(host, profile)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("password"))
+			})
+		})
+
+		Context("when address is nil", func() {
+			It("should return error", func() {
+				t := "bmc"
+				profile := &starlingxv1.HostProfileSpec{
+					BoardManagement: &starlingxv1.BMInfo{
+						Type: &t,
+						Credentials: &starlingxv1.BMCredentials{
+							Password: &starlingxv1.BMPasswordInfo{Secret: "bmc-secret"},
+						},
+					},
+				}
+				err := reconciler.validateBoardManagement(host, profile)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("address"))
+			})
+		})
+
+		Context("when all fields are valid", func() {
+			It("should return nil", func() {
+				t := "bmc"
+				addr := "10.0.0.1"
+				profile := &starlingxv1.HostProfileSpec{
+					BoardManagement: &starlingxv1.BMInfo{
+						Type:    &t,
+						Address: &addr,
+						Credentials: &starlingxv1.BMCredentials{
+							Password: &starlingxv1.BMPasswordInfo{Secret: "bmc-secret"},
+						},
+					},
+				}
+				Expect(reconciler.validateBoardManagement(host, profile)).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("validateProfileAddresses", func() {
+		var reconciler *HostReconciler
+		host := &starlingxv1.Host{}
+
+		BeforeEach(func() {
+			reconciler = &HostReconciler{}
+		})
+
+		Context("when addresses are valid", func() {
+			It("should return nil", func() {
+				profile := &starlingxv1.HostProfileSpec{
+					Addresses: starlingxv1.AddressList{
+						{Interface: "eth0", Address: "10.0.0.1", Prefix: 24},
+					},
+				}
+				Expect(reconciler.validateProfileAddresses(host, profile)).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when address is invalid", func() {
+			It("should return error", func() {
+				profile := &starlingxv1.HostProfileSpec{
+					Addresses: starlingxv1.AddressList{
+						{Interface: "eth0", Address: "not-an-ip", Prefix: 24},
+					},
+				}
+				err := reconciler.validateProfileAddresses(host, profile)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("not-an-ip"))
+			})
+		})
+
+		Context("when route network is invalid", func() {
+			It("should return error", func() {
+				profile := &starlingxv1.HostProfileSpec{
+					Routes: starlingxv1.RouteList{
+						{Interface: "eth0", Network: "bad-net", Prefix: 0, Gateway: "10.0.0.1"},
+					},
+				}
+				err := reconciler.validateProfileAddresses(host, profile)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("bad-net"))
+			})
+		})
+
+		Context("when route gateway is invalid", func() {
+			It("should return error", func() {
+				profile := &starlingxv1.HostProfileSpec{
+					Routes: starlingxv1.RouteList{
+						{Interface: "eth0", Network: "10.0.0.0", Prefix: 24, Gateway: "bad-gw"},
+					},
+				}
+				err := reconciler.validateProfileAddresses(host, profile)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("bad-gw"))
+			})
+		})
+	})
 })

--- a/internal/controller/host/storage_test.go
+++ b/internal/controller/host/storage_test.go
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2026 Wind River Systems, Inc. */
+package host
+
+import (
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/osds"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
+)
+
+var _ = Describe("osdUpdateRequired", func() {
+	Context("when journal is nil in spec", func() {
+		It("should return false", func() {
+			osdInfo := &starlingxv1.OSDInfo{Function: "osd", Path: "/dev/sda"}
+			osd := &osds.OSD{}
+			_, result := osdUpdateRequired(osdInfo, osd)
+			Expect(result).To(BeFalse())
+		})
+	})
+
+	Context("when journal is set and osd has no location", func() {
+		It("should return true with journal location and size", func() {
+			osdInfo := &starlingxv1.OSDInfo{
+				Function: "osd",
+				Path:     "/dev/sda",
+				Journal:  &starlingxv1.JournalInfo{Location: "/dev/sdb", Size: 1},
+			}
+			osd := &osds.OSD{}
+			opts, result := osdUpdateRequired(osdInfo, osd)
+			Expect(result).To(BeTrue())
+			Expect(*opts.JournalLocation).To(Equal("/dev/sdb"))
+			Expect(*opts.JournalSize).To(Equal(1))
+		})
+	})
+
+	Context("when journal sizes differ", func() {
+		It("should return true with updated size", func() {
+			osdInfo := &starlingxv1.OSDInfo{
+				Function: "osd",
+				Path:     "/dev/sda",
+				Journal:  &starlingxv1.JournalInfo{Location: "/dev/sdb", Size: 2},
+			}
+			loc := "/dev/sdb"
+			sizeMiB := 1024 // 1 GiB in MiB
+			osd := &osds.OSD{
+				JournalInfo: osds.JournalInfo{
+					Location: &loc,
+					Size:     &sizeMiB,
+				},
+			}
+			opts, result := osdUpdateRequired(osdInfo, osd)
+			Expect(result).To(BeTrue())
+			Expect(*opts.JournalSize).To(Equal(2))
+		})
+	})
+
+	Context("when journal sizes match", func() {
+		It("should return false", func() {
+			osdInfo := &starlingxv1.OSDInfo{
+				Function: "osd",
+				Path:     "/dev/sda",
+				Journal:  &starlingxv1.JournalInfo{Location: "/dev/sdb", Size: 1},
+			}
+			loc := "/dev/sdb"
+			sizeMiB := 1024 // 1 GiB = 1024 MiB, Gibibytes() = 1024/1024 = 1
+			osd := &osds.OSD{
+				JournalInfo: osds.JournalInfo{
+					Location: &loc,
+					Size:     &sizeMiB,
+				},
+			}
+			_, result := osdUpdateRequired(osdInfo, osd)
+			Expect(result).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
Add pure function and comparison tests across host controller, networking, memory, storage, kernel, and profile_utils packages.

- host_controller_test.go: CompareDisabledAttributes (6 tests, 72.7%), CompareEnabledAttributes (4 tests, 51.4%), FindExistingHost (2 tests, 100%)
- networking_test.go: interfaceUpdateRequired (5 tests, 57.1%), hasIPv4/IPv6 StaticAddresses (100%), hasIPv4/IPv6 DynamicAddresses (88.9%), getInterfaceIPv4/IPv6 Addressing (100%/85.7%)
- memory_test.go: rewrite with proper It blocks, add vmCountMemoryByFunction, platformCountMemoryByFunction, memoryCountByFunction, memoryUpdateRequired (all 85-100%)
- storage_test.go: osdUpdateRequired (4 tests, 100%)
- kernel_processor_test.go: GetKernelUpdateOpts (100%), GetCPUUpdateOpts (94.1%)
- profile_utils_test.go: validateBoardManagement (7 tests, 100%), validateProfileAddresses (4 tests, 100%)
- Make HostControllerAPIHandlers idempotent with sync.Once