### PR TITLE
Add a new comparison step for volume groups

### DIFF
--- a/internal/controller/host/host_controller.go
+++ b/internal/controller/host/host_controller.go
@@ -1031,6 +1031,16 @@ func (r *HostReconciler) CompareEnabledAttributes(in *starlingxv1.HostProfileSpe
 		}
 	}
 
+	if utils.IsReconcilerEnabled(utils.VolumeGroup) {
+		if (in.Storage == nil) != (other.Storage == nil) {
+			return false
+		} else if in.Storage != nil {
+			if !in.Storage.VolumeGroups.DeepEqual(&other.Storage.VolumeGroups) {
+				return false
+			}
+		}
+	}
+
 	if utils.IsReconcilerEnabled(utils.Route) {
 		if !in.Routes.DeepEqual(&other.Routes) {
 			return false


### PR DESCRIPTION
To enable the system to compare and apply volume group changes, a new step has been added to the comparison process. This step will check for any differences in volume group configurations and ensure that they are properly handled during the comparison and application of changes.

This new step is crucial for day-2 operations.

TEST PLAN:
PASS: successfully compared volume groups with no changes PASS: successfully compared volume groups with changes PASS: successfully applied volume group changes in disabled and/or
      enabled node.
PASS: 'go vet ./... && go test ./...'

Closes: #550