### PR TITLE
Defer CGTS-VG configuration during Day-1 operation

### DIFF
--- a/api/v1/constructors.go
+++ b/api/v1/constructors.go
@@ -518,7 +518,7 @@ func parsePhysicalVolumeInfo(group *VolumeGroupInfo, vg *volumegroups.VolumeGrou
 			if partition, ok := host.FindPartition(pv.DeviceUUID); ok {
 				size := partition.Gibibytes()
 				physicalVolume.Size = &size
-				physicalVolume.Path = stripPartitionNumber(partition.DevicePath)
+				physicalVolume.Path = partition.DevicePath
 			} else {
 				msg := fmt.Sprintf("failed to lookup partition %s", pv.DeviceUUID)
 				return NewMissingSystemResource(msg)

--- a/internal/controller/common/common.go
+++ b/internal/controller/common/common.go
@@ -157,6 +157,9 @@ const ParentFound = "parent_found"
 // Constant for standard volume group
 const LVG_CGTS_VG = "cgts-vg"
 
+// LVMFunctionNone represents a volume group with no active LVM function.
+const LVMFunctionNone = "none"
+
 // Common event record reasons
 const (
 	ResourceCreated    = "Created"

--- a/internal/controller/host/host_controller.go
+++ b/internal/controller/host/host_controller.go
@@ -1791,6 +1791,25 @@ func (r *HostReconciler) ReconcileExistingHost(client *gophercloud.ServiceClient
 		return err
 	}
 
+	// Normalize volume group fields so that system-calculated lvmType and
+	// lvmPoolSize do not produce false deltas when not explicitly set by the user.
+	//
+	// This method only acts on volume group section (for lvm-csi purpose), as
+	// followed:
+	//   if one, or more, optional key is omitted by user on user profile and
+	//   the deployment manager detects the presence of a system calculated value,
+	//   the method will copy the value to the user profile, avoiding an
+	//   indesired delta and a cyclic reconciliation loop.
+	//   i.e.
+	//   volumeGroups:
+	//     - name: "cgts-vg"
+	//       lvmFunction: "lvm-csi"
+	//       <....>
+	//   System will configure the thin pool with 50% of the free space and the
+	//   default profile will detects this change. The thin pool size will be
+	//   copied to the user profile.
+	NormalizeVolumeGroupsForComparison(profile, current)
+
 	// N3000 interface name change apply
 	if host.IsUnlockedEnabled() {
 		logHost.Info("syncing interface name", "host", host.ID)

--- a/internal/controller/host/profile_utils.go
+++ b/internal/controller/host/profile_utils.go
@@ -42,17 +42,30 @@ func MergeProfiles(a, b *starlingxv1.HostProfileSpec) (*starlingxv1.HostProfileS
 	return a, nil
 }
 
-// MergeVolumeGroups keeps only VGs defined in the source profile (b),
-// using b as the source of truth.
+// MergeVolumeGroups uses b (user profile) as source of truth for which VGs
+// should exist. VGs in b that match by name in a (defaults) get their nil
+// fields filled from defaults. VGs in b with no match in a are new and
+// included as-is (to be created on the system).
 func MergeVolumeGroups(a, b *starlingxv1.ProfileStorageInfo) starlingxv1.VolumeGroupList {
 	filtered := make(starlingxv1.VolumeGroupList, 0, len(b.VolumeGroups))
 	for _, srcVG := range b.VolumeGroups {
 		for _, vg := range a.VolumeGroups {
 			if vg.Name == srcVG.Name {
-				filtered = append(filtered, srcVG)
+				if srcVG.LVMFunction == nil && vg.LVMFunction != nil {
+					srcVG.LVMFunction = vg.LVMFunction
+				}
+				if srcVG.LVMFunction != nil && *srcVG.LVMFunction != common.LVMFunctionNone {
+					if srcVG.LVMType == nil && vg.LVMType != nil {
+						srcVG.LVMType = vg.LVMType
+					}
+					if srcVG.LVMPoolSize == nil && vg.LVMPoolSize != nil {
+						srcVG.LVMPoolSize = vg.LVMPoolSize
+					}
+				}
 				break
 			}
 		}
+		filtered = append(filtered, srcVG)
 	}
 	return filtered
 }
@@ -159,6 +172,62 @@ func FixVolumeGroupPath(a *starlingxv1.HostProfileSpec, hostInfo *v1info.HostInf
 		result = append(result, vgInfo)
 	}
 	a.Storage.VolumeGroups = result
+}
+
+// NormalizeVolumeGroupsForComparison adjusts the profile and current VG lists
+// so that system-calculated fields (lvmType, lvmPoolSize) do not produce
+// false deltas during comparison.
+// During the configuration the user can omit lvmPoolSize or other keys, by
+// adding the keys in user profile DM will avoid false deltas.
+func NormalizeVolumeGroupsForComparison(profile, current *starlingxv1.HostProfileSpec) {
+	if profile == nil || current == nil {
+		return
+	}
+	if profile.Storage == nil || current.Storage == nil {
+		return
+	}
+
+	currentVGMap := make(map[string]*starlingxv1.VolumeGroupInfo, len(current.Storage.VolumeGroups))
+	for i := range current.Storage.VolumeGroups {
+		vg := &current.Storage.VolumeGroups[i]
+		currentVGMap[vg.Name] = vg
+	}
+
+	for i := range profile.Storage.VolumeGroups {
+		profileVG := &profile.Storage.VolumeGroups[i]
+		currentVG, found := currentVGMap[profileVG.Name]
+		if !found {
+			continue
+		}
+		normalizeVolumeGroup(profileVG, currentVG)
+	}
+}
+
+// normalizeVolumeGroup adjusts a single profile/current VG pair so that
+// system-calculated fields do not produce false deltas.
+func normalizeVolumeGroup(profileVG, currentVG *starlingxv1.VolumeGroupInfo) {
+	hasActiveFunction := profileVG.LVMFunction != nil && *profileVG.LVMFunction != common.LVMFunctionNone
+
+	if hasActiveFunction {
+		defaultFromCurrent(&profileVG.LVMType, currentVG.LVMType)
+		defaultFromCurrent(&profileVG.LVMPoolSize, currentVG.LVMPoolSize)
+	} else {
+		currentVG.LVMType = nil
+		currentVG.LVMPoolSize = nil
+	}
+
+	if profileVG.Name == common.LVG_CGTS_VG {
+		defaultFromCurrent(&profileVG.LVMType, currentVG.LVMType)
+		defaultFromCurrent(&profileVG.LVMPoolSize, currentVG.LVMPoolSize)
+		defaultFromCurrent(&profileVG.LVMFunction, currentVG.LVMFunction)
+	}
+}
+
+// defaultFromCurrent sets *dst to src when *dst is nil and src is non-nil.
+func defaultFromCurrent[T any](dst **T, src *T) {
+	if *dst == nil && src != nil {
+		*dst = src
+	}
 }
 
 // FixPhysicalVolumesPath is to fix device path in the profile's physical volume spec

--- a/internal/controller/host/profile_utils_test.go
+++ b/internal/controller/host/profile_utils_test.go
@@ -10,8 +10,12 @@ import (
 	"reflect"
 
 	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
+	"github.com/wind-river/cloud-platform-deployment-manager/internal/controller/common"
 	v1info "github.com/wind-river/cloud-platform-deployment-manager/platform"
 )
+
+func intPtr(v int) *int       { return &v }
+func strPtr(v string) *string { return &v }
 
 var _ = Describe("Profile utils", func() {
 	Describe("MergeProfiles utility", func() {
@@ -461,14 +465,14 @@ var _ = Describe("Profile utils", func() {
 		Context("when the applied profile changes lvmFunction of an existing VG", func() {
 			It("should use the applied profile's lvmFunction value", func() {
 				lvmCSI := "lvm-csi"
-				lvmNone := "none"
+				lvmNone := common.LVMFunctionNone
 				lvmThick := "thick"
 				size := 261
 
 				hostStorage := &starlingxv1.ProfileStorageInfo{
 					VolumeGroups: starlingxv1.VolumeGroupList{
 						{
-							Name:        "cgts-vg",
+							Name:        common.LVG_CGTS_VG,
 							LVMFunction: &lvmCSI,
 							PhysicalVolumes: starlingxv1.PhysicalVolumeList{
 								{Path: "/dev/disk/by-path/pci-0000:00:0d.0-ata-1.0-part5", Type: "partition", Size: &size},
@@ -488,7 +492,7 @@ var _ = Describe("Profile utils", func() {
 				appliedStorage := &starlingxv1.ProfileStorageInfo{
 					VolumeGroups: starlingxv1.VolumeGroupList{
 						{
-							Name:        "cgts-vg",
+							Name:        common.LVG_CGTS_VG,
 							LVMFunction: &lvmNone,
 							PhysicalVolumes: starlingxv1.PhysicalVolumeList{
 								{Path: "/dev/disk/by-path/pci-0000:00:0d.0-ata-1.0-part5", Type: "partition", Size: &size},
@@ -508,8 +512,8 @@ var _ = Describe("Profile utils", func() {
 				result := MergeVolumeGroups(hostStorage, appliedStorage)
 
 				Expect(result).To(HaveLen(2))
-				Expect(result[0].Name).To(Equal("cgts-vg"))
-				Expect(*result[0].LVMFunction).To(Equal("none"))
+				Expect(result[0].Name).To(Equal(common.LVG_CGTS_VG))
+				Expect(*result[0].LVMFunction).To(Equal(common.LVMFunctionNone))
 				Expect(result[1].Name).To(Equal("lvm-provisioner"))
 				Expect(*result[1].LVMFunction).To(Equal("lvm-csi"))
 			})
@@ -524,7 +528,7 @@ var _ = Describe("Profile utils", func() {
 				hostStorage := &starlingxv1.ProfileStorageInfo{
 					VolumeGroups: starlingxv1.VolumeGroupList{
 						{
-							Name:        "cgts-vg",
+							Name:        common.LVG_CGTS_VG,
 							LVMFunction: &lvmCSI,
 							PhysicalVolumes: starlingxv1.PhysicalVolumeList{
 								{Path: "/dev/disk/by-path/pci-0000:00:0d.0-ata-1.0-part5", Type: "partition", Size: &size},
@@ -544,7 +548,7 @@ var _ = Describe("Profile utils", func() {
 				appliedStorage := &starlingxv1.ProfileStorageInfo{
 					VolumeGroups: starlingxv1.VolumeGroupList{
 						{
-							Name:        "cgts-vg",
+							Name:        common.LVG_CGTS_VG,
 							LVMFunction: &lvmCSI,
 							PhysicalVolumes: starlingxv1.PhysicalVolumeList{
 								{Path: "/dev/disk/by-path/pci-0000:00:0d.0-ata-1.0-part5", Type: "partition", Size: &size},
@@ -556,7 +560,7 @@ var _ = Describe("Profile utils", func() {
 				result := MergeVolumeGroups(hostStorage, appliedStorage)
 
 				Expect(result).To(HaveLen(1))
-				Expect(result[0].Name).To(Equal("cgts-vg"))
+				Expect(result[0].Name).To(Equal(common.LVG_CGTS_VG))
 				Expect(*result[0].LVMFunction).To(Equal("lvm-csi"))
 			})
 		})
@@ -1395,6 +1399,155 @@ var _ = Describe("Profile utils", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(merged).NotTo(BeNil())
 			Expect(merged.Routes).To(HaveLen(4))
+		})
+	})
+})
+
+var _ = Describe("MergeVolumeGroups LVM fields", func() {
+	Context("when defaults have lvmPoolSize but user omits it", func() {
+		It("should inherit lvmPoolSize from defaults since function is active", func() {
+			defaults := &starlingxv1.ProfileStorageInfo{
+				VolumeGroups: starlingxv1.VolumeGroupList{
+					{Name: common.LVG_CGTS_VG, LVMType: strPtr("thin"), LVMFunction: strPtr("lvm-csi"), LVMPoolSize: intPtr(35)},
+				},
+			}
+			user := &starlingxv1.ProfileStorageInfo{
+				VolumeGroups: starlingxv1.VolumeGroupList{
+					{Name: common.LVG_CGTS_VG, LVMFunction: strPtr("lvm-csi")},
+				},
+			}
+
+			result := MergeVolumeGroups(defaults, user)
+
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].LVMPoolSize).NotTo(BeNil())
+			Expect(*result[0].LVMPoolSize).To(Equal(35))
+			Expect(result[0].LVMType).NotTo(BeNil())
+			Expect(*result[0].LVMType).To(Equal("thin"))
+		})
+	})
+
+	Context("when user sets lvmFunction to none", func() {
+		It("should NOT inherit lvmType/lvmPoolSize from defaults", func() {
+			defaults := &starlingxv1.ProfileStorageInfo{
+				VolumeGroups: starlingxv1.VolumeGroupList{
+					{Name: common.LVG_CGTS_VG, LVMType: strPtr("thin"), LVMFunction: strPtr("lvm-csi"), LVMPoolSize: intPtr(35)},
+				},
+			}
+			user := &starlingxv1.ProfileStorageInfo{
+				VolumeGroups: starlingxv1.VolumeGroupList{
+					{Name: common.LVG_CGTS_VG, LVMFunction: strPtr(common.LVMFunctionNone)},
+				},
+			}
+
+			result := MergeVolumeGroups(defaults, user)
+
+			Expect(result).To(HaveLen(1))
+			Expect(*result[0].LVMFunction).To(Equal(common.LVMFunctionNone))
+			Expect(result[0].LVMType).To(BeNil())
+			Expect(result[0].LVMPoolSize).To(BeNil())
+		})
+	})
+})
+
+var _ = Describe("NormalizeVolumeGroupsForComparison", func() {
+	Context("when profile has active lvmFunction but omits lvmType/lvmPoolSize (day-2)", func() {
+		It("should adopt system-calculated values from current into profile", func() {
+			profile := &starlingxv1.HostProfileSpec{
+				Storage: &starlingxv1.ProfileStorageInfo{
+					VolumeGroups: starlingxv1.VolumeGroupList{
+						{Name: common.LVG_CGTS_VG, LVMFunction: strPtr("lvm-csi")},
+					},
+				},
+			}
+			current := &starlingxv1.HostProfileSpec{
+				Storage: &starlingxv1.ProfileStorageInfo{
+					VolumeGroups: starlingxv1.VolumeGroupList{
+						{Name: common.LVG_CGTS_VG, LVMType: strPtr("thin"), LVMFunction: strPtr("lvm-csi"), LVMPoolSize: intPtr(35)},
+					},
+				},
+			}
+
+			NormalizeVolumeGroupsForComparison(profile, current)
+
+			Expect(profile.Storage.VolumeGroups[0].LVMType).NotTo(BeNil())
+			Expect(*profile.Storage.VolumeGroups[0].LVMType).To(Equal("thin"))
+			Expect(profile.Storage.VolumeGroups[0].LVMPoolSize).NotTo(BeNil())
+			Expect(*profile.Storage.VolumeGroups[0].LVMPoolSize).To(Equal(35))
+		})
+	})
+
+	Context("when profile has no lvmFunction (nil)", func() {
+		It("should clear lvmType/lvmPoolSize from current", func() {
+			profile := &starlingxv1.HostProfileSpec{
+				Storage: &starlingxv1.ProfileStorageInfo{
+					VolumeGroups: starlingxv1.VolumeGroupList{
+						{Name: common.LVG_CGTS_VG},
+					},
+				},
+			}
+			current := &starlingxv1.HostProfileSpec{
+				Storage: &starlingxv1.ProfileStorageInfo{
+					VolumeGroups: starlingxv1.VolumeGroupList{
+						{Name: common.LVG_CGTS_VG, LVMType: strPtr("thin"), LVMFunction: strPtr("lvm-csi"), LVMPoolSize: intPtr(35)},
+					},
+				},
+			}
+
+			NormalizeVolumeGroupsForComparison(profile, current)
+
+			Expect(current.Storage.VolumeGroups[0].LVMType).To(BeNil())
+			Expect(current.Storage.VolumeGroups[0].LVMPoolSize).To(BeNil())
+		})
+	})
+
+	Context("when profile has lvmFunction=none", func() {
+		It("should clear lvmType/lvmPoolSize from current", func() {
+			profile := &starlingxv1.HostProfileSpec{
+				Storage: &starlingxv1.ProfileStorageInfo{
+					VolumeGroups: starlingxv1.VolumeGroupList{
+						{Name: common.LVG_CGTS_VG, LVMFunction: strPtr(common.LVMFunctionNone)},
+					},
+				},
+			}
+			current := &starlingxv1.HostProfileSpec{
+				Storage: &starlingxv1.ProfileStorageInfo{
+					VolumeGroups: starlingxv1.VolumeGroupList{
+						{Name: common.LVG_CGTS_VG, LVMType: strPtr("thin"), LVMFunction: strPtr("lvm-csi"), LVMPoolSize: intPtr(121)},
+					},
+				},
+			}
+
+			NormalizeVolumeGroupsForComparison(profile, current)
+
+			Expect(current.Storage.VolumeGroups[0].LVMType).To(BeNil())
+			Expect(current.Storage.VolumeGroups[0].LVMPoolSize).To(BeNil())
+		})
+	})
+
+	Context("for cgts-vg with active lvmFunction", func() {
+		It("should suppress system-calculated diffs by adopting current values", func() {
+			profile := &starlingxv1.HostProfileSpec{
+				Storage: &starlingxv1.ProfileStorageInfo{
+					VolumeGroups: starlingxv1.VolumeGroupList{
+						{Name: common.LVG_CGTS_VG, LVMFunction: strPtr("lvm-csi")},
+					},
+				},
+			}
+			current := &starlingxv1.HostProfileSpec{
+				Storage: &starlingxv1.ProfileStorageInfo{
+					VolumeGroups: starlingxv1.VolumeGroupList{
+						{Name: common.LVG_CGTS_VG, LVMType: strPtr("thin"), LVMFunction: strPtr("lvm-csi"), LVMPoolSize: intPtr(121)},
+					},
+				},
+			}
+
+			NormalizeVolumeGroupsForComparison(profile, current)
+
+			Expect(profile.Storage.VolumeGroups[0].LVMType).NotTo(BeNil())
+			Expect(*profile.Storage.VolumeGroups[0].LVMType).To(Equal("thin"))
+			Expect(profile.Storage.VolumeGroups[0].LVMPoolSize).NotTo(BeNil())
+			Expect(*profile.Storage.VolumeGroups[0].LVMPoolSize).To(Equal(121))
 		})
 	})
 })

--- a/internal/controller/host/storage.go
+++ b/internal/controller/host/storage.go
@@ -302,6 +302,15 @@ func (r *HostReconciler) ReconcileVolumeGroups(client *gophercloud.ServiceClient
 	// Update existing volume groups capabilities and create any new volume
 	// groups as needed.
 	for _, vgInfo := range profile.Storage.VolumeGroups {
+		// Defer cgts-vg configuration until the host is enabled, this will
+		// avoid problems with free disk space
+		if vgInfo.Name == ctrlcommon.LVG_CGTS_VG &&
+			instance.Status.DeploymentScope == cloudManager.ScopeBootstrap &&
+			host.IsLockedDisabled() {
+			logHost.Info("deferring cgts-vg capability update until host is enabled")
+			continue
+		}
+
 		// Considering that the capabilities object will be required to create
 		// or update the VG, create the object here to avoid duplicity
 		var capabilitiesPtr *volumegroups.CapabilitiesOpts


### PR DESCRIPTION
During Day-1 operation, the user can apply the lvm-csi function to the
CGTS-VG volume group. This operation results in the creation of a thin
pool using 50% of the free space. However, during compute node
bootstrapping, the CGTS-VG and other filesystems are fully configured
during the locked state, which can mistakenly lead to the creation of a
thin pool using more than the required space.

To address this issue, the LVM CSI function application is now deferred
until the DM unlocks the machine and commits the disk changes. After that,
the CGTS-VG volume group can be correctly configured.

Also, this commit includes fixes to the LVM CSI optional parameters,
such as lvmPoolSize. During configuration, the user can omit this parameter,
resulting in the default value of 50% of the free space being used for
the thin pool. However, after the configuration is applied, the deployment
manager finds a difference between the host profile and the current
host configuration, creating a cyclic false delta and system alarms.
This false delta also occurs for compute Physical Volumes that had their
device paths stripped of partition identifiers from the device path.

Closes: #558