### PR TITLE
Avoid reconcile when CGTS-VG is absent in user profile

### DIFF
--- a/internal/controller/host/host_controller.go
+++ b/internal/controller/host/host_controller.go
@@ -961,6 +961,32 @@ func (r *HostReconciler) CompareAttributes(in *starlingxv1.HostProfileSpec, othe
 		r.CompareDisabledAttributes(in, other, instance.Namespace, personality, false)
 }
 
+// volumeGroupsEqualIgnoringCurrentCGTS reports whether the desired volume group
+// list (in) and the current volume group list (other) are equivalent once a
+// "cgts-vg" that is present only in the current config is disregarded.
+func volumeGroupsEqualIgnoringCurrentCGTS(in, other *starlingxv1.VolumeGroupList) bool {
+	// If the user profile declares "cgts-vg" then there is nothing special to
+	// ignore; fall back to the regular comparison.
+	for i := range *in {
+		if (*in)[i].Name == common.LVG_CGTS_VG {
+			return in.DeepEqual(other)
+		}
+	}
+
+	// Build a copy of "other" without the current-only "cgts-vg" entry.
+	// If there is no such entry to drop the copy is identical to "other",
+	// so this also handles the case where the lists are already equal.
+	filtered := make(starlingxv1.VolumeGroupList, 0, len(*other))
+	for i := range *other {
+		if (*other)[i].Name == common.LVG_CGTS_VG {
+			continue
+		}
+		filtered = append(filtered, (*other)[i])
+	}
+
+	return in.DeepEqual(&filtered)
+}
+
 // CompareEnabledAttributes determines if two profiles are identical for the
 // purpose of reconciling any attributes that can only be applied when the host
 // is enabled.  The only attributes that we can reconcile while enabled are the
@@ -1035,7 +1061,12 @@ func (r *HostReconciler) CompareEnabledAttributes(in *starlingxv1.HostProfileSpe
 		if (in.Storage == nil) != (other.Storage == nil) {
 			return false
 		} else if in.Storage != nil {
-			if !in.Storage.VolumeGroups.DeepEqual(&other.Storage.VolumeGroups) {
+			// Compare volume groups section. If CGTS-VG volume group is only
+			// present on current config, ignore it.
+			// This is a special case for the cgts-vg volume group which is
+			// automatically added by the system but is not part of the
+			// user-defined configuration.
+			if !volumeGroupsEqualIgnoringCurrentCGTS(&in.Storage.VolumeGroups, &other.Storage.VolumeGroups) {
 				return false
 			}
 		}

--- a/internal/controller/host/host_controller_test.go
+++ b/internal/controller/host/host_controller_test.go
@@ -19,6 +19,7 @@ import (
 
 	starlingxv1 "github.com/wind-river/cloud-platform-deployment-manager/api/v1"
 	comm "github.com/wind-river/cloud-platform-deployment-manager/common"
+	ctrlcommon "github.com/wind-river/cloud-platform-deployment-manager/internal/controller/common"
 	cloudManager "github.com/wind-river/cloud-platform-deployment-manager/internal/controller/manager"
 )
 
@@ -1297,6 +1298,98 @@ var _ = Describe("Host controller", func() {
 						},
 					},
 				}
+				instance := &starlingxv1.Host{}
+				info := &cloudManager.SystemInfo{}
+				Expect(r.CompareEnabledAttributes(in, other, instance, "controller", info)).To(BeFalse())
+			})
+		})
+
+		Context("when cgts-vg exists only in the current config and is not declared in the user profile", func() {
+			It("should return true (in sync) ignoring the system-managed cgts-vg", func() {
+				lvmCSI := "lvm-csi"
+
+				// User profile declares only the lvm-provisioner volume group.
+				in := &starlingxv1.HostProfileSpec{
+					Storage: &starlingxv1.ProfileStorageInfo{
+						VolumeGroups: starlingxv1.VolumeGroupList{
+							{
+								Name:        "lvm-provisioner",
+								LVMFunction: &lvmCSI,
+								PhysicalVolumes: starlingxv1.PhysicalVolumeList{
+									{Type: "disk", Path: "/dev/disk/by-path/pci-0000:00:0d.0-ata-3.0"},
+								},
+							},
+						},
+					},
+				}
+
+				// Current config reported by the system contains the default
+				// cgts-vg in addition to the lvm-provisioner volume group.
+				other := &starlingxv1.HostProfileSpec{
+					Storage: &starlingxv1.ProfileStorageInfo{
+						VolumeGroups: starlingxv1.VolumeGroupList{
+							{
+								Name: ctrlcommon.LVG_CGTS_VG,
+								PhysicalVolumes: starlingxv1.PhysicalVolumeList{
+									{Type: "partition", Path: "/dev/disk/by-path/pci-0000:00:0d.0-ata-1.0-part5"},
+								},
+							},
+							{
+								Name:        "lvm-provisioner",
+								LVMFunction: &lvmCSI,
+								PhysicalVolumes: starlingxv1.PhysicalVolumeList{
+									{Type: "disk", Path: "/dev/disk/by-path/pci-0000:00:0d.0-ata-3.0"},
+								},
+							},
+						},
+					},
+				}
+
+				instance := &starlingxv1.Host{}
+				info := &cloudManager.SystemInfo{}
+				Expect(r.CompareEnabledAttributes(in, other, instance, "controller", info)).To(BeTrue())
+			})
+		})
+
+		Context("when cgts-vg is declared in the user profile and equals the current config", func() {
+			It("should return true (in sync)", func() {
+				lvmCSI := "lvm-csi"
+
+				in := &starlingxv1.HostProfileSpec{
+					Storage: &starlingxv1.ProfileStorageInfo{
+						VolumeGroups: starlingxv1.VolumeGroupList{
+							{Name: ctrlcommon.LVG_CGTS_VG, LVMFunction: &lvmCSI},
+						},
+					},
+				}
+				other := in.DeepCopy()
+
+				instance := &starlingxv1.Host{}
+				info := &cloudManager.SystemInfo{}
+				Expect(r.CompareEnabledAttributes(in, other, instance, "controller", info)).To(BeTrue())
+			})
+		})
+
+		Context("when cgts-vg is declared in the user profile and differs from the current config", func() {
+			It("should return false (out of sync)", func() {
+				lvmCSI := "lvm-csi"
+				lvmNone := ctrlcommon.LVMFunctionNone
+
+				in := &starlingxv1.HostProfileSpec{
+					Storage: &starlingxv1.ProfileStorageInfo{
+						VolumeGroups: starlingxv1.VolumeGroupList{
+							{Name: ctrlcommon.LVG_CGTS_VG, LVMFunction: &lvmCSI},
+						},
+					},
+				}
+				other := &starlingxv1.HostProfileSpec{
+					Storage: &starlingxv1.ProfileStorageInfo{
+						VolumeGroups: starlingxv1.VolumeGroupList{
+							{Name: ctrlcommon.LVG_CGTS_VG, LVMFunction: &lvmNone},
+						},
+					},
+				}
+
 				instance := &starlingxv1.Host{}
 				info := &cloudManager.SystemInfo{}
 				Expect(r.CompareEnabledAttributes(in, other, instance, "controller", info)).To(BeFalse())


### PR DESCRIPTION
During host configuration, the user may set an lvm-csi function in one or more volume groups (VGs) in dedicated mode (when a specific disk is assigned to the VG). In this configuration, CGTS-VG (the volume group that supports the system) can be omitted.

It is expected that this configuration is successfully applied and the host reaches the 'INSYNC=true' state. However, omitting CGTS-VG creates a constant delta caused by the CGTS-VG deletion protection method.

This commit adds a new comparison method that prevents reconciliation, and consequently the 'INSYNC=false' status when the only difference between the host and the user profile is the presence of CGTS-VG in the host's volume group list.

TEST PLAN:
PASS: Node successfully reaches INSYNC=true when configured with only
      CGTS-VG for the lvm-csi function.
PASS: Node successfully reaches INSYNC=true when configured with only a
      dedicated volume group (in thin or thick mode) for the lvm-csi
      function.
PASS: Node successfully reaches INSYNC=true when configured with both
      CGTS-VG and a dedicated volume group for the lvm-csi function.

Closes: #565 