### PR TITLE
Fix host deletion finalizer being removed before lock completes

### DIFF
--- a/internal/controller/host/host_controller.go
+++ b/internal/controller/host/host_controller.go
@@ -2039,11 +2039,6 @@ func (r *HostReconciler) ReconcileResource(
 
 	if !instance.DeletionTimestamp.IsZero() {
 		if utils.ContainsString(instance.Finalizers, HostFinalizerName) {
-
-			// Remove the finalizer so we don't try to do this delete action again.
-			// Defer the removal of the finalizer until the end of the function
-			defer r.removeHostFinalizer(instance)
-
 			// A finalizer is still present so we need to try to delete the
 			// host from the system.
 			if host != nil {
@@ -2051,6 +2046,10 @@ func (r *HostReconciler) ReconcileResource(
 				if err != nil {
 					return err
 				}
+
+				logHost.Info("Host successfully removed")
+				// Only remove the finalizer after successful deletion
+				defer r.removeHostFinalizer(instance)
 			} else {
 				logHost.Info("host being deleted is no longer present on system")
 			}


### PR DESCRIPTION
When a host resource is deleted via kubectl, the controller issues a lock action to sysinv and starts a monitor to wait for the host to reach the locked/disabled state. However, the finalizer removal was deferred unconditionally, causing it to be removed even when the lock action returned an error (monitor wait). With the finalizer gone, Kubernetes garbage collects the Host CR before the controller can complete the deletion from sysinv.

This change moves the finalizer removal to only execute after ReconcileDeletedHost succeeds, ensuring the controller retains ownership of the CR until the host is fully locked and deleted from the system.

Test Plan:
```
PASS: Delete host controller-1 while unlocked. Verify host is locked,
      deleted from sysinv, and finalizer removed only after completion.
PASS: Verify a locked host can be deleted
PASS: Verify a failure to lock/delete does not remove the finalizer
      and retry works
PASS: Verify active controller host deletion is still skipped.
```