### PR TITLE
Allow address pool reconciliation for incomplete pools (#541)

### DIFF
--- a/controllers/host/host_controller.go
+++ b/controllers/host/host_controller.go
@@ -1785,6 +1785,15 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 		return common.NewUserDataError(msg)
 	}
 
+	// For non-active controller hosts, ensure the active controller has
+	// reconciled platform networks to populate any missing pool addresses
+	// before proceeding with networking configuration.
+	if !is_active_host && host.Personality == hosts.PersonalityController {
+		if err := r.ensurePoolsComplete(client, instance, reqNs); err != nil {
+			return err
+		}
+	}
+
 	logHost.Info("comparing profile attributes", "host", host.ID)
 	instance.Status.InSync = r.CompareAttributes(profile, current, instance, host.Personality, system_info)
 	common.SetInstanceDelta(instance, profile, current, common.HostProperties, r.Client.Status(), logHost)
@@ -1827,6 +1836,44 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 	}
 
 	logHost.V(2).Info("final configuration is set", "profile", current)
+
+	return nil
+}
+
+// ensurePoolsComplete checks if any address pool used by this host's platform
+// networks is missing controller addresses. If so, it directly updates the
+// pool to populate the missing address before proceeding with networking.
+// Only acts when the active controller is reconciled to avoid concurrency.
+func (r *HostReconciler) ensurePoolsComplete(client *gophercloud.ServiceClient, instance *starlingxv1.Host, namespace string) error {
+	activeHost, _, err := r.GetHostByPersonality(namespace, client, cloudManager.ActiveController)
+	if err != nil {
+		return err
+	}
+
+	if !activeHost.Status.Reconciled {
+		return nil
+	}
+
+	platformNets, _ := r.ListPlatformNetworks(namespace)
+	for _, pn := range platformNets {
+		pools, _ := r.GetAddressPoolsFromPlatformNetwork(pn.Spec.AssociatedAddressPools, namespace)
+
+		for _, pool := range pools {
+			if r.isAddrPoolIncomplete(client, pool) {
+				systemPool, err := GetSystemAddrPool(client, pool)
+				if err != nil || systemPool == nil {
+					continue
+				}
+				opts, updateRequired, uuid := r.IsAddrPoolUpdateRequired(pn, pool, systemPool)
+				if updateRequired && uuid != "" {
+					logHost.Info("populating incomplete address pool", "pool", pool.Name)
+					if err := r.CreateOrUpdateAddrPools(client, opts, uuid, pool); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
 
 	return nil
 }

--- a/controllers/host/platformnetworks.go
+++ b/controllers/host/platformnetworks.go
@@ -539,6 +539,29 @@ func (r *HostReconciler) IsReconfiguration(client *gophercloud.ServiceClient, ne
 	return nil, false
 }
 
+// isAddrPoolIncomplete returns true if the system address pool is missing
+// controller addresses that are specified in the AddressPool CR spec.
+// This handles the case where a host was deleted and re-added, causing
+// its address to be removed from the pool without triggering a re-reconcile.
+func (r *HostReconciler) isAddrPoolIncomplete(client *gophercloud.ServiceClient, addrpool_instance *starlingxv1.AddressPool) bool {
+	system_addrpool, err := GetSystemAddrPool(client, addrpool_instance)
+	if err != nil || system_addrpool == nil {
+		return false
+	}
+
+	spec := addrpool_instance.Spec
+
+	if spec.Controller1Address != nil && system_addrpool.Controller1Address == "" {
+		return true
+	}
+
+	if spec.Controller0Address != nil && system_addrpool.Controller0Address == "" {
+		return true
+	}
+
+	return false
+}
+
 // ReconcileOtherPlatformNetworksExpected returns true if the network or the address pool
 // has to be newly configured for network types other than oam / admin / mgmt.
 func (r *HostReconciler) ReconcileOtherPlatformNetworksExpected(client *gophercloud.ServiceClient,
@@ -558,6 +581,14 @@ func (r *HostReconciler) ReconcileOtherPlatformNetworksExpected(client *gophercl
 			return err, false
 		}
 		if !is_reconfig {
+			return nil, true
+		}
+
+		// Allow reconciliation when the pool exists but is missing
+		// controller addresses that are defined in the spec. This
+		// handles host delete + re-add where the address was removed
+		// from the pool without triggering a re-reconcile.
+		if r.isAddrPoolIncomplete(client, addrpool_instance) {
 			return nil, true
 		}
 	} else {


### PR DESCRIPTION
During Day-1, the Deployment Manager creates address pools with all controller addresses populated. When a controller host is deleted and re-added (Day-2), the address is removed from the pool but the AddressPool CR remains unchanged, so the addresspool reconciliation is not re-triggered. The pool is then treated as a "reconfiguration" and blocked by ReconcileOtherPlatformNetworksExpected.

This change adds a check in ReconcileOtherPlatformNetworksExpected to allow reconciliation when the system address pool is missing controller addresses that are defined in the AddressPool CR spec. This enables the Deployment Manager to repopulate the missing address after a host is re-provisioned.

Test Plan:
PASS: Deploy duplex system with DM including storage network on
      bond/VLAN. Delete controller-1 host, re-apply deployment
      config. Verify DM detects incomplete pool, updates it, and
      controller-1 reconciles successfully.
PASS: Verify that fully-configured pools are still treated as
      reconfiguration and blocked in bootstrap scope.


(cherry picked from commit 380b7ff8497b49b909b9e8eecb8dff147e8a51c0)