### PR TITLE
Fix deployctl to only export ovsAccess when conditions are met

### DIFF
--- a/api/v1/constructors.go
+++ b/api/v1/constructors.go
@@ -378,7 +378,12 @@ func parseInterfaceInfo(profile *HostProfileSpec, host v1info.HostInfo) error {
 				ethernet.VFDriver = iface.VFDriver
 			}
 
-			ethernet.OVSAccess = iface.OVSAccess
+			if iface.OVSAccess != nil && *iface.OVSAccess && len(iface.Uses) > 0 {
+				lowerIface, found := host.FindInterfaceByName(iface.Uses[0])
+				if found && strings.EqualFold(lowerIface.Class, interfaces.IFClassPCISRIOV) {
+					ethernet.OVSAccess = iface.OVSAccess
+				}
+			}
 
 			ethernets = append(ethernets, ethernet)
 


### PR DESCRIPTION
The parseInterfaceInfo constructor unconditionally assigns the ovs_access field from the system API to the generated deployment configuration. This causes deployctl to export ovsAccess for all ethernet interfaces regardless of whether the required conditions are satisfied, producing invalid configurations that would fail webhook validation when re-applied.

Add conditional logic to only export ovsAccess when the interface meets the required constraints:
- The interface has ovs_access enabled (true)
- The interface has a lower interface configured
- The lower interface is of class pci-sriov

This ensures the generated deployment configuration only contains ovsAccess on interfaces where it is valid, matching the webhook validation rules.

Test Plan:
```
PASS: deployctl build generates config without ovsAccess for
      ethernet interfaces that lack a pci-sriov lower interface
PASS: deployctl build correctly exports ovsAccess=true for
      ethernet interfaces with a pci-sriov lower interface
```