### PR TITLE
Apply kubernetes service parameters during reconciliation

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -5,9 +5,13 @@ package common
 
 // Service Parameter Service Types
 const ServiceTypeIdentity = "identity"
+const ServiceTypeKubernetes = "kubernetes"
 const ServiceTypePlatform = "platform"
 const ServiceTypeRadosgw = "radosgw"
 const ServiceTypeHttp = "http"
+
+// Service Parameter Sections requiring apply
+const ServiceParamSectionKubernetesApiserver = "kube_apiserver"
 
 // Service Parameter Section
 const ServiceParamSectionHttpConfig = "config"

--- a/go.mod
+++ b/go.mod
@@ -118,4 +118,4 @@ require (
 )
 
 // replace github.com/gophercloud/gophercloud => ./external/gophercloud
-replace github.com/gophercloud/gophercloud => github.com/Wind-River/gophercloud v0.0.0-20260521195204-9150f8c41415
+replace github.com/gophercloud/gophercloud => github.com/Wind-River/gophercloud v0.0.0-20260624192703-f206084b0eec

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Wind-River/gophercloud v0.0.0-20260521195204-9150f8c41415 h1:kcZziKXlL9yJKZfaIeE594IY3foR1jk4Rbg0eaK2PL8=
-github.com/Wind-River/gophercloud v0.0.0-20260521195204-9150f8c41415/go.mod h1:vVDhU9TrWNFfORJV7Tvx7UXsu/ImDlVeHhQCdrbzLEA=
+github.com/Wind-River/gophercloud v0.0.0-20260624192703-f206084b0eec h1:Xj2FBtHRhxOD5mwWf1sOcVj3SeYGytondEQhMt0WjEE=
+github.com/Wind-River/gophercloud v0.0.0-20260624192703-f206084b0eec/go.mod h1:vVDhU9TrWNFfORJV7Tvx7UXsu/ImDlVeHhQCdrbzLEA=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/internal/controller/system/system_controller.go
+++ b/internal/controller/system/system_controller.go
@@ -445,6 +445,7 @@ func (r *SystemReconciler) ReconcileServiceParameters(client *gophercloud.Servic
 		return nil
 	}
 	updated := false
+	kubeApiserverUpdated := false
 	for _, spec_sp := range spec.ServiceParameters {
 		found := false
 		for _, info_sp := range info.ServiceParameters {
@@ -460,6 +461,10 @@ func (r *SystemReconciler) ReconcileServiceParameters(client *gophercloud.Servic
 					}
 					// success
 					updated = true
+					if spec_sp.Service == utils.ServiceTypeKubernetes &&
+						spec_sp.Section == utils.ServiceParamSectionKubernetesApiserver {
+						kubeApiserverUpdated = true
+					}
 					r.NormalEvent(instance, common.ResourceUpdated, "ServiceParameter %q %q %q has been modified", result.Service, result.Section, result.ParamName)
 				}
 				break
@@ -482,6 +487,10 @@ func (r *SystemReconciler) ReconcileServiceParameters(client *gophercloud.Servic
 			}
 			// success
 			updated = true
+			if spec_sp.Service == utils.ServiceTypeKubernetes &&
+				spec_sp.Section == utils.ServiceParamSectionKubernetesApiserver {
+				kubeApiserverUpdated = true
+			}
 			r.NormalEvent(instance, common.ResourceCreated, "ServiceParameter %q %q %q has been created", result.Service, result.Section, result.ParamName)
 		}
 	}
@@ -540,7 +549,42 @@ func (r *SystemReconciler) ReconcileServiceParameters(client *gophercloud.Servic
 		}
 	}
 
+	// Apply service parameters for services that require an explicit apply
+	// to take effect. Kubernetes kube_apiserver parameters are not consumed
+	// by puppet classes during unlock; they require service-parameter-apply
+	// to trigger the change_k8s_control_plane_params.py script.
+	//
+	// The apply is only issued when both conditions are met:
+	// 1. The user's deployment configuration explicitly contains
+	//    kubernetes/kube_apiserver service parameters (not inherited from
+	//    system defaults via the merge).
+	// 2. A kubernetes/kube_apiserver parameter was actually created or
+	//    updated during this reconciliation cycle.
+	if kubeApiserverUpdated && kubernetesServiceParametersInSpec(&instance.Spec) {
+		service := utils.ServiceTypeKubernetes
+		opts := serviceparameters.ServiceApplyOpts{
+			Service: &service,
+		}
+		if err := serviceparameters.Apply(client, opts).Err; err != nil {
+			return err
+		}
+		r.NormalEvent(instance, common.ResourceUpdated, "ServiceParameters have been applied for service %q", service)
+	}
+
 	return nil
+}
+
+// kubernetesServiceParametersInSpec returns true if the user's deployment
+// configuration explicitly contains kubernetes/kube_apiserver service
+// parameters that require an explicit apply.
+func kubernetesServiceParametersInSpec(spec *starlingxv1.SystemSpec) bool {
+	for _, sp := range spec.ServiceParameters {
+		if sp.Service == utils.ServiceTypeKubernetes &&
+			sp.Section == utils.ServiceParamSectionKubernetesApiserver {
+			return true
+		}
+	}
+	return false
 }
 
 func ControllerNodesAvailable(objects []hosts.Host, required int) bool {

--- a/internal/controller/system/system_controller_test.go
+++ b/internal/controller/system/system_controller_test.go
@@ -659,6 +659,85 @@ var _ = Describe("System controller", func() {
 		})
 	})
 
+	Describe("kubernetesServiceParametersInSpec", func() {
+		Context("when spec contains kubernetes/kube_apiserver parameters", func() {
+			It("should return true", func() {
+				spec := &starlingxv1.SystemSpec{
+					ServiceParameters: []starlingxv1.ServiceParameterInfo{
+						{
+							Service:    "kubernetes",
+							Section:    "kube_apiserver",
+							ParamName:  "tls-min-version",
+							ParamValue: "VersionTLS13",
+						},
+					},
+				}
+				Expect(kubernetesServiceParametersInSpec(spec)).To(BeTrue())
+			})
+		})
+
+		Context("when spec contains mixed parameters including kubernetes", func() {
+			It("should return true", func() {
+				spec := &starlingxv1.SystemSpec{
+					ServiceParameters: []starlingxv1.ServiceParameterInfo{
+						{
+							Service:    "platform",
+							Section:    "maintenance",
+							ParamName:  "worker_boot_timeout",
+							ParamValue: "720",
+						},
+						{
+							Service:    "kubernetes",
+							Section:    "kube_apiserver",
+							ParamName:  "tls-cipher-suites",
+							ParamValue: "TLS_AES_256_GCM_SHA384",
+						},
+					},
+				}
+				Expect(kubernetesServiceParametersInSpec(spec)).To(BeTrue())
+			})
+		})
+
+		Context("when spec contains no kubernetes/kube_apiserver parameters", func() {
+			It("should return false", func() {
+				spec := &starlingxv1.SystemSpec{
+					ServiceParameters: []starlingxv1.ServiceParameterInfo{
+						{
+							Service:    "platform",
+							Section:    "maintenance",
+							ParamName:  "worker_boot_timeout",
+							ParamValue: "720",
+						},
+					},
+				}
+				Expect(kubernetesServiceParametersInSpec(spec)).To(BeFalse())
+			})
+		})
+
+		Context("when spec contains kubernetes but different section", func() {
+			It("should return false", func() {
+				spec := &starlingxv1.SystemSpec{
+					ServiceParameters: []starlingxv1.ServiceParameterInfo{
+						{
+							Service:    "kubernetes",
+							Section:    "kube_controller_manager",
+							ParamName:  "some-param",
+							ParamValue: "some-value",
+						},
+					},
+				}
+				Expect(kubernetesServiceParametersInSpec(spec)).To(BeFalse())
+			})
+		})
+
+		Context("when spec has no service parameters", func() {
+			It("should return false", func() {
+				spec := &starlingxv1.SystemSpec{}
+				Expect(kubernetesServiceParametersInSpec(spec)).To(BeFalse())
+			})
+		})
+	})
+
 	Describe("FillOptionalMergedSystemSpec", func() {
 		Context("when a ceph backend has no network", func() {
 			It("should fill the default mgmt network", func() {


### PR DESCRIPTION
DM creates kubernetes/kube_apiserver service parameters in the sysinv database but never issues the service-parameter-apply API call. Unlike most service parameters that are consumed by puppet classes during host unlock, kube_apiserver parameters are only applied by the change_k8s_control_plane_params.py script, which is exclusively triggered via the service-parameter-apply API.

This results in the parameters being stored in the database while kube-apiserver continues running with default settings.

Issue the service-parameter-apply for the kubernetes service when kube_apiserver parameters are present in the deployment configuration. Update the gophercloud dependency to fix the Apply function which incorrectly expected HTTP 204 and attempted to decode an empty response body.

Test Plan:
```
PASS: Deploy subcloud with kubernetes/kube_apiserver service
      parameters (tls-min-version, tls-cipher-suites). Verify
      kube-apiserver static pod manifest reflects the configured
      values after deployment completes.
PASS: Deploy system without kubernetes service parameters. Verify
      no apply is issued and reconciliation completes normally.
PASS: Deploy dc system controller with kubernetes service parameters
      applied beforehand during bootstrap. Verify no apply is issued
      and reconciliation completes normally.
```