### PR TITLE
add standard/portworx-labels host-label examples

### DIFF
--- a/examples/standard/portworx-labels/README.md
+++ b/examples/standard/portworx-labels/README.md
@@ -1,0 +1,53 @@
+# Portworx Host Labels Example
+
+This example demonstrates how to use Deployment Manager `HostProfile` labels
+to declaratively assign Portworx placement labels on a Standard system with
+mixed worker roles (storage, storageless, and pure compute).
+
+## Label Strategy
+
+Two labels control Portworx node placement:
+
+| Label | Purpose |
+|---|---|
+| `portworx.io/px-node: "true"` | Shared gate — KMM loads `px.ko` on any node with this label |
+| `portworx.io/node-type: "storage"` or `"storageless"` | Selects whether the node contributes disks to the PX cluster |
+
+## Profiles
+
+| Profile | Labels | Role |
+|---|---|---|
+| `px-storage-worker-profile` | `px-node=true`, `node-type=storage` | Portworx storage node |
+| `px-storageless-worker-profile` | `px-node=true`, `node-type=storageless` | Portworx storageless (compute-only) node |
+| `worker-profile` | *(none)* | Pure compute — no Portworx |
+
+## How It Works
+
+1. Labels are declared in `HostProfile.spec.labels`
+2. DM applies them as StarlingX sysinv host-labels during reconcile
+3. StarlingX propagates host-labels to Kubernetes node labels
+4. KMM `Module` selector matches `portworx.io/px-node: "true"` and loads `px.ko`
+5. Portworx `StorageCluster` uses `node-type` to assign storage vs storageless role
+
+No imperative `system host-label-assign` or `kubectl label node` commands needed.
+
+## Usage
+
+1. Replace `CONTROLLER0MAC`, `WORKER0MAC`, etc. with actual boot MAC addresses
+2. Replace `CHANGEME_BASE64_ENCODED` with your base64-encoded admin password
+3. Adjust `bootDevice`/`rootDevice` paths and interface port names for your hardware
+4. Apply:
+
+```bash
+kubectl apply -k .
+```
+
+## Notes
+
+- Author all labels in the HostProfile **before** the host first reconciles.
+  DM applies the full label set on initial reconcile.
+- If a label is removed out-of-band, DM detects `INSYNC=false` and re-applies
+  the declared state automatically.
+- KMM's `Module.spec.selector` uses a plain label map (AND logic). A single
+  shared `px-node=true` gate covers both storage and storageless nodes; the
+  `node-type` label is consumed separately by the Portworx StorageCluster spec.

--- a/examples/standard/portworx-labels/README.md
+++ b/examples/standard/portworx-labels/README.md
@@ -41,13 +41,3 @@ No imperative `system host-label-assign` or `kubectl label node` commands needed
 ```bash
 kubectl apply -k .
 ```
-
-## Notes
-
-- Author all labels in the HostProfile **before** the host first reconciles.
-  DM applies the full label set on initial reconcile.
-- If a label is removed out-of-band, DM detects `INSYNC=false` and re-applies
-  the declared state automatically.
-- KMM's `Module.spec.selector` uses a plain label map (AND logic). A single
-  shared `px-node=true` gate covers both storage and storageless nodes; the
-  `node-type` label is consumed separately by the Portworx StorageCluster spec.

--- a/examples/standard/portworx-labels/config.yaml
+++ b/examples/standard/portworx-labels/config.yaml
@@ -279,7 +279,7 @@ spec:
       port:
         name: enp3s0
   labels:
-    portworx.io/px-node: "true"
+    px-node: "true"
     portworx.io/node-type: "storage"
   memory:
   - functions:
@@ -381,7 +381,7 @@ spec:
       port:
         name: enp2s2
   labels:
-    portworx.io/px-node: "true"
+    px-node: "true"
     portworx.io/node-type: "storageless"
   memory:
   - functions:

--- a/examples/standard/portworx-labels/config.yaml
+++ b/examples/standard/portworx-labels/config.yaml
@@ -1,0 +1,460 @@
+# Replace placeholders before applying:
+#   CONTROLLER0MAC, CONTROLLER1MAC, WORKER0MAC, WORKER1MAC, WORKER2MAC, WORKER3MAC, WORKER4MAC
+#   CHANGEME_BASE64 (base64-encoded admin password)
+#   OS_REGION_NAME value (from: system show | grep region_name)
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: deployment
+spec: {}
+---
+apiVersion: v1
+data:
+  OS_PASSWORD: CHANGEME_BASE64
+  OS_USERNAME: YWRtaW4=
+kind: Secret
+metadata:
+  name: system-endpoint
+  namespace: deployment
+stringData:
+  OS_AUTH_URL: http://192.168.204.1:5000/v3
+  OS_INTERFACE: internal
+  OS_PROJECT_DOMAIN_NAME: Default
+  OS_PROJECT_NAME: admin
+  OS_REGION_NAME: CHANGEME_REGION_UUID
+type: Opaque
+---
+apiVersion: starlingx.windriver.com/v1
+kind: System
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-0
+  namespace: deployment
+spec:
+  dnsServers:
+  - 8.8.8.8
+  - 8.8.4.4
+  ptp:
+    mechanism: e2e
+    mode: hardware
+    transport: l2
+  storage:
+    filesystems:
+    - name: database
+      size: 10
+  vswitchType: none
+---
+apiVersion: starlingx.windriver.com/v1
+kind: HostProfile
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-0-profile
+  namespace: deployment
+spec:
+  administrativeState: unlocked
+  appArmor: disabled
+  boardManagement:
+    type: none
+  bootDevice: /dev/disk/by-path/pci-0000:00:1f.2-ata-1.0
+  clockSynchronization: ntp
+  console: ttyS0,115200
+  hwSettle: "0"
+  installOutput: graphical
+  interfaces:
+    ethernet:
+    - class: platform
+      dataNetworks: []
+      maxRxRate: 0
+      maxTxRate: 0
+      name: oam0
+      platformNetworks:
+      - oam
+      port:
+        name: enp2s1
+      ptpInterfaces: []
+      ptpRole: none
+      uuid: ""
+    - class: platform
+      dataNetworks: []
+      maxRxRate: 0
+      maxTxRate: 0
+      mtu: 1400
+      name: mgmt0
+      platformNetworks:
+      - mgmt
+      - cluster-host
+      port:
+        name: enp2s2
+      ptpInterfaces: []
+      ptpRole: none
+      uuid: ""
+  memory:
+  - functions:
+    - function: platform
+      pageCount: 2048000
+      pageSize: 4KB
+    node: 0
+  personality: controller
+  powerOn: true
+  provisioningMode: static
+  rootDevice: /dev/disk/by-path/pci-0000:00:1f.2-ata-1.0
+  storage:
+    filesystems:
+    - name: scratch
+      size: 16
+    - name: backup
+      size: 25
+    - name: docker
+      size: 40
+    - name: kubelet
+      size: 10
+    - name: log
+      size: 8
+    - name: var
+      size: 20
+    - name: root
+      size: 20
+    volumeGroups:
+    - name: cgts-vg
+      physicalVolumes:
+      - path: /dev/disk/by-path/pci-0000:00:1f.2-ata-1.0
+        size: 218
+        type: partition
+  subfunctions:
+  - controller
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-0
+  namespace: deployment
+spec:
+  match:
+    bootMAC: CONTROLLER0MAC
+  overrides:
+    interfaces:
+      ethernet:
+      - class: none
+        dataNetworks: []
+        maxRxRate: 0
+        maxTxRate: 0
+        mtu: 1500
+        name: lo
+        platformNetworks: []
+        port:
+          name: lo
+        ptpInterfaces: []
+        ptpRole: none
+        uuid: ""
+    provisioningMode: dynamic
+  profile: controller-0-profile
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: controller-1
+  namespace: deployment
+spec:
+  match:
+    bootMAC: CONTROLLER1MAC
+  overrides:
+    provisioningMode: dynamic
+  profile: controller-0-profile
+---
+# Plain worker profile — no Portworx labels (pure compute).
+# Workers bound to this profile will NOT run Portworx pods or load px.ko.
+apiVersion: starlingx.windriver.com/v1
+kind: HostProfile
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: worker-profile
+  namespace: deployment
+spec:
+  administrativeState: unlocked
+  appArmor: disabled
+  boardManagement:
+    type: none
+  bootDevice: /dev/disk/by-path/pci-0000:00:1f.2-ata-1.0
+  clockSynchronization: ntp
+  console: ttyS0,115200
+  hwSettle: "0"
+  installOutput: graphical
+  interfaces:
+    ethernet:
+    - class: platform
+      dataNetworks: []
+      maxRxRate: 0
+      maxTxRate: 0
+      name: mgmt0
+      platformNetworks:
+      - mgmt
+      port:
+        name: enp2s2
+      ptpInterfaces: []
+      ptpRole: none
+      uuid: ""
+    - class: platform
+      dataNetworks: []
+      maxRxRate: 0
+      maxTxRate: 0
+      name: cluster0
+      platformNetworks:
+      - cluster-host
+      port:
+        name: enp3s0
+      ptpInterfaces: []
+      ptpRole: none
+      uuid: ""
+  memory:
+  - functions:
+    - function: platform
+      pageCount: 512000
+      pageSize: 4KB
+    node: 0
+  personality: worker
+  powerOn: true
+  provisioningMode: static
+  rootDevice: /dev/disk/by-path/pci-0000:00:1f.2-ata-1.0
+  storage:
+    filesystems:
+    - name: scratch
+      size: 16
+    - name: docker
+      size: 40
+    - name: kubelet
+      size: 10
+    - name: log
+      size: 8
+    - name: var
+      size: 20
+    - name: root
+      size: 20
+    volumeGroups:
+    - name: cgts-vg
+      physicalVolumes:
+      - path: /dev/disk/by-path/pci-0000:00:1f.2-ata-1.0
+        size: 218
+        type: partition
+  subfunctions:
+  - worker
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: worker-0
+  namespace: deployment
+spec:
+  match:
+    bootMAC: WORKER0MAC
+  overrides:
+    provisioningMode: dynamic
+  profile: px-storageless-worker-profile
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: worker-1
+  namespace: deployment
+spec:
+  match:
+    bootMAC: WORKER1MAC
+  overrides:
+    provisioningMode: dynamic
+  profile: worker-profile
+---
+# Portworx storage worker profile — carries both placement labels.
+# Workers bound to this profile will have px.ko loaded by KMM and
+# join the Portworx cluster as storage nodes contributing local disks.
+apiVersion: starlingx.windriver.com/v1
+kind: HostProfile
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: px-storage-worker-profile
+  namespace: deployment
+spec:
+  administrativeState: unlocked
+  appArmor: disabled
+  boardManagement:
+    type: none
+  bootDevice: /dev/disk/by-path/pci-0000:00:1f.2-ata-1.0
+  clockSynchronization: ntp
+  console: ttyS0,115200
+  hwSettle: "0"
+  installOutput: graphical
+  interfaces:
+    ethernet:
+    - class: platform
+      dataNetworks: []
+      maxRxRate: 0
+      maxTxRate: 0
+      mtu: 1400
+      name: mgmt0
+      platformNetworks:
+      - mgmt
+      port:
+        name: enp2s2
+      ptpInterfaces: []
+      ptpRole: none
+      uuid: ""
+    - class: platform
+      dataNetworks: []
+      maxRxRate: 0
+      maxTxRate: 0
+      name: cluster0
+      platformNetworks:
+      - cluster-host
+      port:
+        name: enp3s0
+      ptpInterfaces: []
+      ptpRole: none
+      uuid: ""
+  labels:
+    portworx.io/px-node: "true"
+    portworx.io/node-type: "storage"
+  memory:
+  - functions:
+    - function: platform
+      pageCount: 640000
+      pageSize: 4KB
+    node: 0
+  personality: worker
+  powerOn: true
+  provisioningMode: static
+  rootDevice: /dev/disk/by-path/pci-0000:00:1f.2-ata-1.0
+  storage:
+    filesystems:
+    - name: scratch
+      size: 16
+    - name: docker
+      size: 40
+    - name: kubelet
+      size: 10
+    - name: log
+      size: 8
+    - name: var
+      size: 20
+    - name: root
+      size: 20
+  subfunctions:
+  - worker
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: worker-2
+  namespace: deployment
+spec:
+  match:
+    bootMAC: WORKER2MAC
+  overrides:
+    provisioningMode: dynamic
+  profile: px-storage-worker-profile
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: worker-3
+  namespace: deployment
+spec:
+  match:
+    bootMAC: WORKER3MAC
+  overrides:
+    provisioningMode: dynamic
+  profile: px-storage-worker-profile
+---
+apiVersion: starlingx.windriver.com/v1
+kind: Host
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: worker-4
+  namespace: deployment
+spec:
+  match:
+    bootMAC: WORKER4MAC
+  overrides:
+    provisioningMode: dynamic
+  profile: px-storage-worker-profile
+---
+# Portworx storageless worker profile — carries both placement labels.
+# Workers bound to this profile will have px.ko loaded by KMM and
+# join the Portworx cluster as storageless (compute-only) nodes.
+apiVersion: starlingx.windriver.com/v1
+kind: HostProfile
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: px-storageless-worker-profile
+  namespace: deployment
+spec:
+  administrativeState: unlocked
+  appArmor: disabled
+  boardManagement:
+    type: none
+  bootDevice: /dev/disk/by-path/pci-0000:00:1f.2-ata-1.0
+  clockSynchronization: ntp
+  console: ttyS0,115200
+  hwSettle: "0"
+  installOutput: graphical
+  interfaces:
+    ethernet:
+    - class: platform
+      dataNetworks: []
+      maxRxRate: 0
+      maxTxRate: 0
+      mtu: 1400
+      name: mgmt0
+      platformNetworks:
+      - mgmt
+      - cluster-host
+      port:
+        name: enp2s2
+      ptpInterfaces: []
+      ptpRole: none
+      uuid: ""
+  labels:
+    portworx.io/px-node: "true"
+    portworx.io/node-type: "storageless"
+  memory:
+  - functions:
+    - function: platform
+      pageCount: 640000
+      pageSize: 4KB
+    node: 0
+  personality: worker
+  powerOn: true
+  provisioningMode: static
+  rootDevice: /dev/disk/by-path/pci-0000:00:1f.2-ata-1.0
+  storage:
+    filesystems:
+    - name: scratch
+      size: 16
+    - name: docker
+      size: 40
+    - name: kubelet
+      size: 10
+    - name: log
+      size: 8
+    - name: var
+      size: 20
+    - name: root
+      size: 20
+  subfunctions:
+  - worker

--- a/examples/standard/portworx-labels/config.yaml
+++ b/examples/standard/portworx-labels/config.yaml
@@ -130,7 +130,6 @@ spec:
       - class: none
         mtu: 1500
         name: lo
-        platformNetworks: []
         port:
           name: lo
     provisioningMode: dynamic

--- a/examples/standard/portworx-labels/config.yaml
+++ b/examples/standard/portworx-labels/config.yaml
@@ -66,21 +66,12 @@ spec:
   interfaces:
     ethernet:
     - class: platform
-      dataNetworks: []
-      maxRxRate: 0
-      maxTxRate: 0
       name: oam0
       platformNetworks:
       - oam
       port:
         name: enp2s1
-      ptpInterfaces: []
-      ptpRole: none
-      uuid: ""
     - class: platform
-      dataNetworks: []
-      maxRxRate: 0
-      maxTxRate: 0
       mtu: 1400
       name: mgmt0
       platformNetworks:
@@ -88,9 +79,6 @@ spec:
       - cluster-host
       port:
         name: enp2s2
-      ptpInterfaces: []
-      ptpRole: none
-      uuid: ""
   memory:
   - functions:
     - function: platform
@@ -140,17 +128,11 @@ spec:
     interfaces:
       ethernet:
       - class: none
-        dataNetworks: []
-        maxRxRate: 0
-        maxTxRate: 0
         mtu: 1500
         name: lo
         platformNetworks: []
         port:
           name: lo
-        ptpInterfaces: []
-        ptpRole: none
-        uuid: ""
     provisioningMode: dynamic
   profile: controller-0-profile
 ---
@@ -190,29 +172,17 @@ spec:
   interfaces:
     ethernet:
     - class: platform
-      dataNetworks: []
-      maxRxRate: 0
-      maxTxRate: 0
       name: mgmt0
       platformNetworks:
       - mgmt
       port:
         name: enp2s2
-      ptpInterfaces: []
-      ptpRole: none
-      uuid: ""
     - class: platform
-      dataNetworks: []
-      maxRxRate: 0
-      maxTxRate: 0
       name: cluster0
       platformNetworks:
       - cluster-host
       port:
         name: enp3s0
-      ptpInterfaces: []
-      ptpRole: none
-      uuid: ""
   memory:
   - functions:
     - function: platform
@@ -297,30 +267,18 @@ spec:
   interfaces:
     ethernet:
     - class: platform
-      dataNetworks: []
-      maxRxRate: 0
-      maxTxRate: 0
       mtu: 1400
       name: mgmt0
       platformNetworks:
       - mgmt
       port:
         name: enp2s2
-      ptpInterfaces: []
-      ptpRole: none
-      uuid: ""
     - class: platform
-      dataNetworks: []
-      maxRxRate: 0
-      maxTxRate: 0
       name: cluster0
       platformNetworks:
       - cluster-host
       port:
         name: enp3s0
-      ptpInterfaces: []
-      ptpRole: none
-      uuid: ""
   labels:
     portworx.io/px-node: "true"
     portworx.io/node-type: "storage"
@@ -416,9 +374,6 @@ spec:
   interfaces:
     ethernet:
     - class: platform
-      dataNetworks: []
-      maxRxRate: 0
-      maxTxRate: 0
       mtu: 1400
       name: mgmt0
       platformNetworks:
@@ -426,9 +381,6 @@ spec:
       - cluster-host
       port:
         name: enp2s2
-      ptpInterfaces: []
-      ptpRole: none
-      uuid: ""
   labels:
     portworx.io/px-node: "true"
     portworx.io/node-type: "storageless"

--- a/examples/standard/portworx-labels/kustomization.yaml
+++ b/examples/standard/portworx-labels/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- config.yaml


### PR DESCRIPTION
This change adds a new Deployment Manager example configuration demonstrating
declarative Portworx node-placement labels via HostProfile on a Standard 2+5
system with mixed worker roles (storage, storageless, and pure compute).

The example uses HostProfile.spec.labels to assign two Portworx-consumed labels:

  - px-node: "true"                                    — shared gate for KMM px-fuse module loading
  - portworx.io/node-type: "storage" | "storageless"   — PX storage role selector

Three worker profiles are defined:
  - px-storage-worker-profile (3 workers, inherits from worker-profile, adds PX labels)
  - px-storageless-worker-profile (1 worker, inherits from worker-profile, adds PX labels)
  - worker-profile (1 pure-compute worker, no Portworx)

This is a standalone example (not a Kustomize overlay on standard/default)
because it targets dynamically provisioned hosts via spec.match.bootMAC,
whereas the default base uses static provisioning via spec.overrides.bootMAC.

Files added:
  - examples/standard/portworx-labels/config.yaml
  - examples/standard/portworx-labels/kustomization.yaml
  - examples/standard/portworx-labels/README.md

Signed-off-by: Aditya Kumar <aditya.kumar@windriver.com>