### PR TITLE
Add platform TLS service parameters to DM default parameters

### DIFF
--- a/build/filter_test.go
+++ b/build/filter_test.go
@@ -438,6 +438,48 @@ var _ = Describe("Test filters utilities:", func() {
 				Expect(expectedFilteredServiceParams).To(Equal(system.Spec.ServiceParameters))
 			})
 		})
+
+		Context("when spec has platform TLS service parameters", func() {
+			It("should exclude TLS params as defaults", func() {
+				filter := &ServiceParameterFilter{}
+
+				system := &v1.System{
+					Spec: v1.SystemSpec{
+						ServiceParameters: []v1.ServiceParameterInfo{
+							{
+								Service:   utils.ServiceTypePlatform,
+								Section:   utils.ServiceParamSectionPlatformConfig,
+								ParamName: utils.ServiceParamNamePlatformTLSMinVersion,
+							},
+							{
+								Service:   utils.ServiceTypePlatform,
+								Section:   utils.ServiceParamSectionPlatformConfig,
+								ParamName: utils.ServiceParamNamePlatformTLSCipherSuite,
+							},
+							{
+								Service:   "custom",
+								Section:   "section",
+								ParamName: "param",
+							},
+						},
+					},
+				}
+
+				deployment := &Deployment{}
+
+				err := filter.Filter(system, deployment)
+				Expect(err).ToNot(HaveOccurred())
+
+				expectedFilteredServiceParams := v1.ServiceParameterList{
+					{
+						Service:   "custom",
+						Section:   "section",
+						ParamName: "param",
+					},
+				}
+				Expect(expectedFilteredServiceParams).To(Equal(system.Spec.ServiceParameters))
+			})
+		})
 	})
 
 	Describe("Test InterfaceRemoveUuidFilter", func() {

--- a/common/constants.go
+++ b/common/constants.go
@@ -27,6 +27,8 @@ const ServiceParamNamePlatformMaxCpuPercentage = "cpu_max_freq_min_percentage"
 
 const ServiceParamNamePlatConfigIntelNicDriverVersion = "intel_nic_driver_version"
 const ServiceParamNamePlatConfigIntelPstate = "intel_pstate"
+const ServiceParamNamePlatformTLSMinVersion = "tls-min-version"
+const ServiceParamNamePlatformTLSCipherSuite = "tls-cipher-suite"
 const ServiceParamNameRadosgwFsSizeMB = "fs_size_mb"
 const ServiceParamNameRadosgwServiceEnabled = "service_enabled"
 const ServiceParamNameSecurityComplianceLockoutDuration = "lockout_seconds"
@@ -103,6 +105,14 @@ var DefaultParameters = [...]ServiceParam{
 	ServiceParam{Service: ServiceTypePlatform,
 		Section:   ServiceParamSectionPlatformConfig,
 		ParamName: ServiceParamNamePlatConfigIntelPstate,
+	},
+	ServiceParam{Service: ServiceTypePlatform,
+		Section:   ServiceParamSectionPlatformConfig,
+		ParamName: ServiceParamNamePlatformTLSMinVersion,
+	},
+	ServiceParam{Service: ServiceTypePlatform,
+		Section:   ServiceParamSectionPlatformConfig,
+		ParamName: ServiceParamNamePlatformTLSCipherSuite,
 	},
 	ServiceParam{Service: ServiceTypeRadosgw,
 		Section:   ServiceParamSectionRadosgwConfig,


### PR DESCRIPTION
The Deployment Manager filters service parameters against the DefaultParameters list in common/constants.go. Parameters not in this list are excluded from system configuration snapshots and cannot be applied during subcloud deployment.

Add tls-min-version and tls-cipher-suite (platform/config) to the DefaultParameters array so DM can export, import, and reconcile platform TLS settings. Add corresponding test case in filter_test.go to verify TLS parameters are handled as defaults.

Validation of parameter values (VersionTLS12, VersionTLS13, IANA cipher names) is performed server-side by the sysinv API.

Test Plan:
PASS - DM export from system with TLS params, TLS params appear in exported YAML.
PASS - DM deploy with TLS params in system YAML, params created on target.
PASS - DM deploy without TLS params, bootstrap defaults apply. PASS - DM reconcile, TLS params not removed as non-default. PASS - go test ./build/... --ginkgo.focus="ServiceParameterFilter"