### PR TITLE
Skip ceph filesystem reconciliation when ceph storage backend exists

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -793,6 +793,12 @@ func (db *DeploymentBuilder) buildHostsAndProfiles(d *Deployment) error {
 		// The host already has the boot MAC stored
 		profile.Spec.BootMAC = nil
 
+		// When the system has a ceph store storage backend, the ceph filesystem
+		// is managed by the backend and should not be included in the profile.
+		if hasCephStoreBackend(d) {
+			filterCephHostFS(&profile.Spec)
+		}
+
 		// Force the provisioning mode to static until there is a need to make
 		// this optional.
 		static := starlingxv1.ProvioningModeStatic
@@ -898,4 +904,33 @@ func (db *DeploymentBuilder) simplifyHostProfiles(d *Deployment) error {
 	d.Profiles = profiles
 
 	return nil
+}
+
+// hasCephStoreBackend checks whether the system has a storage backend
+// with type "ceph". When true, the "ceph" host filesystem is managed
+func hasCephStoreBackend(d *Deployment) bool {
+	if d.System.Spec.Storage == nil {
+		return false
+	}
+	for _, b := range d.System.Spec.Storage.Backends {
+		if b.Type == "ceph" {
+			return true
+		}
+	}
+	return false
+}
+
+// filterCephHostFS checks whether the system has a ceph storage
+// backend and, when true, removes the "ceph" entry from the provided profile.
+func filterCephHostFS(spec *starlingxv1.HostProfileSpec) {
+	if spec.Storage == nil || spec.Storage.FileSystems == nil {
+		return
+	}
+	filtered := make(starlingxv1.FileSystemList, 0, len(spec.Storage.FileSystems))
+	for _, fs := range spec.Storage.FileSystems {
+		if fs.Name != "ceph" {
+			filtered = append(filtered, fs)
+		}
+	}
+	spec.Storage.FileSystems = filtered
 }

--- a/build/build_suite_test.go
+++ b/build/build_suite_test.go
@@ -1104,4 +1104,94 @@ var _ = Describe("Build utilities", func() {
 			})
 		})
 	})
+
+	Describe("hasCephStoreBackend", func() {
+		Context("when system has a ceph-store backend", func() {
+			It("should return true", func() {
+				d := &Deployment{
+					System: starlingxv1.System{
+						Spec: starlingxv1.SystemSpec{
+							Storage: &starlingxv1.SystemStorageInfo{
+								Backends: starlingxv1.StorageBackendList{
+									{Name: "ceph-store", Type: "ceph"},
+								},
+							},
+						},
+					},
+				}
+				Expect(hasCephStoreBackend(d)).To(BeTrue())
+			})
+		})
+
+		Context("when system has no ceph-store backend", func() {
+			It("should return false", func() {
+				d := &Deployment{
+					System: starlingxv1.System{
+						Spec: starlingxv1.SystemSpec{
+							Storage: &starlingxv1.SystemStorageInfo{
+								Backends: starlingxv1.StorageBackendList{
+									{Name: "shared_services", Type: "external"},
+								},
+							},
+						},
+					},
+				}
+				Expect(hasCephStoreBackend(d)).To(BeFalse())
+			})
+		})
+
+		Context("when system has nil storage", func() {
+			It("should return false", func() {
+				d := &Deployment{
+					System: starlingxv1.System{
+						Spec: starlingxv1.SystemSpec{},
+					},
+				}
+				Expect(hasCephStoreBackend(d)).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("filterCephHostFS", func() {
+		Context("when profile has ceph filesystem", func() {
+			It("should remove only the ceph entry", func() {
+				spec := &starlingxv1.HostProfileSpec{
+					Storage: &starlingxv1.ProfileStorageInfo{
+						FileSystems: starlingxv1.FileSystemList{
+							{Name: "scratch", Size: 16},
+							{Name: "ceph", Size: 20},
+							{Name: "docker", Size: 30},
+						},
+					},
+				}
+				filterCephHostFS(spec)
+				Expect(spec.Storage.FileSystems).To(Equal(starlingxv1.FileSystemList{
+					{Name: "scratch", Size: 16},
+					{Name: "docker", Size: 30},
+				}))
+			})
+		})
+
+		Context("when profile has no ceph filesystem", func() {
+			It("should not modify the list", func() {
+				spec := &starlingxv1.HostProfileSpec{
+					Storage: &starlingxv1.ProfileStorageInfo{
+						FileSystems: starlingxv1.FileSystemList{
+							{Name: "scratch", Size: 16},
+						},
+					},
+				}
+				filterCephHostFS(spec)
+				Expect(spec.Storage.FileSystems).To(HaveLen(1))
+			})
+		})
+
+		Context("when storage is nil", func() {
+			It("should not panic", func() {
+				spec := &starlingxv1.HostProfileSpec{}
+				filterCephHostFS(spec)
+				Expect(spec.Storage).To(BeNil())
+			})
+		})
+	})
 })

--- a/internal/controller/host/host_controller.go
+++ b/internal/controller/host/host_controller.go
@@ -1721,6 +1721,13 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 	//  configuration.
 	profile.ProvisioningMode = nil
 
+	// When the system has a ceph-store backend, the ceph filesystem is
+	// managed by the backend itself and must not be reconciled by DM.
+	err = filterCephFileSystem(client, profile, current)
+	if err != nil {
+		return err
+	}
+
 	// N3000 interface name change apply
 	if host.IsUnlockedEnabled() {
 		logHost.Info("syncing interface name", "host", host.ID)
@@ -2015,6 +2022,53 @@ func (r *HostReconciler) ReconcileResource(
 	}
 
 	return err
+}
+
+// hasCephStoreBackend checks whether the system has a storage backend
+// with type "ceph". When true, the "ceph" host filesystem is managed
+// by the backend and must be ignored during host reconciliation.
+func hasCephStoreBackend(client *gophercloud.ServiceClient) (bool, error) {
+	result, err := storagebackends.ListBackends(client)
+	if err != nil {
+		return false, err
+	}
+	for _, sb := range result {
+		if sb.Backend == "ceph" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// filterCephFileSystem checks whether the system has a ceph storage
+// backend and, when true, removes the "ceph" entry from the provided
+// profiles so that it is not considered during comparison or reconciliation.
+func filterCephFileSystem(client *gophercloud.ServiceClient, profile *starlingxv1.HostProfileSpec, current *starlingxv1.HostProfileSpec) error {
+	hasCeph, err := hasCephStoreBackend(client)
+	if err != nil {
+		return err
+	}
+	if hasCeph {
+		removeCephFileSystem(profile)
+		removeCephFileSystem(current)
+	}
+	return nil
+}
+
+// removeCephFileSystem removes the "ceph" entry from a profile's
+// storage filesystem list so that it is not considered during
+// comparison or reconciliation.
+func removeCephFileSystem(profile *starlingxv1.HostProfileSpec) {
+	if profile == nil || profile.Storage == nil || profile.Storage.FileSystems == nil {
+		return
+	}
+	filtered := make(starlingxv1.FileSystemList, 0, len(profile.Storage.FileSystems))
+	for _, fs := range profile.Storage.FileSystems {
+		if fs.Name != "ceph" {
+			filtered = append(filtered, fs)
+		}
+	}
+	profile.Storage.FileSystems = filtered
 }
 
 // Function to obtain ceph replication factor

--- a/internal/controller/host/host_controller_test.go
+++ b/internal/controller/host/host_controller_test.go
@@ -1332,4 +1332,61 @@ var _ = Describe("Host controller", func() {
 			Expect(found).To(BeNil())
 		})
 	})
+
+	Context("when calling hasCephStoreBackend", func() {
+		It("should return true when ceph-store backend exists", func() {
+			HostControllerAPIHandlers()
+			client := gcClient.ServiceClient()
+			hasCeph, err := hasCephStoreBackend(client)
+
+			if _, ok := err.(gophercloud.ErrDefault404); ok {
+				Skip("404 error encountered, skipping")
+			}
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hasCeph).To(BeTrue())
+		})
+	})
+
+	Context("when calling removeCephFileSystem", func() {
+		It("should remove ceph filesystem from profile", func() {
+			profile := &starlingxv1.HostProfileSpec{
+				Storage: &starlingxv1.ProfileStorageInfo{
+					FileSystems: starlingxv1.FileSystemList{
+						{Name: "scratch", Size: 16},
+						{Name: "ceph", Size: 20},
+						{Name: "docker", Size: 30},
+					},
+				},
+			}
+			removeCephFileSystem(profile)
+			Expect(profile.Storage.FileSystems).To(HaveLen(2))
+			for _, fs := range profile.Storage.FileSystems {
+				Expect(fs.Name).ToNot(Equal("ceph"))
+			}
+		})
+
+		It("should not modify profile without ceph filesystem", func() {
+			profile := &starlingxv1.HostProfileSpec{
+				Storage: &starlingxv1.ProfileStorageInfo{
+					FileSystems: starlingxv1.FileSystemList{
+						{Name: "scratch", Size: 16},
+						{Name: "docker", Size: 30},
+					},
+				},
+			}
+			removeCephFileSystem(profile)
+			Expect(profile.Storage.FileSystems).To(HaveLen(2))
+		})
+
+		It("should handle nil profile safely", func() {
+			removeCephFileSystem(nil)
+		})
+
+		It("should handle nil storage safely", func() {
+			profile := &starlingxv1.HostProfileSpec{}
+			removeCephFileSystem(profile)
+			Expect(profile.Storage).To(BeNil())
+		})
+	})
 })


### PR DESCRIPTION
When the system has a storage backend with type "ceph", the ceph host filesystem is managed by the backend itself and should not be reconciled by the Deployment Manager.

In the host controller, filter the ceph filesystem from both the desired and current profile early in ReconcileExistingHost, before any comparison or reconciliation runs. This prevents false diffs and avoids unnecessary reconcile loops.

In deployctl build, exclude the ceph filesystem from generated host profiles when the system spec contains a ceph backend.

#### Test Plan:
1. PASS - DX with ceph configured and "ceph: 20" filesystem configured, dm
       should ignore and reconcile the host.
2. PASS - DX with ceph configured and not "ceph: 20" filesystem
       configured, dm should ignore and reconcile the host.
3. PASS - deployctl build with ceph backend, should ignore the ceph: 20
       filesystem.
4. PASS - deployctl build with ceph rook backend, should "ceph"
       filesystem.